### PR TITLE
Fix coordinator data initialization and safe git diff handling

### DIFF
--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -157,9 +157,8 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             entry: Integration configuration entry.
             update_interval: Scan interval.
 
-        Note: self.data is explicitly initialized to an empty dictionary
-        immediately after super().__init__(). This is intentional to ensure
-        it is never None, as the base class constructor sets it to None.
+        Note: After initialization, self.data is always a dictionary and is
+        never None, ensuring callers can rely on dictionary semantics.
 
         """
         self.hass = hass

--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -143,7 +143,6 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
         return f"blueprint_{hashlib.sha256(rel_path.encode()).hexdigest()}"
 
     config_entry: ConfigEntry
-    data: dict[str, dict[str, Any]]
 
     def __init__(
         self,
@@ -427,8 +426,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
 
         if (len(self._persisted_etags) + len(self._persisted_hashes)) < old_count:
             _LOGGER.debug("Pruned stale blueprint metadata from memory, triggering save")
-            if self.data is not None:
-                self.data = {path: info for path, info in self.data.items() if path in valid_paths}
+            self.data = {path: info for path, info in self.data.items() if path in valid_paths}
             self.hass.async_create_background_task(
                 self._async_save_metadata(force=True), name=f"{DOMAIN}_prune_save"
             )
@@ -1271,8 +1269,6 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
         Returns:
             GitDiffResult if cached, else None.
         """
-        if self.data is None:
-            return None
         info = self.data.get(path, {})
         cached = info.get("_cached_git_diff")
         if cached and isinstance(cached, dict):
@@ -1294,6 +1290,9 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
     ) -> None:
         """Set cached git diff.
 
+        If the coordinator's data is not yet initialized or
+        the path is not in the data, this method does nothing.
+
         Args:
             path: Local path of the blueprint.
             local_hash: Hash of the local file.
@@ -1301,7 +1300,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             diff_text: Generated unified diff string.
             is_semantic_sync: Whether the diff is empty due to semantic sync.
         """
-        if self.data is not None and path in self.data:
+        if path in self.data:
             self.data[path]["_cached_git_diff"] = {
                 "local": local_hash,
                 "remote": remote_hash,
@@ -1317,7 +1316,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
         passes blueprint validation. This prevents unvalidated content
         from being used in the installation flow.
         """
-        info = self.data.get(path) if self.data is not None else None
+        info = self.data.get(path)
         if not info or not info.get("updatable"):
             return None
 
@@ -1375,7 +1374,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
         Returns:
             GitDiffResult or None if it cannot be generated.
         """
-        if self.data is None or path not in self.data:
+        if path not in self.data:
             return None
 
         info = self.data[path]
@@ -1462,7 +1461,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             clear_etag: If True, clear the stored ETag for this blueprint.
 
         """
-        if self.data and path in self.data:
+        if path in self.data:
             update_data = {
                 "remote_hash": None,
                 "remote_content": None,
@@ -1555,10 +1554,8 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
 
         cdn_url = self._get_cdn_url(normalized_url) if self.is_cdn_enabled() else None
 
-        stored_etag = self.data.get(path, {}).get("etag") if self.data is not None else None
-        stored_remote_hash = (
-            self.data.get(path, {}).get("remote_hash") if self.data is not None else None
-        )
+        stored_etag = self.data.get(path, {}).get("etag")
+        stored_remote_hash = self.data.get(path, {}).get("remote_hash")
 
         try:
             remote_content, new_etag = await self._async_fetch_with_cdn_fallback(

--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -161,7 +161,6 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
         """
         self.hass = hass
         self.config_entry = entry
-        self.data: dict[str, dict[str, Any]] = {}
         self.setup_complete = False
         super().__init__(
             hass,
@@ -169,6 +168,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             name=DOMAIN,
             update_interval=update_interval,
         )
+        self.data: dict[str, dict[str, Any]] = {}
         self._translations: dict[tuple[str, str], dict[str, str]] = {}
         self.hass.data.setdefault(DOMAIN, {}).setdefault("translation_cache", {})
         self._translation_lock = asyncio.Lock()
@@ -427,7 +427,8 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
 
         if (len(self._persisted_etags) + len(self._persisted_hashes)) < old_count:
             _LOGGER.debug("Pruned stale blueprint metadata from memory, triggering save")
-            self.data = {path: info for path, info in self.data.items() if path in valid_paths}
+            if self.data is not None:
+                self.data = {path: info for path, info in self.data.items() if path in valid_paths}
             self.hass.async_create_background_task(
                 self._async_save_metadata(force=True), name=f"{DOMAIN}_prune_save"
             )
@@ -1270,6 +1271,8 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
         Returns:
             GitDiffResult if cached, else None.
         """
+        if self.data is None:
+            return None
         info = self.data.get(path, {})
         cached = info.get("_cached_git_diff")
         if cached and isinstance(cached, dict):
@@ -1298,7 +1301,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             diff_text: Generated unified diff string.
             is_semantic_sync: Whether the diff is empty due to semantic sync.
         """
-        if path in self.data:
+        if self.data is not None and path in self.data:
             self.data[path]["_cached_git_diff"] = {
                 "local": local_hash,
                 "remote": remote_hash,
@@ -1314,7 +1317,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
         passes blueprint validation. This prevents unvalidated content
         from being used in the installation flow.
         """
-        info = self.data.get(path)
+        info = self.data.get(path) if self.data is not None else None
         if not info or not info.get("updatable"):
             return None
 
@@ -1372,7 +1375,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
         Returns:
             GitDiffResult or None if it cannot be generated.
         """
-        if path not in self.data:
+        if self.data is None or path not in self.data:
             return None
 
         info = self.data[path]
@@ -1552,8 +1555,10 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
 
         cdn_url = self._get_cdn_url(normalized_url) if self.is_cdn_enabled() else None
 
-        stored_etag = self.data.get(path, {}).get("etag")
-        stored_remote_hash = self.data.get(path, {}).get("remote_hash")
+        stored_etag = self.data.get(path, {}).get("etag") if self.data is not None else None
+        stored_remote_hash = (
+            self.data.get(path, {}).get("remote_hash") if self.data is not None else None
+        )
 
         try:
             remote_content, new_etag = await self._async_fetch_with_cdn_fallback(

--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -430,8 +430,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
 
         if (len(self._persisted_etags) + len(self._persisted_hashes)) < old_count:
             _LOGGER.debug("Pruned stale blueprint metadata from memory, triggering save")
-            if self.data is not None:
-                self.data = {path: info for path, info in self.data.items() if path in valid_paths}
+            self.data = {path: info for path, info in self.data.items() if path in valid_paths}
             self.hass.async_create_background_task(
                 self._async_save_metadata(force=True), name=f"{DOMAIN}_prune_save"
             )

--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -157,6 +157,10 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             entry: Integration configuration entry.
             update_interval: Scan interval.
 
+        Note: self.data is explicitly initialized after super().__init__()
+        to ensure it is always a dictionary, as the base class constructor
+        sets it to None.
+
         """
         self.hass = hass
         self.config_entry = entry
@@ -426,7 +430,8 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
 
         if (len(self._persisted_etags) + len(self._persisted_hashes)) < old_count:
             _LOGGER.debug("Pruned stale blueprint metadata from memory, triggering save")
-            self.data = {path: info for path, info in self.data.items() if path in valid_paths}
+            if self.data is not None:
+                self.data = {path: info for path, info in self.data.items() if path in valid_paths}
             self.hass.async_create_background_task(
                 self._async_save_metadata(force=True), name=f"{DOMAIN}_prune_save"
             )

--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -157,9 +157,9 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             entry: Integration configuration entry.
             update_interval: Scan interval.
 
-        Note: self.data is explicitly initialized after super().__init__()
-        to ensure it is always a dictionary, as the base class constructor
-        sets it to None.
+        Note: self.data is explicitly initialized to an empty dictionary
+        immediately after super().__init__(). This is intentional to ensure
+        it is never None, as the base class constructor sets it to None.
 
         """
         self.hass = hass

--- a/tests/test_coordinator_data_robustness.py
+++ b/tests/test_coordinator_data_robustness.py
@@ -11,12 +11,22 @@ from custom_components.blueprints_updater.coordinator import BlueprintUpdateCoor
 @pytest.fixture
 def mock_coordinator(hass):
     """Fixture for BlueprintUpdateCoordinator with minimal mocking."""
+
+    def mock_init(self, hass, logger, name, update_interval=None) -> None:
+        """Mock side effect to simulate base class setup without failing checks."""
+        self.hass = hass
+        self.logger = logger
+        self.name = name
+        self.update_interval = update_interval
+        self.data = None
+
     entry = MagicMock()
     entry.options = {}
     entry.data = {}
     with patch(
         "homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__",
-        return_value=None,
+        autospec=True,
+        side_effect=mock_init,
     ):
         return BlueprintUpdateCoordinator(hass, entry, timedelta(hours=24))
 
@@ -40,7 +50,6 @@ async def test_async_prune_stale_metadata_empty_data(hass, mock_coordinator):
         mock_save.assert_called_once_with(force=True)
 
     assert not coordinator.data
-    assert not coordinator._persisted_etags
     assert not coordinator._persisted_etags
     assert not coordinator._persisted_hashes
 

--- a/tests/test_coordinator_data_robustness.py
+++ b/tests/test_coordinator_data_robustness.py
@@ -105,3 +105,25 @@ def test_update_error_state_with_existing_path(mock_coordinator) -> None:
     assert isinstance(info["last_error"], str)
     assert "fetch_error|detail" in info["last_error"]
     assert info["etag"] is None
+
+
+def test_update_error_state_preserve_etag(mock_coordinator) -> None:
+    """_update_error_state should preserve ETag when clear_etag is False."""
+    path = "existing/path"
+    etag = "some_etag"
+    mock_coordinator.data = {
+        path: {
+            "name": "Test",
+            "remote_hash": "old_hash",
+            "updatable": True,
+            "last_error": None,
+            "etag": etag,
+        }
+    }
+
+    mock_coordinator._update_error_state(path, "fetch_error", "detail", clear_etag=False)
+
+    info = mock_coordinator.data[path]
+    assert info["remote_hash"] is None
+    assert info["updatable"] is False
+    assert info["etag"] == etag

--- a/tests/test_coordinator_data_robustness.py
+++ b/tests/test_coordinator_data_robustness.py
@@ -1,4 +1,4 @@
-"""Tests for issue where self.data is being accessed safely."""
+"""Tests for the coordinator's data initialization contract and robustness."""
 
 from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch

--- a/tests/test_coordinator_data_robustness.py
+++ b/tests/test_coordinator_data_robustness.py
@@ -32,6 +32,12 @@ def mock_coordinator(hass):
 
 
 @pytest.mark.asyncio
+async def test_coordinator_data_initialized_to_empty_dict(hass, mock_coordinator):
+    """Confirm BlueprintUpdateCoordinator sets self.data to {} after initialization."""
+    assert mock_coordinator.data == {}
+
+
+@pytest.mark.asyncio
 async def test_async_prune_stale_metadata_empty_data(hass, mock_coordinator):
     """Test that _async_prune_stale_metadata works correctly with empty self.data."""
     coordinator = mock_coordinator
@@ -82,8 +88,10 @@ def test_update_error_state_with_existing_path(mock_coordinator) -> None:
         path: {
             "name": "Test",
             "remote_hash": "old_hash",
+            "remote_content": "old_content",
             "updatable": True,
             "last_error": None,
+            "invalid_remote_hash": "some_bad_hash",
         }
     }
 
@@ -91,6 +99,8 @@ def test_update_error_state_with_existing_path(mock_coordinator) -> None:
 
     info = mock_coordinator.data[path]
     assert info["remote_hash"] is None
+    assert info["remote_content"] is None
+    assert info["invalid_remote_hash"] is None
     assert info["updatable"] is False
     assert isinstance(info["last_error"], str)
     assert "fetch_error|detail" in info["last_error"]

--- a/tests/test_issue_none_data.py
+++ b/tests/test_issue_none_data.py
@@ -46,29 +46,6 @@ async def test_async_prune_stale_metadata_empty_data(hass, mock_coordinator):
 
 
 @pytest.mark.asyncio
-async def test_async_prune_stale_metadata_none_data(hass, mock_coordinator):
-    """Regression test for issue where self.data is None during pruning."""
-    coordinator = mock_coordinator
-    coordinator.data = None
-    coordinator._persisted_etags = {"stale_path": "etag"}
-    coordinator._persisted_hashes = {"stale_path": "hash"}
-
-    with (
-        patch(
-            "custom_components.blueprints_updater.coordinator.os.path.isfile",
-            return_value=False,
-        ),
-        patch.object(coordinator, "_async_save_metadata", new_callable=AsyncMock) as mock_save,
-    ):
-        await coordinator._async_prune_stale_metadata(set())
-        mock_save.assert_called_once_with(force=True)
-
-    assert coordinator.data is None
-    assert not coordinator._persisted_etags
-    assert not coordinator._persisted_hashes
-
-
-@pytest.mark.asyncio
 async def test_git_diff_empty_data(hass, mock_coordinator):
     """Test that git diff methods handle empty self.data correctly."""
     coordinator = mock_coordinator

--- a/tests/test_issue_none_data.py
+++ b/tests/test_issue_none_data.py
@@ -34,11 +34,36 @@ async def test_async_prune_stale_metadata_empty_data(hass, mock_coordinator):
         patch(
             "custom_components.blueprints_updater.coordinator.os.path.isfile", return_value=False
         ),
-        patch.object(coordinator, "_async_save_metadata", new_callable=AsyncMock),
+        patch.object(coordinator, "_async_save_metadata", new_callable=AsyncMock) as mock_save,
     ):
         await coordinator._async_prune_stale_metadata(set())
+        mock_save.assert_called_once_with(force=True)
 
     assert not coordinator.data
+    assert not coordinator._persisted_etags
+    assert not coordinator._persisted_etags
+    assert not coordinator._persisted_hashes
+
+
+@pytest.mark.asyncio
+async def test_async_prune_stale_metadata_none_data(hass, mock_coordinator):
+    """Regression test for issue where self.data is None during pruning."""
+    coordinator = mock_coordinator
+    coordinator.data = None
+    coordinator._persisted_etags = {"stale_path": "etag"}
+    coordinator._persisted_hashes = {"stale_path": "hash"}
+
+    with (
+        patch(
+            "custom_components.blueprints_updater.coordinator.os.path.isfile",
+            return_value=False,
+        ),
+        patch.object(coordinator, "_async_save_metadata", new_callable=AsyncMock) as mock_save,
+    ):
+        await coordinator._async_prune_stale_metadata(set())
+        mock_save.assert_called_once_with(force=True)
+
+    assert coordinator.data is None
     assert not coordinator._persisted_etags
     assert not coordinator._persisted_hashes
 
@@ -54,3 +79,33 @@ async def test_git_diff_empty_data(hass, mock_coordinator):
 
     coordinator.set_cached_git_diff("any_path", "lh", "rh", "diff")
     assert "any_path" not in coordinator.data
+
+
+def test_update_error_state_with_missing_path(mock_coordinator) -> None:
+    """_update_error_state should be a no-op when the path is not present in data."""
+    mock_coordinator.data = {}
+
+    mock_coordinator._update_error_state("nonexistent/path", "test_error", "detail")
+    assert not mock_coordinator.data
+
+
+def test_update_error_state_with_existing_path(mock_coordinator) -> None:
+    """_update_error_state should update/reset error state when the path exists."""
+    path = "existing/path"
+    mock_coordinator.data = {
+        path: {
+            "name": "Test",
+            "remote_hash": "old_hash",
+            "updatable": True,
+            "last_error": None,
+        }
+    }
+
+    mock_coordinator._update_error_state(path, "fetch_error", "detail", clear_etag=True)
+
+    info = mock_coordinator.data[path]
+    assert info["remote_hash"] is None
+    assert info["updatable"] is False
+    assert isinstance(info["last_error"], str)
+    assert "fetch_error|detail" in info["last_error"]
+    assert info["etag"] is None

--- a/tests/test_issue_none_data.py
+++ b/tests/test_issue_none_data.py
@@ -1,7 +1,6 @@
-"""Tests for issue where self.data is None during startup."""
+"""Tests for issue where self.data is being accessed safely."""
 
 from datetime import timedelta
-from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -19,15 +18,14 @@ def mock_coordinator(hass):
         "homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__",
         return_value=None,
     ):
-        coord = BlueprintUpdateCoordinator(hass, entry, timedelta(hours=24))
-        coord.data = cast(Any, None)
-        return coord
+        return BlueprintUpdateCoordinator(hass, entry, timedelta(hours=24))
 
 
 @pytest.mark.asyncio
-async def test_async_prune_stale_metadata_none_data(hass, mock_coordinator):
-    """Test that _async_prune_stale_metadata does not crash when self.data is None."""
+async def test_async_prune_stale_metadata_empty_data(hass, mock_coordinator):
+    """Test that _async_prune_stale_metadata works correctly with empty self.data."""
     coordinator = mock_coordinator
+    coordinator.data = {}
 
     coordinator._persisted_etags = {"stale_path": "etag"}
     coordinator._persisted_hashes = {"stale_path": "hash"}
@@ -40,19 +38,19 @@ async def test_async_prune_stale_metadata_none_data(hass, mock_coordinator):
     ):
         await coordinator._async_prune_stale_metadata(set())
 
-    assert coordinator.data is None
+    assert not coordinator.data
     assert not coordinator._persisted_etags
     assert not coordinator._persisted_hashes
 
 
 @pytest.mark.asyncio
-async def test_git_diff_none_data(hass, mock_coordinator):
-    """Test that git diff methods do not crash when self.data is None."""
+async def test_git_diff_empty_data(hass, mock_coordinator):
+    """Test that git diff methods handle empty self.data correctly."""
     coordinator = mock_coordinator
+    coordinator.data = {}
 
     assert await coordinator.async_get_git_diff("any_path") is None
     assert coordinator.get_cached_git_diff("any_path", "lh", "rh") is None
 
     coordinator.set_cached_git_diff("any_path", "lh", "rh", "diff")
-
-    assert coordinator.data is None
+    assert "any_path" not in coordinator.data

--- a/tests/test_issue_none_data.py
+++ b/tests/test_issue_none_data.py
@@ -1,0 +1,58 @@
+"""Tests for issue where self.data is None during startup."""
+
+from datetime import timedelta
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.blueprints_updater.coordinator import BlueprintUpdateCoordinator
+
+
+@pytest.fixture
+def mock_coordinator(hass):
+    """Fixture for BlueprintUpdateCoordinator with minimal mocking."""
+    entry = MagicMock()
+    entry.options = {}
+    entry.data = {}
+    with patch(
+        "homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__",
+        return_value=None,
+    ):
+        coord = BlueprintUpdateCoordinator(hass, entry, timedelta(hours=24))
+        coord.data = cast(Any, None)
+        return coord
+
+
+@pytest.mark.asyncio
+async def test_async_prune_stale_metadata_none_data(hass, mock_coordinator):
+    """Test that _async_prune_stale_metadata does not crash when self.data is None."""
+    coordinator = mock_coordinator
+
+    coordinator._persisted_etags = {"stale_path": "etag"}
+    coordinator._persisted_hashes = {"stale_path": "hash"}
+
+    with (
+        patch(
+            "custom_components.blueprints_updater.coordinator.os.path.isfile", return_value=False
+        ),
+        patch.object(coordinator, "_async_save_metadata", new_callable=AsyncMock),
+    ):
+        await coordinator._async_prune_stale_metadata(set())
+
+    assert coordinator.data is None
+    assert not coordinator._persisted_etags
+    assert not coordinator._persisted_hashes
+
+
+@pytest.mark.asyncio
+async def test_git_diff_none_data(hass, mock_coordinator):
+    """Test that git diff methods do not crash when self.data is None."""
+    coordinator = mock_coordinator
+
+    assert await coordinator.async_get_git_diff("any_path") is None
+    assert coordinator.get_cached_git_diff("any_path", "lh", "rh") is None
+
+    coordinator.set_cached_git_diff("any_path", "lh", "rh", "diff")
+
+    assert coordinator.data is None


### PR DESCRIPTION
Close #55

## Summary by Sourcery

Ensure the blueprint update coordinator initializes its data consistently and safely handles operations when no blueprint state is present.

Bug Fixes:
- Initialize the coordinator's data attribute after the base class constructor to guarantee it is never None during use.
- Guard git diff caching and error state updates so they become no-ops when the target path is not present in the coordinator data.

Tests:
- Add tests covering coordinator behavior with empty data, including git diff handling, stale metadata pruning, and error state updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal data initialization logic for better robustness and consistency.

* **Tests**
  * Added comprehensive test coverage for data initialization and error state handling scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->