### PR TITLE
Automate semantic version calculation and metadata updates in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -131,8 +131,9 @@ jobs:
           import sys
           with open('pyproject.toml', 'r', encoding='utf-8') as f:
               doc = tomlkit.parse(f.read())
-          if 'project' in doc:
-              doc['project']['version'] = sys.argv[1]
+          if 'project' not in doc:
+            raise SystemExit('Expected a [project] table in pyproject.toml to set version')
+          doc['project']['version'] = sys.argv[1]
           with open('pyproject.toml', 'w', encoding='utf-8') as f:
               f.write(tomlkit.dumps(doc))
           " "$VERSION"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,45 +46,57 @@ jobs:
           BUMP_TYPE: ${{ github.event.inputs.bump_type }}
           IS_PRERELEASE: ${{ github.event.inputs.prerelease }}
         run: |
+          shopt -s inherit_errexit
           git fetch --tags
-          LATEST_STABLE=$(git tag --merged HEAD --list --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
+          
+          # Export necessary data
+          export LATEST_STABLE=$(git tag --merged HEAD --list --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
           export LATEST_STABLE="${LATEST_STABLE:-0.0.0}"
-          CURRENT_ANY=$(git tag --merged HEAD --list --sort=-v:refname | head -n 1 || true)
+          export CURRENT_ANY=$(git tag --merged HEAD --list --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$' | head -n 1 || true)
           export CURRENT_ANY="${CURRENT_ANY:-0.0.0}"
+          export ALL_TAGS=$(git tag --merged HEAD --list || true)
 
           NEW_VERSION=$(uv run --with packaging python -c "
-          import re
           import os
+          import re
           import sys
           from packaging.version import parse
 
-          latest_stable = os.environ.get('LATEST_STABLE', '0.0.0')
-          current_any = os.environ.get('CURRENT_ANY', '0.0.0')
-          bump_type = os.environ.get('BUMP_TYPE', 'patch')
-          is_prerelease = os.environ.get('IS_PRERELEASE', 'false').lower() == 'true'
+          bump_type = os.environ['BUMP_TYPE']
+          is_prerelease = os.environ['IS_PRERELEASE'].lower() == 'true'
+          latest_stable = os.environ['LATEST_STABLE']
+          current_any = os.environ['CURRENT_ANY']
+          all_tags = os.environ['ALL_TAGS'].split('\n')
 
-          def get_next_stable(v_str, b_type):
-              v = parse(v_str)
-              major, minor, patch = v.major, v.minor, v.micro
-              if b_type == 'major':
-                  return f'{major + 1}.0.0'
-              elif b_type == 'minor':
-                  return f'{major}.{minor + 1}.0'
-              else:
-                  return f'{major}.{minor}.{patch + 1}'
-
-          target_stable = get_next_stable(latest_stable, bump_type)
+          # Calculate target stable base
+          v = [int(x) for x in latest_stable.split('.')]
+          if bump_type == 'major':
+              v[0] += 1
+              v[1] = 0
+              v[2] = 0
+          elif bump_type == 'minor':
+              v[1] += 1
+              v[2] = 0
+          else:  # patch
+              v[2] += 1
+          
+          target_stable = f'{v[0]}.{v[1]}.{v[2]}'
 
           if not is_prerelease:
               result = target_stable
           else:
-              match = re.match(r'^' + re.escape(target_stable) + r'-rc\.(\d+)$', current_any)
-              if match:
-                  rc_num = int(match.group(1))
-                  result = f'{target_stable}-rc.{rc_num + 1}'
-              else:
-                  result = f'{target_stable}-rc.1'
+              # Scan all tags for the max RC number of this target stable
+              rc_pattern = re.compile(r'^' + re.escape(target_stable) + r'-rc\.(\d+)$')
+              rc_numbers = []
+              for tag in all_tags:
+                  match = rc_pattern.match(tag.strip())
+                  if match:
+                      rc_numbers.append(int(match.group(1)))
+              
+              next_rc = max(rc_numbers) + 1 if rc_numbers else 1
+              result = f'{target_stable}-rc.{next_rc}'
 
+          # Final validation
           if parse(result) <= parse(latest_stable):
               print(f'Error: Calculated version {result} is not greater than latest stable {latest_stable}', file=sys.stderr)
               sys.exit(1)
@@ -95,6 +107,11 @@ jobs:
 
           print(result)
           ")
+
+          if [[ -z "$NEW_VERSION" ]]; then
+              echo "Error: Calculated version is empty"
+              exit 1
+          fi
 
           echo "VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "TAG_NAME=$NEW_VERSION" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,17 +43,17 @@ jobs:
       - name: Setup version
         id: get_version
         shell: bash
-        env:
-          BUMP_TYPE: ${{ github.event.inputs.bump_type }}
-          IS_PRERELEASE: ${{ github.event.inputs.prerelease }}
         run: |
-          shopt -s inherit_errexit || true
-          git fetch --tags
+          shopt -s inherit_errexit || {
+              echo "Warning: inherit_errexit not supported, falling back to strict flags" >&2
+              set -euo pipefail
+          }
 
-          # Export necessary data for tools/calculate_version.py
-          export LATEST_STABLE=$(git tag --merged HEAD --list --sort=-v:refname | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
+          export BUMP_TYPE="${{ github.event.inputs.bump_type }}"
+          export IS_PRERELEASE="${{ github.event.inputs.prerelease }}"
+          LATEST_STABLE=$(git tag --merged HEAD --list --sort=-v:refname | grep -E '^(v?[0-9]+\.[0-9]+\.[0-9]+)$' | head -n 1)
           export LATEST_STABLE="${LATEST_STABLE:-0.0.0}"
-          export CURRENT_ANY=$(git tag --merged HEAD --list --sort=-v:refname | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$' | head -n 1 || true)
+          CURRENT_ANY=$(git tag --merged HEAD --list --sort=-v:refname | head -n 1)
           export CURRENT_ANY="${CURRENT_ANY:-0.0.0}"
           export ALL_TAGS=$(git tag --merged HEAD --list || true)
 
@@ -67,30 +67,12 @@ jobs:
               exit 1
           fi
 
+          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
           echo "VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT
-          echo "TAG_NAME=$NEW_VERSION" >> $GITHUB_OUTPUT
-          echo "Calculated version: $NEW_VERSION"
 
-      - name: Update manifest.json
+      - name: Update versions
         run: |
-          VERSION="${{ steps.get_version.outputs.VERSION }}"
-          jq ".version = \"$VERSION\"" custom_components/blueprints_updater/manifest.json > manifest.json.tmp
-          mv manifest.json.tmp custom_components/blueprints_updater/manifest.json
-
-      - name: Update pyproject.toml
-        run: |
-          VERSION="${{ steps.get_version.outputs.VERSION }}"
-          uv run --with tomlkit python -c "
-          import tomlkit
-          import sys
-          with open('pyproject.toml', 'r', encoding='utf-8') as f:
-              doc = tomlkit.parse(f.read())
-          if 'project' not in doc:
-            raise SystemExit('Expected a [project] table in pyproject.toml to set version')
-          doc['project']['version'] = sys.argv[1]
-          with open('pyproject.toml', 'w', encoding='utf-8') as f:
-              f.write(tomlkit.dumps(doc))
-          " "$VERSION"
+          uv run --with tomlkit python tools/update_project_metadata.py
 
       - name: Format files
         run: npx prettier --write custom_components/blueprints_updater/manifest.json pyproject.toml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,11 +49,11 @@ jobs:
 
           export BUMP_TYPE="${{ github.event.inputs.bump_type }}"
           export IS_PRERELEASE="${{ github.event.inputs.prerelease || 'false' }}"
-          LATEST_STABLE=$(git tag --merged HEAD --list --sort=-v:refname | grep -E '^(v?[0-9]+\.[0-9]+\.[0-9]+)$' | head -n 1)
+          LATEST_STABLE=$(git tag --list --sort=-v:refname | grep -E '^(v?[0-9]+\.[0-9]+\.[0-9]+)$' | head -n 1)
           export LATEST_STABLE="${LATEST_STABLE:-0.0.0}"
-          CURRENT_ANY=$(git tag --merged HEAD --list --sort=-v:refname | grep -E '^(v?[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?)$' | head -n 1)
+          CURRENT_ANY=$(git tag --list --sort=-v:refname | grep -E '^(v?[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?)$' | head -n 1)
           export CURRENT_ANY="${CURRENT_ANY:-0.0.0}"
-          export ALL_TAGS=$(git tag --merged HEAD --list || true)
+          export ALL_TAGS=$(git tag --list || true)
 
           NEW_VERSION=$(uv run --with packaging python tools/calculate_version.py) || {
               echo "Error: Version calculation failed"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
         run: |
           shopt -s inherit_errexit
           git fetch --tags
-          
+
           # Export necessary data
           export LATEST_STABLE=$(git tag --merged HEAD --list --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
           export LATEST_STABLE="${LATEST_STABLE:-0.0.0}"
@@ -79,7 +79,7 @@ jobs:
               v[2] = 0
           else:  # patch
               v[2] += 1
-          
+
           target_stable = f'{v[0]}.{v[1]}.{v[2]}'
 
           if not is_prerelease:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,71 +42,22 @@ jobs:
 
       - name: Setup version
         id: get_version
+        shell: bash
         env:
           BUMP_TYPE: ${{ github.event.inputs.bump_type }}
           IS_PRERELEASE: ${{ github.event.inputs.prerelease }}
         run: |
-          shopt -s inherit_errexit
+          shopt -s inherit_errexit || true
           git fetch --tags
 
-          # Export necessary data
-          export LATEST_STABLE=$(git tag --merged HEAD --list --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
+          # Export necessary data for tools/calculate_version.py
+          export LATEST_STABLE=$(git tag --merged HEAD --list --sort=-v:refname | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
           export LATEST_STABLE="${LATEST_STABLE:-0.0.0}"
-          export CURRENT_ANY=$(git tag --merged HEAD --list --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$' | head -n 1 || true)
+          export CURRENT_ANY=$(git tag --merged HEAD --list --sort=-v:refname | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$' | head -n 1 || true)
           export CURRENT_ANY="${CURRENT_ANY:-0.0.0}"
           export ALL_TAGS=$(git tag --merged HEAD --list || true)
 
-          NEW_VERSION=$(uv run --with packaging python -c "
-          import os
-          import re
-          import sys
-          from packaging.version import parse
-
-          bump_type = os.environ['BUMP_TYPE']
-          is_prerelease = os.environ['IS_PRERELEASE'].lower() == 'true'
-          latest_stable = os.environ['LATEST_STABLE']
-          current_any = os.environ['CURRENT_ANY']
-          all_tags = os.environ['ALL_TAGS'].split('\n')
-
-          # Calculate target stable base
-          v = [int(x) for x in latest_stable.split('.')]
-          if bump_type == 'major':
-              v[0] += 1
-              v[1] = 0
-              v[2] = 0
-          elif bump_type == 'minor':
-              v[1] += 1
-              v[2] = 0
-          else:  # patch
-              v[2] += 1
-
-          target_stable = f'{v[0]}.{v[1]}.{v[2]}'
-
-          if not is_prerelease:
-              result = target_stable
-          else:
-              # Scan all tags for the max RC number of this target stable
-              rc_pattern = re.compile(r'^' + re.escape(target_stable) + r'-rc\.(\d+)$')
-              rc_numbers = []
-              for tag in all_tags:
-                  match = rc_pattern.match(tag.strip())
-                  if match:
-                      rc_numbers.append(int(match.group(1)))
-              
-              next_rc = max(rc_numbers) + 1 if rc_numbers else 1
-              result = f'{target_stable}-rc.{next_rc}'
-
-          # Final validation
-          if parse(result) <= parse(latest_stable):
-              print(f'Error: Calculated version {result} is not greater than latest stable {latest_stable}', file=sys.stderr)
-              sys.exit(1)
-
-          if is_prerelease and current_any.startswith(target_stable) and parse(result) <= parse(current_any):
-              print(f'Error: Calculated pre-release {result} is not greater than latest version {current_any}', file=sys.stderr)
-              sys.exit(1)
-
-          print(result)
-          ")
+          NEW_VERSION=$(uv run --with packaging python tools/calculate_version.py)
 
           if [[ -z "$NEW_VERSION" ]]; then
               echo "Error: Calculated version is empty"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,10 +3,14 @@ name: Release
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: "Version to release (e.g., 1.0.2)"
+      bump_type:
+        description: "Select version bump type"
         required: true
-        type: string
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
       prerelease:
         description: "Mark as pre-release"
         required: false
@@ -38,40 +42,63 @@ jobs:
 
       - name: Setup version
         id: get_version
+        env:
+          BUMP_TYPE: ${{ github.event.inputs.bump_type }}
+          IS_PRERELEASE: ${{ github.event.inputs.prerelease }}
         run: |
-          VERSION="${{ github.event.inputs.version }}"
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-          echo "TAG_NAME=$VERSION" >> $GITHUB_OUTPUT
+          git fetch --tags
+          LATEST_STABLE=$(git tag --merged HEAD --list --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
+          export LATEST_STABLE="${LATEST_STABLE:-0.0.0}"
+          CURRENT_ANY=$(git tag --merged HEAD --list --sort=-v:refname | head -n 1 || true)
+          export CURRENT_ANY="${CURRENT_ANY:-0.0.0}"
 
-      - name: Validate version
-        run: |
-          NEW_VERSION="${{ steps.get_version.outputs.VERSION }}"
-          TAG_NAME="${{ steps.get_version.outputs.TAG_NAME }}"
-
-          if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
-            echo "Error: Tag $TAG_NAME already exists."
-            exit 1
-          fi
-
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0")
-          LATEST_VERSION="$LATEST_TAG"
-
-          uv run --with packaging python -c "
-          from packaging.version import parse, InvalidVersion
+          NEW_VERSION=$(uv run --with packaging python -c "
+          import re
+          import os
           import sys
+          from packaging.version import parse
 
-          try:
-              v_new = parse('$NEW_VERSION')
-              v_old = parse('$LATEST_VERSION')
-          except InvalidVersion as e:
-              print(f'Error: Invalid version format -> {e}')
+          latest_stable = os.environ.get('LATEST_STABLE', '0.0.0')
+          current_any = os.environ.get('CURRENT_ANY', '0.0.0')
+          bump_type = os.environ.get('BUMP_TYPE', 'patch')
+          is_prerelease = os.environ.get('IS_PRERELEASE', 'false').lower() == 'true'
+
+          def get_next_stable(v_str, b_type):
+              v = parse(v_str)
+              major, minor, patch = v.major, v.minor, v.micro
+              if b_type == 'major':
+                  return f'{major + 1}.0.0'
+              elif b_type == 'minor':
+                  return f'{major}.{minor + 1}.0'
+              else:
+                  return f'{major}.{minor}.{patch + 1}'
+
+          target_stable = get_next_stable(latest_stable, bump_type)
+
+          if not is_prerelease:
+              result = target_stable
+          else:
+              match = re.match(r'^' + re.escape(target_stable) + r'-rc\.(\d+)$', current_any)
+              if match:
+                  rc_num = int(match.group(1))
+                  result = f'{target_stable}-rc.{rc_num + 1}'
+              else:
+                  result = f'{target_stable}-rc.1'
+
+          if parse(result) <= parse(latest_stable):
+              print(f'Error: Calculated version {result} is not greater than latest stable {latest_stable}', file=sys.stderr)
               sys.exit(1)
 
-          if not (v_new > v_old):
-              print(f'Error: New version ({v_new}) must be strictly greater than the latest released version ({v_old}).')
+          if is_prerelease and current_any.startswith(target_stable) and parse(result) <= parse(current_any):
+              print(f'Error: Calculated pre-release {result} is not greater than latest version {current_any}', file=sys.stderr)
               sys.exit(1)
-          "
-          echo "Version validation passed."
+
+          print(result)
+          ")
+
+          echo "VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "TAG_NAME=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "Calculated version: $NEW_VERSION"
 
       - name: Update manifest.json
         run: |
@@ -82,7 +109,16 @@ jobs:
       - name: Update pyproject.toml
         run: |
           VERSION="${{ steps.get_version.outputs.VERSION }}"
-          sed -i "s/^version = \".*\"/version = \"$VERSION\"/" pyproject.toml
+          uv run --with tomlkit python -c "
+          import tomlkit
+          import sys
+          with open('pyproject.toml', 'r', encoding='utf-8') as f:
+              doc = tomlkit.parse(f.read())
+          if 'project' in doc:
+              doc['project']['version'] = sys.argv[1]
+          with open('pyproject.toml', 'w', encoding='utf-8') as f:
+              f.write(tomlkit.dumps(doc))
+          " "$VERSION"
 
       - name: Format files
         run: npx prettier --write custom_components/blueprints_updater/manifest.json pyproject.toml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,10 +44,8 @@ jobs:
         id: get_version
         shell: bash
         run: |
-          shopt -s inherit_errexit || {
-              echo "Warning: inherit_errexit not supported, falling back to strict flags" >&2
-              set -euo pipefail
-          }
+          set -euo pipefail
+          shopt -s inherit_errexit 2>/dev/null || echo "Warning: inherit_errexit not supported" >&2
 
           export BUMP_TYPE="${{ github.event.inputs.bump_type }}"
           export IS_PRERELEASE="${{ github.event.inputs.prerelease }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,7 +57,10 @@ jobs:
           export CURRENT_ANY="${CURRENT_ANY:-0.0.0}"
           export ALL_TAGS=$(git tag --merged HEAD --list || true)
 
-          NEW_VERSION=$(uv run --with packaging python tools/calculate_version.py)
+          NEW_VERSION=$(uv run --with packaging python tools/calculate_version.py) || {
+              echo "Error: Version calculation failed"
+              exit 1
+          }
 
           if [[ -z "$NEW_VERSION" ]]; then
               echo "Error: Calculated version is empty"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,9 +49,9 @@ jobs:
 
           export BUMP_TYPE="${{ github.event.inputs.bump_type }}"
           export IS_PRERELEASE="${{ github.event.inputs.prerelease || 'false' }}"
-          LATEST_STABLE=$(git tag --list --sort=-v:refname | grep -E '^(v?[0-9]+\.[0-9]+\.[0-9]+)$' | head -n 1)
+          LATEST_STABLE=$(git tag --list --sort=-creatordate | grep -E '^(v?[0-9]+\.[0-9]+\.[0-9]+)$' | head -n 1)
           export LATEST_STABLE="${LATEST_STABLE:-0.0.0}"
-          CURRENT_ANY=$(git tag --list --sort=-v:refname | grep -E '^(v?[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?)$' | head -n 1)
+          CURRENT_ANY=$(git tag --list --sort=-creatordate | grep -E '^(v?[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?)$' | head -n 1)
           export CURRENT_ANY="${CURRENT_ANY:-0.0.0}"
           export ALL_TAGS=$(git tag --list || true)
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,10 +48,10 @@ jobs:
           shopt -s inherit_errexit 2>/dev/null || echo "Warning: inherit_errexit not supported" >&2
 
           export BUMP_TYPE="${{ github.event.inputs.bump_type }}"
-          export IS_PRERELEASE="${{ github.event.inputs.prerelease }}"
+          export IS_PRERELEASE="${{ github.event.inputs.prerelease || 'false' }}"
           LATEST_STABLE=$(git tag --merged HEAD --list --sort=-v:refname | grep -E '^(v?[0-9]+\.[0-9]+\.[0-9]+)$' | head -n 1)
           export LATEST_STABLE="${LATEST_STABLE:-0.0.0}"
-          CURRENT_ANY=$(git tag --merged HEAD --list --sort=-v:refname | head -n 1)
+          CURRENT_ANY=$(git tag --merged HEAD --list --sort=-v:refname | grep -E '^(v?[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?)$' | head -n 1)
           export CURRENT_ANY="${CURRENT_ANY:-0.0.0}"
           export ALL_TAGS=$(git tag --merged HEAD --list || true)
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,6 +67,7 @@ jobs:
 
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
           echo "VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "TAG_NAME=$NEW_VERSION" >> $GITHUB_OUTPUT
 
       - name: Update versions
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ dev = [
   "pytest",
   "pytest-asyncio",
   "interrogate",
+  "packaging",
+  "tomlkit",
 ]
 
 [tool.ruff]

--- a/tools/calculate_version.py
+++ b/tools/calculate_version.py
@@ -53,6 +53,13 @@ def main() -> None:
         )
         sys.exit(1)
 
+    if bump_type not in ("major", "minor", "patch"):
+        print(
+            f"Error: Invalid bump_type '{bump_type}', expected major, minor, or patch",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     v = [int(parts[0]), int(parts[1]), int(parts[2])]
     if bump_type == "major":
         v[0] += 1

--- a/tools/calculate_version.py
+++ b/tools/calculate_version.py
@@ -15,9 +15,16 @@ import sys
 
 from packaging.version import parse
 
+DEFAULT_VERSION = "0.0.0"
+DEFAULT_PREFIX = "v"
+
 
 def normalize_version(version_str: str, prefix: str) -> str:
     """Strip prefixes and return a clean version string for parsing.
+
+    The function enforces consistency: if a version string does not start
+    with the expected prefix (or 'v' as a fallback), it raises an error
+    to prevent style contamination.
 
     Args:
         version_str: The version string to normalize.
@@ -25,9 +32,23 @@ def normalize_version(version_str: str, prefix: str) -> str:
 
     Returns:
         A normalized Semantic Version string.
+
+    Raises:
+        ValueError: If the version string has an unexpected prefix.
     """
-    normalized = version_str.removeprefix(prefix)
-    return normalized.removeprefix("v")
+    if not version_str or version_str == DEFAULT_VERSION:
+        return DEFAULT_VERSION
+
+    if prefix and version_str.startswith(prefix):
+        normalized = version_str.removeprefix(prefix)
+    elif version_str.startswith("v"):
+        normalized = version_str.removeprefix("v")
+    elif prefix:
+        raise ValueError(f"Version '{version_str}' does not match prefix '{prefix}' or 'v'")
+
+    else:
+        normalized = version_str
+    return normalized
 
 
 def _calculate_next_rc(prefix: str, target_stable: str, all_tags: list[str]) -> str:
@@ -47,9 +68,6 @@ def _calculate_next_rc(prefix: str, target_stable: str, all_tags: list[str]) -> 
 
     Returns:
         The calculated pre-release string (e.g., 'v1.2.3-rc.1').
-
-    Raises:
-        RuntimeError: If inconsistent tag prefixes are detected when TAG_PREFIX is empty.
     """
     if not prefix:
         v_regex = "v"
@@ -62,11 +80,9 @@ def _calculate_next_rc(prefix: str, target_stable: str, all_tags: list[str]) -> 
         bare_regex = None
 
     patterns: list[tuple[re.Pattern[str], str]] = [
-        (
-            re.compile(rf"^{v_regex}{re.escape(target_stable)}-rc\.(\d+)$"),
-            prefix,
-        )
+        (re.compile(rf"^{v_regex}{re.escape(target_stable)}-rc\.(\d+)$"), prefix)
     ]
+
     if bare_regex is not None:
         patterns.append((re.compile(rf"^{bare_regex}{re.escape(target_stable)}-rc\.(\d+)$"), ""))
 
@@ -109,9 +125,9 @@ def main() -> None:
     Environment Inputs:
         BUMP_TYPE: Version segment to increment ('major', 'minor', 'patch').
         IS_PRERELEASE: Boolean string ('true' or 'false') for RC suffixes.
-        LATEST_STABLE: Baseline stable version string (e.g., 'v1.0.2').
+        LATEST_STABLE: Baseline stable version string.
         CURRENT_ANY: Latest reachable tag for regression checks.
-        ALL_TAGS: Newline-separated tags for exhaustive pre-release scanning.
+        ALL_TAGS: Newline-separated tags for exhaustive prerelease scanning.
         TAG_PREFIX: Optional override for the version prefix (e.g., 'v').
 
     Output:
@@ -130,23 +146,24 @@ def main() -> None:
         sys.exit(1)
     is_prerelease = is_prerelease_raw == "true"
 
-    latest_stable_str = os.environ["LATEST_STABLE"]
-    current_any_str = os.environ["CURRENT_ANY"]
+    latest_stable_str = os.environ.get("LATEST_STABLE", DEFAULT_VERSION)
+    current_any_str = os.environ.get("CURRENT_ANY", DEFAULT_VERSION)
     all_tags_raw = os.environ.get("ALL_TAGS", "")
     all_tags = [t.strip() for t in all_tags_raw.split("\n") if t.strip()]
 
-    detected_prefix = "v" if latest_stable_str.startswith("v") else ""
-    prefix = os.environ.get("TAG_PREFIX", detected_prefix)
+    configured_prefix = os.environ.get("TAG_PREFIX")
+    if configured_prefix is not None:
+        prefix = configured_prefix
+    else:
+        prefix = "v" if latest_stable_str.startswith("v") else ""
 
     try:
         stable_baseline_str = normalize_version(latest_stable_str, prefix)
-        current_baseline_str = normalize_version(current_any_str, prefix)
-
         parsed_stable = parse(stable_baseline_str)
         v = [parsed_stable.major, parsed_stable.minor, parsed_stable.micro]
     except Exception as e:
         print(
-            f"Error: Could not parse baseline versions: {e}",
+            f"Error: Could not parse baseline stable version '{latest_stable_str}': {e}",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -175,9 +192,13 @@ def main() -> None:
     else:
         result_str = _calculate_next_rc(prefix, target_stable, all_tags)
 
-    norm_result = parse(normalize_version(result_str, prefix))
-    norm_latest = parse(normalize_version(latest_stable_str, prefix))
-    norm_current = parse(normalize_version(current_any_str, prefix))
+    try:
+        norm_result = parse(normalize_version(result_str, prefix))
+        norm_latest = parse(normalize_version(latest_stable_str, prefix))
+        norm_current = parse(normalize_version(current_any_str, prefix))
+    except Exception as e:
+        print(f"Error: Verification parsing failed: {e}", file=sys.stderr)
+        sys.exit(1)
 
     if norm_result <= norm_latest:
         print(

--- a/tools/calculate_version.py
+++ b/tools/calculate_version.py
@@ -1,0 +1,75 @@
+"""Version calculation logic for the release workflow.
+
+This script calculates the next version based on the selected bump type
+(major, minor, patch) and pre-release flag, ensuring Semantic Versioning 2.0.0
+compliance and branch-aware regression checking.
+"""
+
+import os
+import re
+import sys
+
+from packaging.version import parse
+
+
+def main() -> None:
+    """Calculate the next version based on environment variables."""
+    bump_type = os.environ["BUMP_TYPE"]
+    is_prerelease = os.environ["IS_PRERELEASE"].lower() == "true"
+    latest_stable_str = os.environ["LATEST_STABLE"]
+    current_any_str = os.environ["CURRENT_ANY"]
+    all_tags = os.environ["ALL_TAGS"].split("\n")
+
+    prefix = "v" if latest_stable_str.startswith("v") else ""
+
+    latest_stable_numeric = latest_stable_str.lstrip("v")
+    v = [int(x) for x in latest_stable_numeric.split(".")]
+    if bump_type == "major":
+        v[0] += 1
+        v[1] = 0
+        v[2] = 0
+    elif bump_type == "minor":
+        v[1] += 1
+        v[2] = 0
+    else:
+        v[2] += 1
+
+    target_stable = f"{v[0]}.{v[1]}.{v[2]}"
+
+    if not is_prerelease:
+        result = f"{prefix}{target_stable}"
+    else:
+        rc_pattern = re.compile(f"^v?{re.escape(target_stable)}" + r"-rc\.(\d+)$")
+        rc_numbers = []
+        for tag in all_tags:
+            if match := rc_pattern.match(tag.strip()):
+                rc_numbers.append(int(match[1]))
+
+        next_rc = max(rc_numbers) + 1 if rc_numbers else 1
+        result = f"{prefix}{target_stable}-rc.{next_rc}"
+
+    if parse(result) <= parse(latest_stable_str):
+        print(
+            f"Error: Calculated version {result} is not greater than "
+            f"latest stable {latest_stable_str}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if (
+        is_prerelease
+        and current_any_str.lstrip("v").startswith(target_stable)
+        and parse(result) <= parse(current_any_str)
+    ):
+        print(
+            f"Error: Calculated pre-release {result} is not greater than "
+            f"latest version {current_any_str}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/calculate_version.py
+++ b/tools/calculate_version.py
@@ -30,12 +30,79 @@ def normalize_version(version_str: str, prefix: str) -> str:
     return normalized.removeprefix("v")
 
 
+def _calculate_next_rc(prefix: str, target_stable: str, all_tags: list[str]) -> str:
+    """Calculate the next RC tag for a given stable target with prefix strictness.
+
+    The function is strict about mismatches between the configured `prefix`
+    and discovered tags:
+    - If `prefix == "v"`, only 'v'-prefixed RC tags are considered.
+    - If `prefix == ""`, both bare and 'v'-prefixed tags are allowed, but
+      mixing styles triggers an error to enforce repository consistency.
+    - If any other `prefix` is used, only tags with that prefix are considered.
+
+    Args:
+        prefix: The configured TAG_PREFIX.
+        target_stable: The base Semantic Version (e.g., '1.2.3').
+        all_tags: List of existing tags to scan for RC patterns.
+
+    Returns:
+        The calculated pre-release string (e.g., 'v1.2.3-rc.1').
+
+    Raises:
+        RuntimeError: If inconsistent tag prefixes are detected when TAG_PREFIX is empty.
+    """
+    if not prefix:
+        v_regex = "v"
+        bare_regex = ""
+    elif prefix == "v":
+        v_regex = "v"
+        bare_regex = None
+    else:
+        v_regex = re.escape(prefix)
+        bare_regex = None
+
+    patterns: list[tuple[re.Pattern[str], str]] = [
+        (
+            re.compile(rf"^{v_regex}{re.escape(target_stable)}-rc\.(\d+)$"),
+            prefix,
+        )
+    ]
+    if bare_regex is not None:
+        patterns.append((re.compile(rf"^{bare_regex}{re.escape(target_stable)}-rc\.(\d+)$"), ""))
+
+    rc_numbers: list[int] = []
+    detected_prefixes: set[str] = set()
+
+    for raw_tag in all_tags:
+        tag = raw_tag.strip()
+        for pattern, det_prefix in patterns:
+            if match := pattern.match(tag):
+                rc_numbers.append(int(match[1]))
+                detected_prefixes.add(det_prefix)
+                break
+
+    if not prefix and len(detected_prefixes) > 1:
+        print(
+            f"Error: Inconsistent RC tag prefixes detected for {target_stable!r}: "
+            "found both 'v' and unprefixed tags. Please standardize your tag format.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    effective_prefix = prefix
+    if not effective_prefix and detected_prefixes == {"v"}:
+        effective_prefix = "v"
+
+    next_rc = max(rc_numbers) + 1 if rc_numbers else 1
+    return f"{effective_prefix}{target_stable}-rc.{next_rc}"
+
+
 def main() -> None:
     """Compute and print the next version using environment configuration.
 
     The function orchestrates the full calculation pipeline:
     1. Parses environment variables for bump strategies and base versions.
-    2. Validates input formats using packaging.version.
+    2. Validates input formats and detects active version lines.
     3. Increments specific version segments or RC counters.
     4. Performs regression checks against stable and latest reachable tags.
 
@@ -72,12 +139,25 @@ def main() -> None:
     prefix = os.environ.get("TAG_PREFIX", detected_prefix)
 
     try:
-        baseline = normalize_version(latest_stable_str, prefix)
-        parsed = parse(baseline)
-        v = [parsed.major, parsed.minor, parsed.micro]
+        stable_baseline_str = normalize_version(latest_stable_str, prefix)
+        current_baseline_str = normalize_version(current_any_str, prefix)
+
+        parsed_stable = parse(stable_baseline_str)
+        parsed_current = parse(current_baseline_str)
+
+        current_stable_part = (
+            f"{parsed_current.major}.{parsed_current.minor}.{parsed_current.micro}"
+        )
+        if parse(current_stable_part) > parsed_stable:
+            baseline_str = current_stable_part
+        else:
+            baseline_str = stable_baseline_str
+
+        parsed_baseline = parse(baseline_str)
+        v = [parsed_baseline.major, parsed_baseline.minor, parsed_baseline.micro]
     except Exception as e:
         print(
-            f"Error: Could not parse version '{latest_stable_str}': {e}",
+            f"Error: Could not parse baseline versions: {e}",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -105,6 +185,7 @@ def main() -> None:
         result_str = f"{prefix}{target_stable}"
     else:
         result_str = _calculate_next_rc(prefix, target_stable, all_tags)
+
     norm_result = parse(normalize_version(result_str, prefix))
     norm_latest = parse(normalize_version(latest_stable_str, prefix))
     norm_current = parse(normalize_version(current_any_str, prefix))
@@ -130,19 +211,6 @@ def main() -> None:
         sys.exit(1)
 
     print(result_str)
-
-
-def _calculate_next_rc(prefix: str, target_stable: str, all_tags: list[str]) -> str:
-    p_regex = f"(?:{re.escape(prefix)}|v)?" if prefix != "v" else "v?"
-    rc_pattern = re.compile(rf"^{p_regex}{re.escape(target_stable)}-rc\.(\d+)$")
-
-    rc_numbers = []
-    for tag in all_tags:
-        if match := rc_pattern.match(tag.strip()):
-            rc_numbers.append(int(match.group(1)))
-
-    next_rc = max(rc_numbers) + 1 if rc_numbers else 1
-    return f"{prefix}{target_stable}-rc.{next_rc}"
 
 
 if __name__ == "__main__":

--- a/tools/calculate_version.py
+++ b/tools/calculate_version.py
@@ -38,7 +38,15 @@ def main() -> None:
         Exits with status 1 on validation failure or malformed input.
     """
     bump_type = os.environ["BUMP_TYPE"]
-    is_prerelease = os.environ["IS_PRERELEASE"].lower() == "true"
+    is_prerelease_raw = os.environ["IS_PRERELEASE"].strip().lower()
+    if is_prerelease_raw not in ("true", "false"):
+        print(
+            f"Error: Invalid IS_PRERELEASE value '{os.environ['IS_PRERELEASE']}', "
+            "expected 'true' or 'false'",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    is_prerelease = is_prerelease_raw == "true"
     latest_stable_str = os.environ["LATEST_STABLE"]
     current_any_str = os.environ["CURRENT_ANY"]
     all_tags_raw = os.environ.get("ALL_TAGS", "")

--- a/tools/calculate_version.py
+++ b/tools/calculate_version.py
@@ -2,8 +2,8 @@
 
 This module provides a standalone CLI tool to compute the next valid version
 based on repository history and user-selected bump strategies. It enforces
-branch-aware regression checks and handles pre-release (RC) increments by
-scanning all reachable tags across both 'v'-prefixed and numeric-only formats.
+global regression checks and handles pre-release (RC) increments by
+scanning all reachable tags across custom prefixes and standard formats.
 
 This utility is specifically designed for use within GitHub Actions release
 workflows to ensure consistent versioning across project branches.
@@ -14,6 +14,20 @@ import re
 import sys
 
 from packaging.version import parse
+
+
+def normalize_version(version_str: str, prefix: str) -> str:
+    """Strip prefixes and return a clean version string for parsing.
+
+    Args:
+        version_str: The version string to normalize.
+        prefix: The primary prefix to remove.
+
+    Returns:
+        A normalized Semantic Version string.
+    """
+    normalized = version_str.removeprefix(prefix)
+    return normalized.removeprefix("v")
 
 
 def main() -> None:
@@ -38,6 +52,7 @@ def main() -> None:
         Exits with status 1 on validation failure or malformed input.
     """
     bump_type = os.environ["BUMP_TYPE"]
+
     is_prerelease_raw = os.environ["IS_PRERELEASE"].strip().lower()
     if is_prerelease_raw not in ("true", "false"):
         print(
@@ -47,16 +62,17 @@ def main() -> None:
         )
         sys.exit(1)
     is_prerelease = is_prerelease_raw == "true"
+
     latest_stable_str = os.environ["LATEST_STABLE"]
     current_any_str = os.environ["CURRENT_ANY"]
     all_tags_raw = os.environ.get("ALL_TAGS", "")
     all_tags = [t.strip() for t in all_tags_raw.split("\n") if t.strip()]
 
-    baseline = latest_stable_str.removeprefix("v")
     detected_prefix = "v" if latest_stable_str.startswith("v") else ""
     prefix = os.environ.get("TAG_PREFIX", detected_prefix)
 
     try:
+        baseline = normalize_version(latest_stable_str, prefix)
         parsed = parse(baseline)
         v = [parsed.major, parsed.minor, parsed.micro]
     except Exception as e:
@@ -88,18 +104,10 @@ def main() -> None:
     if not is_prerelease:
         result_str = f"{prefix}{target_stable}"
     else:
-        rc_pattern = re.compile(f"^v?{re.escape(target_stable)}" + r"-rc\.(\d+)$")
-        rc_numbers = []
-        for tag in all_tags:
-            if match := rc_pattern.match(tag.strip()):
-                rc_numbers.append(int(match[1]))
-
-        next_rc = max(rc_numbers) + 1 if rc_numbers else 1
-        result_str = f"{prefix}{target_stable}-rc.{next_rc}"
-
-    norm_result = parse(result_str.removeprefix("v"))
-    norm_latest = parse(latest_stable_str.removeprefix("v"))
-    norm_current = parse(current_any_str.removeprefix("v"))
+        result_str = _calculate_next_rc(prefix, target_stable, all_tags)
+    norm_result = parse(normalize_version(result_str, prefix))
+    norm_latest = parse(normalize_version(latest_stable_str, prefix))
+    norm_current = parse(normalize_version(current_any_str, prefix))
 
     if norm_result <= norm_latest:
         print(
@@ -111,7 +119,7 @@ def main() -> None:
 
     if (
         is_prerelease
-        and current_any_str.removeprefix("v").startswith(target_stable)
+        and normalize_version(current_any_str, prefix).startswith(target_stable)
         and norm_result <= norm_current
     ):
         print(
@@ -122,6 +130,19 @@ def main() -> None:
         sys.exit(1)
 
     print(result_str)
+
+
+def _calculate_next_rc(prefix: str, target_stable: str, all_tags: list[str]) -> str:
+    p_regex = f"({re.escape(prefix)}|v)?" if prefix != "v" else "v?"
+    rc_pattern = re.compile(rf"^{p_regex}{re.escape(target_stable)}-rc\.(\d+)$")
+
+    rc_numbers = []
+    for tag in all_tags:
+        if match := rc_pattern.match(tag.strip()):
+            rc_numbers.append(int(match[1]))
+
+    next_rc = max(rc_numbers) + 1 if rc_numbers else 1
+    return f"{prefix}{target_stable}-rc.{next_rc}"
 
 
 if __name__ == "__main__":

--- a/tools/calculate_version.py
+++ b/tools/calculate_version.py
@@ -51,20 +51,24 @@ def normalize_version(version_str: str, prefix: str) -> str:
     return normalized
 
 
-def _calculate_next_rc(prefix: str, target_stable: str, all_tags: list[str]) -> str:
+def _calculate_next_rc(
+    prefix: str, target_stable: str, all_tags: list[str], is_auto_detected: bool
+) -> str:
     """Calculate the next RC tag for a given stable target with prefix strictness.
 
     The function is strict about mismatches between the configured `prefix`
     and discovered tags:
     - If `prefix == "v"`, only 'v'-prefixed RC tags are considered.
-    - If `prefix == ""`, both bare and 'v'-prefixed tags are allowed, but
-      mixing styles triggers an error to enforce repository consistency.
+    - If `prefix == ""`, both bare and 'v'-prefixed tags are allowed.
+    - In auto-detection mode (is_auto_detected=True), mixing styles triggers
+      an error to enforce repository consistency.
     - If any other `prefix` is used, only tags with that prefix are considered.
 
     Args:
         prefix: The configured TAG_PREFIX.
         target_stable: The base Semantic Version (e.g., '1.2.3').
         all_tags: List of existing tags to scan for RC patterns.
+        is_auto_detected: Whether the prefix style was automatically detected.
 
     Returns:
         The calculated pre-release string (e.g., 'v1.2.3-rc.1').
@@ -97,7 +101,7 @@ def _calculate_next_rc(prefix: str, target_stable: str, all_tags: list[str]) -> 
                 detected_prefixes.add(det_prefix)
                 break
 
-    if not prefix and len(detected_prefixes) > 1:
+    if is_auto_detected and not prefix and len(detected_prefixes) > 1:
         print(
             f"Error: Inconsistent RC tag prefixes detected for {target_stable!r}: "
             "found both 'v' and unprefixed tags. Please standardize your tag format.",
@@ -190,7 +194,7 @@ def main() -> None:
     if not is_prerelease:
         result_str = f"{prefix}{target_stable}"
     else:
-        result_str = _calculate_next_rc(prefix, target_stable, all_tags)
+        result_str = _calculate_next_rc(prefix, target_stable, all_tags, configured_prefix is None)
 
     try:
         norm_result = parse(normalize_version(result_str, prefix))

--- a/tools/calculate_version.py
+++ b/tools/calculate_version.py
@@ -21,7 +21,7 @@ def main() -> None:
 
     The function orchestrates the full calculation pipeline:
     1. Parses environment variables for bump strategies and base versions.
-    2. Validates input formats (X.Y.Z).
+    2. Validates input formats using packaging.version.
     3. Increments specific version segments or RC counters.
     4. Performs regression checks against stable and latest reachable tags.
 
@@ -31,6 +31,7 @@ def main() -> None:
         LATEST_STABLE: Baseline stable version string (e.g., 'v1.0.2').
         CURRENT_ANY: Latest reachable tag for regression checks.
         ALL_TAGS: Newline-separated tags for exhaustive pre-release scanning.
+        TAG_PREFIX: Optional override for the version prefix (e.g., 'v').
 
     Output:
         Prints the calculated version string to standard output.
@@ -43,13 +44,16 @@ def main() -> None:
     all_tags_raw = os.environ.get("ALL_TAGS", "")
     all_tags = [t.strip() for t in all_tags_raw.split("\n") if t.strip()]
 
-    prefix = "v" if latest_stable_str.startswith("v") else ""
+    baseline = latest_stable_str.removeprefix("v")
+    detected_prefix = "v" if latest_stable_str.startswith("v") else ""
+    prefix = os.environ.get("TAG_PREFIX", detected_prefix)
 
-    latest_stable_numeric = latest_stable_str.lstrip("v")
-    parts = latest_stable_numeric.split(".")
-    if len(parts) != 3:
+    try:
+        parsed = parse(baseline)
+        v = [parsed.major, parsed.minor, parsed.micro]
+    except Exception as e:
         print(
-            f"Error: Invalid version format '{latest_stable_str}', expected X.Y.Z",
+            f"Error: Could not parse version '{latest_stable_str}': {e}",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -61,7 +65,6 @@ def main() -> None:
         )
         sys.exit(1)
 
-    v = [int(parts[0]), int(parts[1]), int(parts[2])]
     if bump_type == "major":
         v[0] += 1
         v[1] = 0
@@ -75,7 +78,7 @@ def main() -> None:
     target_stable = f"{v[0]}.{v[1]}.{v[2]}"
 
     if not is_prerelease:
-        result = f"{prefix}{target_stable}"
+        result_str = f"{prefix}{target_stable}"
     else:
         rc_pattern = re.compile(f"^v?{re.escape(target_stable)}" + r"-rc\.(\d+)$")
         rc_numbers = []
@@ -84,11 +87,15 @@ def main() -> None:
                 rc_numbers.append(int(match[1]))
 
         next_rc = max(rc_numbers) + 1 if rc_numbers else 1
-        result = f"{prefix}{target_stable}-rc.{next_rc}"
+        result_str = f"{prefix}{target_stable}-rc.{next_rc}"
 
-    if parse(result) <= parse(latest_stable_str):
+    norm_result = parse(result_str.removeprefix("v"))
+    norm_latest = parse(latest_stable_str.removeprefix("v"))
+    norm_current = parse(current_any_str.removeprefix("v"))
+
+    if norm_result <= norm_latest:
         print(
-            f"Error: Calculated version {result} is not greater than "
+            f"Error: Calculated version {result_str} is not greater than "
             f"latest stable {latest_stable_str}",
             file=sys.stderr,
         )
@@ -96,17 +103,17 @@ def main() -> None:
 
     if (
         is_prerelease
-        and current_any_str.lstrip("v").startswith(target_stable)
-        and parse(result) <= parse(current_any_str)
+        and current_any_str.removeprefix("v").startswith(target_stable)
+        and norm_result <= norm_current
     ):
         print(
-            f"Error: Calculated pre-release {result} is not greater than "
+            f"Error: Calculated pre-release {result_str} is not greater than "
             f"latest version {current_any_str}",
             file=sys.stderr,
         )
         sys.exit(1)
 
-    print(result)
+    print(result_str)
 
 
 if __name__ == "__main__":

--- a/tools/calculate_version.py
+++ b/tools/calculate_version.py
@@ -133,13 +133,13 @@ def main() -> None:
 
 
 def _calculate_next_rc(prefix: str, target_stable: str, all_tags: list[str]) -> str:
-    p_regex = f"({re.escape(prefix)}|v)?" if prefix != "v" else "v?"
+    p_regex = f"(?:{re.escape(prefix)}|v)?" if prefix != "v" else "v?"
     rc_pattern = re.compile(rf"^{p_regex}{re.escape(target_stable)}-rc\.(\d+)$")
 
     rc_numbers = []
     for tag in all_tags:
         if match := rc_pattern.match(tag.strip()):
-            rc_numbers.append(int(match[1]))
+            rc_numbers.append(int(match.group(1)))
 
     next_rc = max(rc_numbers) + 1 if rc_numbers else 1
     return f"{prefix}{target_stable}-rc.{next_rc}"

--- a/tools/calculate_version.py
+++ b/tools/calculate_version.py
@@ -40,7 +40,8 @@ def main() -> None:
     is_prerelease = os.environ["IS_PRERELEASE"].lower() == "true"
     latest_stable_str = os.environ["LATEST_STABLE"]
     current_any_str = os.environ["CURRENT_ANY"]
-    all_tags = os.environ["ALL_TAGS"].split("\n")
+    all_tags_raw = os.environ.get("ALL_TAGS", "")
+    all_tags = [t.strip() for t in all_tags_raw.split("\n") if t.strip()]
 
     prefix = "v" if latest_stable_str.startswith("v") else ""
 

--- a/tools/calculate_version.py
+++ b/tools/calculate_version.py
@@ -143,18 +143,7 @@ def main() -> None:
         current_baseline_str = normalize_version(current_any_str, prefix)
 
         parsed_stable = parse(stable_baseline_str)
-        parsed_current = parse(current_baseline_str)
-
-        current_stable_part = (
-            f"{parsed_current.major}.{parsed_current.minor}.{parsed_current.micro}"
-        )
-        if parse(current_stable_part) > parsed_stable:
-            baseline_str = current_stable_part
-        else:
-            baseline_str = stable_baseline_str
-
-        parsed_baseline = parse(baseline_str)
-        v = [parsed_baseline.major, parsed_baseline.minor, parsed_baseline.micro]
+        v = [parsed_stable.major, parsed_stable.minor, parsed_stable.micro]
     except Exception as e:
         print(
             f"Error: Could not parse baseline versions: {e}",

--- a/tools/calculate_version.py
+++ b/tools/calculate_version.py
@@ -1,8 +1,12 @@
-"""Version calculation logic for the release workflow.
+"""Version calculation utility for Semantic Versioning 2.0.0 releases.
 
-This script calculates the next version based on the selected bump type
-(major, minor, patch) and pre-release flag, ensuring Semantic Versioning 2.0.0
-compliance and branch-aware regression checking.
+This module provides a standalone CLI tool to compute the next valid version
+based on repository history and user-selected bump strategies. It enforces
+branch-aware regression checks and handles pre-release (RC) increments by
+scanning all reachable tags across both 'v'-prefixed and numeric-only formats.
+
+This utility is specifically designed for use within GitHub Actions release
+workflows to ensure consistent versioning across project branches.
 """
 
 import os
@@ -13,7 +17,25 @@ from packaging.version import parse
 
 
 def main() -> None:
-    """Calculate the next version based on environment variables."""
+    """Compute and print the next version using environment configuration.
+
+    The function orchestrates the full calculation pipeline:
+    1. Parses environment variables for bump strategies and base versions.
+    2. Validates input formats (X.Y.Z).
+    3. Increments specific version segments or RC counters.
+    4. Performs regression checks against stable and latest reachable tags.
+
+    Environment Inputs:
+        BUMP_TYPE: Version segment to increment ('major', 'minor', 'patch').
+        IS_PRERELEASE: Boolean string ('true' or 'false') for RC suffixes.
+        LATEST_STABLE: Baseline stable version string (e.g., 'v1.0.2').
+        CURRENT_ANY: Latest reachable tag for regression checks.
+        ALL_TAGS: Newline-separated tags for exhaustive pre-release scanning.
+
+    Output:
+        Prints the calculated version string to standard output.
+        Exits with status 1 on validation failure or malformed input.
+    """
     bump_type = os.environ["BUMP_TYPE"]
     is_prerelease = os.environ["IS_PRERELEASE"].lower() == "true"
     latest_stable_str = os.environ["LATEST_STABLE"]
@@ -23,7 +45,15 @@ def main() -> None:
     prefix = "v" if latest_stable_str.startswith("v") else ""
 
     latest_stable_numeric = latest_stable_str.lstrip("v")
-    v = [int(x) for x in latest_stable_numeric.split(".")]
+    parts = latest_stable_numeric.split(".")
+    if len(parts) != 3:
+        print(
+            f"Error: Invalid version format '{latest_stable_str}', expected X.Y.Z",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    v = [int(parts[0]), int(parts[1]), int(parts[2])]
     if bump_type == "major":
         v[0] += 1
         v[1] = 0

--- a/tools/update_project_metadata.py
+++ b/tools/update_project_metadata.py
@@ -46,7 +46,9 @@ def update_pyproject(version: str) -> None:
         sys.exit(1)
 
     dynamic = project.get("dynamic", [])
-    if isinstance(dynamic, list) and "version" in dynamic:
+    dynamic_fields = {dynamic} if isinstance(dynamic, str) else set(dynamic)
+
+    if "version" in dynamic_fields:
         print(
             "Error: 'version' is declared as dynamic in pyproject.toml. Cannot update manually.",
             file=sys.stderr,

--- a/tools/update_project_metadata.py
+++ b/tools/update_project_metadata.py
@@ -1,0 +1,83 @@
+"""Update project metadata files with the new version.
+
+This script updates manifest.json and pyproject.toml, ensuring that
+Semantic Versioning is applied consistently across all project descriptors.
+It performs safety checks to prevent overwriting dynamic versions.
+"""
+
+import json
+import os
+import sys
+from typing import cast
+
+import tomlkit
+from tomlkit.items import Table
+
+
+def update_manifest(version: str) -> None:
+    """Update the Home Assistant integration manifest.
+
+    Args:
+        version: The new version string to apply.
+    """
+    path = "custom_components/blueprints_updater/manifest.json"
+    with open(path, encoding="utf-8") as f:
+        manifest = json.load(f)
+
+    manifest["version"] = version
+
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2)
+        f.write("\n")
+
+
+def update_pyproject(version: str) -> None:
+    """Update the pyproject.toml file.
+
+    Args:
+        version: The new version string to apply.
+    """
+    path = "pyproject.toml"
+    with open(path, encoding="utf-8") as f:
+        doc = tomlkit.parse(f.read())
+
+    if "project" not in doc:
+        print("Error: [project] table not found in pyproject.toml", file=sys.stderr)
+        sys.exit(1)
+
+    project = cast(Table, doc["project"])
+    if not isinstance(project, dict):
+        print("Error: [project] must be a table in pyproject.toml", file=sys.stderr)
+        sys.exit(1)
+
+    dynamic = project.get("dynamic", [])
+    if isinstance(dynamic, list) and "version" in dynamic:
+        print(
+            "Error: 'version' is declared as dynamic in pyproject.toml. Cannot update manually.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    project["version"] = version
+
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(tomlkit.dumps(doc))
+
+
+def main() -> None:
+    """Read the version from the environment and update all metadata files."""
+    version = os.environ.get("NEW_VERSION")
+    if not version:
+        print("Error: NEW_VERSION environment variable is not set", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        update_manifest(version)
+        update_pyproject(version)
+    except Exception as e:
+        print(f"Error updating project metadata: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/update_project_metadata.py
+++ b/tools/update_project_metadata.py
@@ -8,7 +8,6 @@ It performs safety checks to prevent overwriting dynamic versions.
 import json
 import os
 import sys
-from typing import cast
 
 import tomlkit
 from tomlkit.items import Table
@@ -41,12 +40,8 @@ def update_pyproject(version: str) -> None:
     with open(path, encoding="utf-8") as f:
         doc = tomlkit.parse(f.read())
 
-    if "project" not in doc:
-        print("Error: [project] table not found in pyproject.toml", file=sys.stderr)
-        sys.exit(1)
-
-    project = cast(Table, doc["project"])
-    if not isinstance(project, dict):
+    project = doc.get("project")
+    if not isinstance(project, Table):
         print("Error: [project] must be a table in pyproject.toml", file=sys.stderr)
         sys.exit(1)
 

--- a/tools/update_project_metadata.py
+++ b/tools/update_project_metadata.py
@@ -20,6 +20,10 @@ def update_manifest(version: str) -> None:
         version: The new version string to apply.
     """
     path = "custom_components/blueprints_updater/manifest.json"
+    if not os.path.isfile(path):
+        print(f"Error: manifest.json not found at {path}", file=sys.stderr)
+        sys.exit(1)
+
     with open(path, encoding="utf-8") as f:
         manifest = json.load(f)
 
@@ -33,16 +37,30 @@ def update_manifest(version: str) -> None:
 def update_pyproject(version: str) -> None:
     """Update the pyproject.toml file.
 
+    This function defensively navigates the TOML schema to ensure that
+    [project] exists and that the version is not declared as dynamic.
+
     Args:
         version: The new version string to apply.
     """
     path = "pyproject.toml"
+    if not os.path.isfile(path):
+        print(f"Error: pyproject.toml not found at {path}", file=sys.stderr)
+        sys.exit(1)
+
     with open(path, encoding="utf-8") as f:
         doc = tomlkit.parse(f.read())
 
     project = doc.get("project")
+    if project is None:
+        print("Error: [project] table not found in pyproject.toml", file=sys.stderr)
+        sys.exit(1)
+
     if not isinstance(project, Table):
-        print("Error: [project] must be a table in pyproject.toml", file=sys.stderr)
+        print(
+            f"Error: [project] in pyproject.toml is a {type(project).__name__}, expected a table",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     dynamic = project.get("dynamic", [])
@@ -59,7 +77,8 @@ def update_pyproject(version: str) -> None:
         dynamic_fields = set(dynamic)
     else:
         print(
-            "Error: [project.dynamic] must be a string or a list of strings in pyproject.toml",
+            f"Error: [project.dynamic] is a {type(dynamic).__name__}, "
+            "expected a string or a list of strings",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/tools/update_project_metadata.py
+++ b/tools/update_project_metadata.py
@@ -46,7 +46,23 @@ def update_pyproject(version: str) -> None:
         sys.exit(1)
 
     dynamic = project.get("dynamic", [])
-    dynamic_fields = {dynamic} if isinstance(dynamic, str) else set(dynamic)
+
+    if isinstance(dynamic, str):
+        dynamic_fields = {dynamic}
+    elif isinstance(dynamic, list):
+        if not all(isinstance(item, str) for item in dynamic):
+            print(
+                "Error: [project.dynamic] must be a string or a list of strings in pyproject.toml",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        dynamic_fields = set(dynamic)
+    else:
+        print(
+            "Error: [project.dynamic] must be a string or a list of strings in pyproject.toml",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     if "version" in dynamic_fields:
         print(

--- a/uv.lock
+++ b/uv.lock
@@ -391,10 +391,12 @@ source = { virtual = "." }
 dev = [
     { name = "homeassistant" },
     { name = "interrogate" },
+    { name = "packaging" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
+    { name = "tomlkit" },
     { name = "ty" },
 ]
 
@@ -404,10 +406,12 @@ dev = [
 dev = [
     { name = "homeassistant", specifier = ">=2026.4.2" },
     { name = "interrogate" },
+    { name = "packaging" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
+    { name = "tomlkit" },
     { name = "ty" },
 ]
 
@@ -1810,6 +1814,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/af/14b24e41977adb296d6bd1fb59402cf7d60ce364f90c890bd2ec65c43b5a/tomlkit-0.14.0.tar.gz", hash = "sha256:cf00efca415dbd57575befb1f6634c4f42d2d87dbba376128adb42c121b87064", size = 187167, upload-time = "2026-01-13T01:14:53.304Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl", hash = "sha256:592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680", size = 39310, upload-time = "2026-01-13T01:14:51.965Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -475,30 +475,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.42.89"
+version = "1.42.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/0c/f7bccb22b245cabf392816baba20f9e95f78ace7dbc580fd40136e80e732/boto3-1.42.89.tar.gz", hash = "sha256:3e43aacc0801bba9bcd23a8c271c089af297a69565f783fcdd357ae0e330bf1e", size = 113165, upload-time = "2026-04-13T19:36:17.516Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/17/510f31d7d6190c01725710d95415733e467f4406d450a106f6eacfd3a94d/boto3-1.42.90.tar.gz", hash = "sha256:bafb5bb1dea262ac95f9afb1e415f06a9490f05cb203bdd897d0afdcd17733c6", size = 113174, upload-time = "2026-04-16T20:27:43.012Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/33/55103ba5ef9975ea54b8d39e69b76eb6e9fded3beae5f01065e26951a3a1/boto3-1.42.89-py3-none-any.whl", hash = "sha256:6204b189f4d0c655535f43d7eaa57ff4e8d965b8463c97e45952291211162932", size = 140556, upload-time = "2026-04-13T19:36:13.894Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/bd/a0c5011a8eddce39a9b613b13a75057bf960ef2145ff4d1583ed81a2599b/boto3-1.42.90-py3-none-any.whl", hash = "sha256:fde7f7bcad6ec8342d6bf18f56d118d0cb6df189310cfaf73e2eb6443b1cb418", size = 140554, upload-time = "2026-04-16T20:27:40.226Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.42.89"
+version = "1.42.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0f/cc/e6be943efa9051bd15c2ee14077c2b10d6e27c9e9385fc43a03a5c4ed8b5/botocore-1.42.89.tar.gz", hash = "sha256:95ac52f472dad29942f3088b278ab493044516c16dbf9133c975af16527baa99", size = 15206290, upload-time = "2026-04-13T19:36:02.321Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/cf/4eaa0b7ab2ba0b2a0c93e277779b1385127e2f07876a08d698b529affdae/botocore-1.42.90.tar.gz", hash = "sha256:234c39492cd3088acb021d999e3392a4d50238ae3e70b9d9ae1504c30d9009d1", size = 15209231, upload-time = "2026-04-16T20:27:29.323Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/f1/90a7b8eda38b7c3a65ca7ee0075bdf310b6b471cb1b95fab6e8994323a50/botocore-1.42.89-py3-none-any.whl", hash = "sha256:d9b786c8d9db6473063b4cc5be0ba7e6a381082307bd6afb69d4216f9fa95f35", size = 14887287, upload-time = "2026-04-13T19:35:56.677Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/1e/44afcdc3b526b6e1569dd142083c6ed1cb8b92b4141de1c78ded883b449a/botocore-1.42.90-py3-none-any.whl", hash = "sha256:5c95504720346990adc8e3ae1023eb46f9409084b79688e4773ba7099c5fd3db", size = 14892274, upload-time = "2026-04-16T20:27:24.057Z" },
 ]
 
 [[package]]
@@ -1669,27 +1669,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.10"
+version = "0.15.11"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/d9/aa3f7d59a10ef6b14fe3431706f854dbf03c5976be614a9796d36326810c/ruff-0.15.10.tar.gz", hash = "sha256:d1f86e67ebfdef88e00faefa1552b5e510e1d35f3be7d423dc7e84e63788c94e", size = 4631728, upload-time = "2026-04-09T14:06:09.884Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/8d/192f3d7103816158dfd5ea50d098ef2aec19194e6cbccd4b3485bdb2eb2d/ruff-0.15.11.tar.gz", hash = "sha256:f092b21708bf0e7437ce9ada249dfe688ff9a0954fc94abab05dcea7dcd29c33", size = 4637264, upload-time = "2026-04-16T18:46:26.58Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/00/a1c2fdc9939b2c03691edbda290afcd297f1f389196172826b03d6b6a595/ruff-0.15.10-py3-none-linux_armv6l.whl", hash = "sha256:0744e31482f8f7d0d10a11fcbf897af272fefdfcb10f5af907b18c2813ff4d5f", size = 10563362, upload-time = "2026-04-09T14:06:21.189Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/15/006990029aea0bebe9d33c73c3e28c80c391ebdba408d1b08496f00d422d/ruff-0.15.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b1e7c16ea0ff5a53b7c2df52d947e685973049be1cdfe2b59a9c43601897b22e", size = 10951122, upload-time = "2026-04-09T14:06:02.236Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/c0/4ac978fe874d0618c7da647862afe697b281c2806f13ce904ad652fa87e4/ruff-0.15.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:93cc06a19e5155b4441dd72808fdf84290d84ad8a39ca3b0f994363ade4cebb1", size = 10314005, upload-time = "2026-04-09T14:06:00.026Z" },
-    { url = "https://files.pythonhosted.org/packages/da/73/c209138a5c98c0d321266372fc4e33ad43d506d7e5dd817dd89b60a8548f/ruff-0.15.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83e1dd04312997c99ea6965df66a14fb4f03ba978564574ffc68b0d61fd3989e", size = 10643450, upload-time = "2026-04-09T14:05:42.137Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/76/0deec355d8ec10709653635b1f90856735302cb8e149acfdf6f82a5feb70/ruff-0.15.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8154d43684e4333360fedd11aaa40b1b08a4e37d8ffa9d95fee6fa5b37b6fab1", size = 10379597, upload-time = "2026-04-09T14:05:49.984Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/be/86bba8fc8798c081e28a4b3bb6d143ccad3fd5f6f024f02002b8f08a9fa3/ruff-0.15.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ab88715f3a6deb6bde6c227f3a123410bec7b855c3ae331b4c006189e895cef", size = 11146645, upload-time = "2026-04-09T14:06:12.246Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/89/140025e65911b281c57be1d385ba1d932c2366ca88ae6663685aed8d4881/ruff-0.15.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a768ff5969b4f44c349d48edf4ab4f91eddb27fd9d77799598e130fb628aa158", size = 12030289, upload-time = "2026-04-09T14:06:04.776Z" },
-    { url = "https://files.pythonhosted.org/packages/88/de/ddacca9545a5e01332567db01d44bd8cf725f2db3b3d61a80550b48308ea/ruff-0.15.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ee3ef42dab7078bda5ff6a1bcba8539e9857deb447132ad5566a038674540d0", size = 11496266, upload-time = "2026-04-09T14:05:55.485Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/bb/7ddb00a83760ff4a83c4e2fc231fd63937cc7317c10c82f583302e0f6586/ruff-0.15.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51cb8cc943e891ba99989dd92d61e29b1d231e14811db9be6440ecf25d5c1609", size = 11256418, upload-time = "2026-04-09T14:05:57.69Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/8d/55de0d35aacf6cd50b6ee91ee0f291672080021896543776f4170fc5c454/ruff-0.15.10-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:e59c9bdc056a320fb9ea1700a8d591718b8faf78af065484e801258d3a76bc3f", size = 11288416, upload-time = "2026-04-09T14:05:44.695Z" },
-    { url = "https://files.pythonhosted.org/packages/68/cf/9438b1a27426ec46a80e0a718093c7f958ef72f43eb3111862949ead3cc1/ruff-0.15.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:136c00ca2f47b0018b073f28cb5c1506642a830ea941a60354b0e8bc8076b151", size = 10621053, upload-time = "2026-04-09T14:05:52.782Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/50/e29be6e2c135e9cd4cb15fbade49d6a2717e009dff3766dd080fcb82e251/ruff-0.15.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8b80a2f3c9c8a950d6237f2ca12b206bccff626139be9fa005f14feb881a1ae8", size = 10378302, upload-time = "2026-04-09T14:06:14.361Z" },
-    { url = "https://files.pythonhosted.org/packages/18/2f/e0b36a6f99c51bb89f3a30239bc7bf97e87a37ae80aa2d6542d6e5150364/ruff-0.15.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:e3e53c588164dc025b671c9df2462429d60357ea91af7e92e9d56c565a9f1b07", size = 10850074, upload-time = "2026-04-09T14:06:16.581Z" },
-    { url = "https://files.pythonhosted.org/packages/11/08/874da392558ce087a0f9b709dc6ec0d60cbc694c1c772dab8d5f31efe8cb/ruff-0.15.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b0c52744cf9f143a393e284125d2576140b68264a93c6716464e129a3e9adb48", size = 11358051, upload-time = "2026-04-09T14:06:18.948Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/46/602938f030adfa043e67112b73821024dc79f3ab4df5474c25fa4c1d2d14/ruff-0.15.10-py3-none-win32.whl", hash = "sha256:d4272e87e801e9a27a2e8df7b21011c909d9ddd82f4f3281d269b6ba19789ca5", size = 10588964, upload-time = "2026-04-09T14:06:07.14Z" },
-    { url = "https://files.pythonhosted.org/packages/25/b6/261225b875d7a13b33a6d02508c39c28450b2041bb01d0f7f1a83d569512/ruff-0.15.10-py3-none-win_amd64.whl", hash = "sha256:28cb32d53203242d403d819fd6983152489b12e4a3ae44993543d6fe62ab42ed", size = 11745044, upload-time = "2026-04-09T14:05:39.473Z" },
-    { url = "https://files.pythonhosted.org/packages/58/ed/dea90a65b7d9e69888890fb14c90d7f51bf0c1e82ad800aeb0160e4bacfd/ruff-0.15.10-py3-none-win_arm64.whl", hash = "sha256:601d1610a9e1f1c2165a4f561eeaa2e2ea1e97f3287c5aa258d3dab8b57c6188", size = 11035607, upload-time = "2026-04-09T14:05:47.593Z" },
+    { url = "https://files.pythonhosted.org/packages/02/1e/6aca3427f751295ab011828e15e9bf452200ac74484f1db4be0197b8170b/ruff-0.15.11-py3-none-linux_armv6l.whl", hash = "sha256:e927cfff503135c558eb581a0c9792264aae9507904eb27809cdcff2f2c847b7", size = 10607943, upload-time = "2026-04-16T18:46:05.967Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/26/1341c262e74f36d4e84f3d6f4df0ac68cd53331a66bfc5080daa17c84c0b/ruff-0.15.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7a1b5b2938d8f890b76084d4fa843604d787a912541eae85fd7e233398bbb73e", size = 10988592, upload-time = "2026-04-16T18:46:00.742Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/850b1d6ffa9564fbb6740429bad53df1094082fe515c8c1e74b6d8d05f18/ruff-0.15.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d4176f3d194afbdaee6e41b9ccb1a2c287dba8700047df474abfbe773825d1cb", size = 10338501, upload-time = "2026-04-16T18:46:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/11/cc1284d3e298c45a817a6aadb6c3e1d70b45c9b36d8d9cce3387b495a03a/ruff-0.15.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b17c886fb88203ced3afe7f14e8d5ae96e9d2f4ccc0ee66aa19f2c2675a27e4", size = 10670693, upload-time = "2026-04-16T18:46:41.941Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/9e/f8288b034ab72b371513c13f9a41d9ba3effac54e24bfb467b007daee2ca/ruff-0.15.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:49fafa220220afe7758a487b048de4c8f9f767f37dfefad46b9dd06759d003eb", size = 10416177, upload-time = "2026-04-16T18:46:21.717Z" },
+    { url = "https://files.pythonhosted.org/packages/85/71/504d79abfd3d92532ba6bbe3d1c19fada03e494332a59e37c7c2dabae427/ruff-0.15.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f2ab8427e74a00d93b8bda1307b1e60970d40f304af38bccb218e056c220120d", size = 11221886, upload-time = "2026-04-16T18:46:15.086Z" },
+    { url = "https://files.pythonhosted.org/packages/43/5a/947e6ab7a5ad603d65b474be15a4cbc6d29832db5d762cd142e4e3a74164/ruff-0.15.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:195072c0c8e1fc8f940652073df082e37a5d9cb43b4ab1e4d0566ab8977a13b7", size = 12075183, upload-time = "2026-04-16T18:46:07.944Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/a1/0b7bb6268775fdd3a0818aee8efd8f5b4e231d24dd4d528ced2534023182/ruff-0.15.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a3a0996d486af3920dec930a2e7daed4847dfc12649b537a9335585ada163e9e", size = 11516575, upload-time = "2026-04-16T18:46:31.687Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bef2cb556d509259f1fe440bb9cd33c756222cf0a7afe90d15edf0866702431", size = 11306537, upload-time = "2026-04-16T18:46:36.988Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/92/4cfae6441f3967317946f3b788136eecf093729b94d6561f963ed810c82e/ruff-0.15.11-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:030d921a836d7d4a12cf6e8d984a88b66094ccb0e0f17ddd55067c331191bf19", size = 11296813, upload-time = "2026-04-16T18:46:24.182Z" },
+    { url = "https://files.pythonhosted.org/packages/43/26/972784c5dde8313acde8ac71ba8ac65475b85db4a2352a76c9934361f9bc/ruff-0.15.11-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0e783b599b4577788dbbb66b9addcef87e9a8832f4ce0c19e34bf55543a2f890", size = 10633136, upload-time = "2026-04-16T18:46:39.802Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/53/3985a4f185020c2f367f2e08a103032e12564829742a1b417980ce1514a0/ruff-0.15.11-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ae90592246625ba4a34349d68ec28d4400d75182b71baa196ddb9f82db025ef5", size = 10424701, upload-time = "2026-04-16T18:46:10.381Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/57/bf0dfb32241b56c83bb663a826133da4bf17f682ba8c096973065f6e6a68/ruff-0.15.11-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1f111d62e3c983ed20e0ca2e800f8d77433a5b1161947df99a5c2a3fb60514f0", size = 10873887, upload-time = "2026-04-16T18:46:29.157Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/e48076b2a57dc33ee8c7a957296f97c744ca891a8ffb4ffb1aaa3b3f517d/ruff-0.15.11-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:06f483d6646f59eaffba9ae30956370d3a886625f511a3108994000480621d1c", size = 11404316, upload-time = "2026-04-16T18:46:19.462Z" },
+    { url = "https://files.pythonhosted.org/packages/88/27/0195d15fe7a897cbcba0904792c4b7c9fdd958456c3a17d2ea6093716a9a/ruff-0.15.11-py3-none-win32.whl", hash = "sha256:476a2aa56b7da0b73a3ee80b6b2f0e19cce544245479adde7baa65466664d5f3", size = 10655535, upload-time = "2026-04-16T18:46:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/5e/c927b325bd4c1d3620211a4b96f47864633199feed60fa936025ab27e090/ruff-0.15.11-py3-none-win_amd64.whl", hash = "sha256:8b6756d88d7e234fb0c98c91511aae3cd519d5e3ed271cae31b20f39cb2a12a3", size = 11779692, upload-time = "2026-04-16T18:46:17.268Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b6/aeadee5443e49baa2facd51131159fd6301cc4ccfc1541e4df7b021c37dd/ruff-0.15.11-py3-none-win_arm64.whl", hash = "sha256:063fed18cc1bbe0ee7393957284a6fe8b588c6a406a285af3ee3f46da2391ee4", size = 11032614, upload-time = "2026-04-16T18:46:34.487Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary by Sourcery

Automate release versioning in the GitHub Actions workflow by deriving semantic versions from existing tags and a selected bump type instead of requiring a manually entered version.

Enhancements:
- Replace manual version input with a choice of semantic bump types (patch, minor, major) in the release workflow.
- Add script logic to compute the next stable or pre-release version based on git tags, enforcing that new versions are strictly greater than existing ones.
- Switch pyproject.toml version updates from a regex-based sed replacement to a structured update using tomlkit via uv.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Replaced free-form version input with a constrained bump-type selector (patch/minor/major) while keeping prerelease option.
  * Automated version calculation in the release flow with strict validation to prevent empty or invalid results.
  * Switched project file updates to a safer TOML/JSON-aware updater and ensured release/tag names come from the computed version.
  * Added development tooling dependencies to support these workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->