### PR TITLE
Handle HTTP 304 Not Modified in Redirect Guard

### DIFF
--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -2654,6 +2654,14 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
         safe-hostname allowlist. Raises httpx.HTTPError on too many redirects or
         security violations.
 
+        Note on 304 responses:
+        HTTP 304 Not Modified is technically in the 3xx Redirection class but
+        represents a terminal state (conditional success) rather than a resource
+        to be followed. This method treats 304 as a final response to ensure it
+        is subjected to HTTPS enforcement and to avoid HTTPStatusErrors that
+        some client versions raise for unhandled 3xx codes when
+        follow_redirects=False.
+
         Args:
             session: Async HTTP client.
             url: Original request URL.
@@ -2674,7 +2682,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
                 follow_redirects=False,
             )
 
-            if not response.is_redirect:
+            if response.status_code == 304 or not response.is_redirect:
                 if response.url.scheme != "https":
                     _LOGGER.error(
                         "Blocking unsafe final URL (non-HTTPS) for %s: %s",
@@ -2685,8 +2693,10 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
                         f"Security violation: Final destination for {redact_url(url)} "
                         f"must be HTTPS (got {response.url.scheme})"
                     )
+
                 if response.status_code == 304:
                     return response
+
                 response.raise_for_status()
                 return response
 

--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -14,6 +14,7 @@ import time
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import timedelta
+from http import HTTPStatus
 from typing import Any, TypedDict, cast
 from urllib.parse import urlparse
 
@@ -76,6 +77,7 @@ from .utils import (
     redact_url,
     retry_async,
     sanitize_error_detail,
+    verify_https_enforcement,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -2681,22 +2683,12 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
                 timeout=REQUEST_TIMEOUT,
                 follow_redirects=False,
             )
+            if response.status_code == HTTPStatus.NOT_MODIFIED:
+                verify_https_enforcement(response, url)
+                return response
 
-            if response.status_code == 304 or not response.is_redirect:
-                if response.url.scheme != "https":
-                    _LOGGER.error(
-                        "Blocking unsafe final URL (non-HTTPS) for %s: %s",
-                        redact_url(url),
-                        response.url.scheme,
-                    )
-                    raise httpx.HTTPError(
-                        f"Security violation: Final destination for {redact_url(url)} "
-                        f"must be HTTPS (got {response.url.scheme})"
-                    )
-
-                if response.status_code == 304:
-                    return response
-
+            if not response.is_redirect:
+                verify_https_enforcement(response, url)
                 response.raise_for_status()
                 return response
 
@@ -2741,7 +2733,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             Blueprint content string, or None for a 304 Not Modified response.
 
         """
-        if response.status_code == 304:
+        if response.status_code == HTTPStatus.NOT_MODIFIED:
             return None
 
         content_type = response.headers.get("Content-Type", "")

--- a/custom_components/blueprints_updater/utils.py
+++ b/custom_components/blueprints_updater/utils.py
@@ -221,3 +221,20 @@ def sanitize_error_detail(detail: str, max_length: int = 120) -> str:
     cleaned = RE_URL_REDACTION.sub(lambda m: redact_url(m.group(0)), detail)
     cleaned = cleaned.replace("|", "/")
     return textwrap.shorten(cleaned, width=max_length, placeholder="...")
+
+
+def verify_https_enforcement(response: httpx.Response, original_url: str) -> None:
+    """Verify that the response URL uses HTTPS scheme.
+
+    Raises httpx.HTTPError if the scheme is not https.
+    """
+    if response.url.scheme != "https":
+        _LOGGER.error(
+            "Blocking unsafe final URL (non-HTTPS) for %s: %s",
+            redact_url(original_url),
+            response.url.scheme,
+        )
+        raise httpx.HTTPError(
+            f"Security violation: Final destination for {redact_url(original_url)} "
+            f"must be HTTPS (got {response.url.scheme})"
+        )

--- a/tests/coordinator/test_edge_cases.py
+++ b/tests/coordinator/test_edge_cases.py
@@ -3,6 +3,7 @@
 import asyncio
 import contextlib
 from datetime import timedelta
+from http import HTTPStatus
 from types import MappingProxyType
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -174,7 +175,7 @@ async def test_async_background_refresh_semaphore_limit(coordinator):
             active_requests -= 1
 
         mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
+        mock_response.status_code = HTTPStatus.OK
         mock_response.url = httpx.URL("https://mock_url")
         mock_response.text = "blueprint: name"
         mock_response.headers = {"Content-Type": "text/yaml"}
@@ -215,7 +216,7 @@ async def test_async_fetch_content_forum_invalid_json_sets_fetch_error(coordinat
     coordinator.data = {path: info}
 
     mock_response = MagicMock(spec=httpx.Response)
-    mock_response.status_code = 200
+    mock_response.status_code = HTTPStatus.OK
     mock_response.url = httpx.URL(source_url)
     mock_response.headers = {"Content-Type": "application/json"}
     mock_response.text = '{"posts": [ {"cooked": "invalid"}'

--- a/tests/coordinator/test_etag_logic.py
+++ b/tests/coordinator/test_etag_logic.py
@@ -1,6 +1,7 @@
 """Tests for Blueprints Updater ETag logic."""
 
 from datetime import timedelta
+from http import HTTPStatus
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -76,7 +77,7 @@ async def test_304_response_preserves_updatable_status(
     }
 
     mock_response = MagicMock(spec=httpx.Response)
-    mock_response.status_code = 304
+    mock_response.status_code = HTTPStatus.NOT_MODIFIED
     mock_response.url = httpx.URL("https://github.com/user/repo/test.yaml")
     mock_response.headers = httpx.Headers({"ETag": "etag_v2", "Content-Type": "text/yaml"})
     mock_response.raise_for_status = MagicMock(return_value=None)
@@ -162,7 +163,7 @@ async def test_etag_migration_forces_download(
     }
 
     mock_response = MagicMock(spec=httpx.Response)
-    mock_response.status_code = 200
+    mock_response.status_code = HTTPStatus.OK
     mock_response.url = httpx.URL("https://github.com/user/repo/bp.yaml")
     mock_response.headers = httpx.Headers({"ETag": "new_etag", "Content-Type": "text/yaml"})
     mock_response.text = remote_content

--- a/tests/coordinator/test_networking.py
+++ b/tests/coordinator/test_networking.py
@@ -1,6 +1,7 @@
 """Tests for coordinator networking, fetching, and CDN logic."""
 
 import asyncio
+from http import HTTPStatus
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -35,7 +36,7 @@ async def test_async_fetch_content_pacing_logic(coordinator):
     """Test that _async_fetch_content respects MIN_SEND_INTERVAL pacing."""
     mock_session = MagicMock(spec=httpx.AsyncClient)
     mock_response = MagicMock(spec=httpx.Response)
-    mock_response.status_code = 200
+    mock_response.status_code = HTTPStatus.OK
     mock_response.is_redirect = False
     mock_response.url = httpx.URL("https://example.com/path")
     mock_response.text = "content"
@@ -72,7 +73,7 @@ async def test_async_fetch_content_pacing_logic_max(coordinator):
     """Test that _async_fetch_content respects MAX_SEND_INTERVAL pacing."""
     mock_session = MagicMock(spec=httpx.AsyncClient)
     mock_response = MagicMock(spec=httpx.Response)
-    mock_response.status_code = 200
+    mock_response.status_code = HTTPStatus.OK
     mock_response.is_redirect = False
     mock_response.url = httpx.URL("https://example.com/path")
     mock_response.text = "content"
@@ -128,7 +129,7 @@ async def test_async_fetch_content_pacing_synchronization(coordinator):
             patch.object(async_client, "get", new_callable=AsyncMock) as mock_get,
         ):
             mock_get.return_value = MagicMock(spec=httpx.Response)
-            mock_get.return_value.status_code = 200
+            mock_get.return_value.status_code = HTTPStatus.OK
             mock_get.return_value.is_redirect = False
             mock_get.return_value.url = httpx.URL("https://example.com/path")
             mock_get.return_value.headers = {"ETag": "new", "Content-Type": "text/yaml"}
@@ -158,7 +159,7 @@ async def test_execute_with_redirect_guard_security(coordinator):
     mock_session = MagicMock(spec=httpx.AsyncClient)
 
     mock_resp_redirect = MagicMock(spec=httpx.Response)
-    mock_resp_redirect.status_code = 302
+    mock_resp_redirect.status_code = HTTPStatus.FOUND
     mock_resp_redirect.is_redirect = True
     mock_resp_redirect.headers = {"Location": "https://example.com/next"}
     mock_resp_redirect.url = httpx.URL("https://example.com/start")
@@ -174,7 +175,7 @@ async def test_execute_with_redirect_guard_security(coordinator):
         )
 
     mock_resp_unsafe = MagicMock(spec=httpx.Response)
-    mock_resp_unsafe.status_code = 302
+    mock_resp_unsafe.status_code = HTTPStatus.FOUND
     mock_resp_unsafe.is_redirect = True
     mock_resp_unsafe.headers = {"Location": "http://unsafe.com"}
     mock_resp_unsafe.url = httpx.URL("https://example.com/start")
@@ -196,7 +197,7 @@ async def test_execute_with_redirect_guard_final_https(coordinator):
     mock_session = MagicMock(spec=httpx.AsyncClient)
 
     mock_resp_final_safe = MagicMock()
-    mock_resp_final_safe.status_code = 200
+    mock_resp_final_safe.status_code = HTTPStatus.OK
     mock_resp_final_safe.is_redirect = False
     mock_resp_final_safe.url = httpx.URL("https://safe.com/bp.yaml")
     mock_resp_final_safe.raise_for_status = MagicMock()
@@ -210,7 +211,7 @@ async def test_execute_with_redirect_guard_final_https(coordinator):
         assert str(resp.url) == "https://safe.com/bp.yaml"
 
     mock_resp_final_unsafe = MagicMock()
-    mock_resp_final_unsafe.status_code = 200
+    mock_resp_final_unsafe.status_code = HTTPStatus.OK
     mock_resp_final_unsafe.is_redirect = False
     mock_resp_final_unsafe.url = httpx.URL("http://unsafe.com/bp.yaml")
     mock_resp_final_unsafe.raise_for_status = MagicMock()
@@ -225,12 +226,34 @@ async def test_execute_with_redirect_guard_final_https(coordinator):
 
 
 @pytest.mark.asyncio
+async def test_execute_with_redirect_guard_304_non_redirect_handling(coordinator):
+    """Test that 304 responses are handled correctly even if not flagged as redirects."""
+    mock_session = MagicMock(spec=httpx.AsyncClient)
+
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_response.status_code = HTTPStatus.NOT_MODIFIED
+    mock_response.is_redirect = False
+    mock_response.url = httpx.URL("https://example.com/bp.yaml")
+    mock_response.headers = httpx.Headers({"ETag": "test-etag"})
+    mock_response.raise_for_status = MagicMock()
+
+    mock_session.get = AsyncMock(return_value=mock_response)
+
+    result = await coordinator._execute_with_redirect_guard(
+        mock_session, "https://example.com/bp.yaml", {}
+    )
+
+    mock_response.raise_for_status.assert_not_called()
+    assert result is mock_response
+
+
+@pytest.mark.asyncio
 async def test_execute_with_redirect_guard_304_handling(coordinator):
     """Test that 304 responses are handled correctly even if flagged as redirects."""
     mock_session = MagicMock(spec=httpx.AsyncClient)
 
     mock_response = MagicMock(spec=httpx.Response)
-    mock_response.status_code = 304
+    mock_response.status_code = HTTPStatus.NOT_MODIFIED
     mock_response.is_redirect = True
     mock_response.url = httpx.URL("https://example.com/bp.yaml")
     mock_response.headers = httpx.Headers({"ETag": "test-etag"})
@@ -246,7 +269,7 @@ async def test_execute_with_redirect_guard_304_handling(coordinator):
         resp = await coordinator._execute_with_redirect_guard(
             mock_session, "https://example.com/bp.yaml", {}
         )
-        assert resp.status_code == 304
+        assert resp.status_code == HTTPStatus.NOT_MODIFIED
         mock_response.raise_for_status.assert_not_called()
 
 
@@ -256,7 +279,7 @@ async def test_execute_with_redirect_guard_304_https_enforcement(coordinator):
     mock_session = MagicMock(spec=httpx.AsyncClient)
 
     mock_response = MagicMock(spec=httpx.Response)
-    mock_response.status_code = 304
+    mock_response.status_code = HTTPStatus.NOT_MODIFIED
     mock_response.is_redirect = True
     mock_response.url = httpx.URL("http://unsafe.com/bp.yaml")
 

--- a/tests/coordinator/test_networking.py
+++ b/tests/coordinator/test_networking.py
@@ -222,3 +222,50 @@ async def test_execute_with_redirect_guard_final_https(coordinator):
         pytest.raises(httpx.HTTPError, match="must be HTTPS"),
     ):
         await coordinator._execute_with_redirect_guard(mock_session, "http://start.com/bp.yaml", {})
+
+
+@pytest.mark.asyncio
+async def test_execute_with_redirect_guard_304_handling(coordinator):
+    """Test that 304 responses are handled correctly even if flagged as redirects."""
+    mock_session = MagicMock(spec=httpx.AsyncClient)
+
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_response.status_code = 304
+    mock_response.is_redirect = True
+    mock_response.url = httpx.URL("https://example.com/bp.yaml")
+    mock_response.headers = httpx.Headers({"ETag": "test-etag"})
+    mock_response.raise_for_status = MagicMock(
+        side_effect=httpx.HTTPStatusError(
+            "Redirect error", request=MagicMock(), response=mock_response
+        )
+    )
+
+    mock_session.get = AsyncMock(return_value=mock_response)
+
+    with patch.object(coordinator, "_is_safe_url", return_value=True):
+        resp = await coordinator._execute_with_redirect_guard(
+            mock_session, "https://example.com/bp.yaml", {}
+        )
+        assert resp.status_code == 304
+        mock_response.raise_for_status.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_execute_with_redirect_guard_304_https_enforcement(coordinator):
+    """Test that 304 responses are still subject to HTTPS enforcement."""
+    mock_session = MagicMock(spec=httpx.AsyncClient)
+
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_response.status_code = 304
+    mock_response.is_redirect = True
+    mock_response.url = httpx.URL("http://unsafe.com/bp.yaml")
+
+    mock_session.get = AsyncMock(return_value=mock_response)
+
+    with (
+        patch.object(coordinator, "_is_safe_url", return_value=True),
+        pytest.raises(httpx.HTTPError, match="must be HTTPS"),
+    ):
+        await coordinator._execute_with_redirect_guard(
+            mock_session, "http://unsafe.com/bp.yaml", {}
+        )

--- a/tests/coordinator/test_update_cycle.py
+++ b/tests/coordinator/test_update_cycle.py
@@ -3,6 +3,7 @@
 import asyncio
 import contextlib
 import os
+from http import HTTPStatus
 from types import MappingProxyType
 from typing import Any, cast
 from unittest.mock import ANY, AsyncMock, MagicMock, mock_open, patch
@@ -168,7 +169,7 @@ async def test_async_fetch_blueprint_force(coordinator):
 
     mock_session = MagicMock(spec=httpx.AsyncClient)
     mock_response = MagicMock(spec=httpx.Response)
-    mock_response.status_code = 200
+    mock_response.status_code = HTTPStatus.OK
     mock_response.text = f"blueprint:\n  name: New\n  domain: automation\n  source_url: {url}\n"
     mock_response.headers = httpx.Headers({"ETag": "new_etag", "Content-Type": "text/yaml"})
     mock_response.raise_for_status = MagicMock()
@@ -244,7 +245,7 @@ async def test_async_background_refresh_503_resilience(coordinator):
         side_effect=httpx.HTTPStatusError(
             "Service Unavailable",
             request=MagicMock(),
-            response=MagicMock(status_code=503),
+            response=MagicMock(status_code=HTTPStatus.SERVICE_UNAVAILABLE),
         )
     )
 
@@ -448,7 +449,7 @@ async def test_async_fetch_blueprint_regression_key_error_hash(coordinator):
 
     mock_session = MagicMock(spec=httpx.AsyncClient)
     mock_response = MagicMock(spec=httpx.Response)
-    mock_response.status_code = 200
+    mock_response.status_code = HTTPStatus.OK
     mock_response.text = content
     mock_response.headers = httpx.Headers({"ETag": "etag", "Content-Type": "text/yaml"})
     mock_response.raise_for_status = MagicMock()
@@ -911,7 +912,7 @@ async def test_async_update_blueprint(coordinator):
     results: dict[str, Any] = {path: {"last_error": None, "local_hash": "old_hash"}}
 
     mock_response = MagicMock(spec=httpx.Response)
-    mock_response.status_code = 200
+    mock_response.status_code = HTTPStatus.OK
     mock_response.headers = {"ETag": "new_etag", "Content-Type": "text/yaml"}
     mock_response.raise_for_status = MagicMock()
     mock_response.text = "blueprint:\n  name: Test"
@@ -963,11 +964,11 @@ async def test_async_update_blueprint_304_auto_update(coordinator):
     }
 
     mock_response_304 = MagicMock(spec=httpx.Response)
-    mock_response_304.status_code = 304
+    mock_response_304.status_code = HTTPStatus.NOT_MODIFIED
     mock_response_304.headers = {"ETag": "stored_etag"}
 
     mock_response_200 = MagicMock(spec=httpx.Response)
-    mock_response_200.status_code = 200
+    mock_response_200.status_code = HTTPStatus.OK
     mock_response_200.headers = {"ETag": "stored_etag", "Content-Type": "text/yaml"}
     mock_response_200.text = "blueprint:\n  name: Test\n  source_url: https://url/test.yaml"
     mock_response_200.raise_for_status = MagicMock()
@@ -1132,7 +1133,7 @@ async def test_async_update_blueprint_in_place_errors_isolated(
         mock_session.get = AsyncMock(side_effect=side_effect)
     else:
         mock_resp = MagicMock(spec=httpx.Response)
-        mock_resp.status_code = 200
+        mock_resp.status_code = HTTPStatus.OK
         mock_resp.url = httpx.URL("https://url")
         mock_resp.headers = {"Content-Type": "text/yaml"}
         mock_resp.raise_for_status = MagicMock()
@@ -1199,7 +1200,7 @@ async def test_async_update_blueprint_not_modified(coordinator):
     }
 
     mock_response = MagicMock(spec=httpx.Response)
-    mock_response.status_code = 304
+    mock_response.status_code = HTTPStatus.NOT_MODIFIED
     mock_response.headers = {"ETag": "old_etag", "Content-Type": "text/yaml"}
     mock_response.raise_for_status = MagicMock()
 

--- a/tests/ui/test_init_edge_cases.py
+++ b/tests/ui/test_init_edge_cases.py
@@ -1,6 +1,7 @@
 """Tests targeting edge cases and setup failures in the integration initialization."""
 
 from datetime import timedelta
+from http import HTTPStatus
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -146,7 +147,7 @@ async def test_coordinator_error_paths_fetch_refresh_and_configs(hass: HomeAssis
 
     mock_resp = MagicMock()
     mock_resp.is_redirect = False
-    mock_resp.status_code = 200
+    mock_resp.status_code = HTTPStatus.OK
     mock_resp.url = httpx.URL("https://mock_url")
     mock_resp.headers = {"Content-Type": "application/json"}
     mock_resp.json = MagicMock(side_effect=ValueError("JSON fail"))


### PR DESCRIPTION
Fix a bug that occurred in version 2.0.0-rc.2

## Summary by Sourcery

Handle HTTP 304 Not Modified responses correctly in the redirect guard while centralizing HTTPS enforcement logic.

Bug Fixes:
- Treat HTTP 304 Not Modified responses as final results in the redirect guard, avoiding spurious HTTPStatusError exceptions from some httpx client versions.

Enhancements:
- Extract HTTPS scheme enforcement into a reusable verify_https_enforcement utility used by the redirect guard.
- Adopt HTTPStatus enum constants throughout coordinator and update-cycle tests for clearer and less error-prone status code handling.

Tests:
- Add test coverage for 304 Not Modified handling in the redirect guard, including both redirect-flagged and non-redirect responses and HTTPS enforcement.
- Update existing coordinator, edge-case, ETag, and UI tests to align with the new 304 behavior and HTTPStatus-based status checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Properly treat HTTP 304 (Not Modified) as a terminal response in redirect handling and enforce HTTPS on final response URLs, avoiding unnecessary redirect-following or error escalation.

* **Tests**
  * Added/updated tests covering 304 behavior and HTTPS enforcement, and standardized HTTP status usage in networking tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->