### PR TITLE
Remove legacy code and get ready for the major release

### DIFF
--- a/custom_components/blueprints_updater/__init__.py
+++ b/custom_components/blueprints_updater/__init__.py
@@ -218,8 +218,7 @@ def _async_register_services(hass: HomeAssistant) -> None:
             expected_id = BlueprintUpdateCoordinator.generate_unique_id(
                 active_coordinator.config_entry.entry_id, info["rel_path"]
             )
-            legacy_id = BlueprintUpdateCoordinator.generate_legacy_unique_id(info["rel_path"])
-            if entity_entry.unique_id in (expected_id, legacy_id):
+            if entity_entry.unique_id == expected_id:
                 target_path = path
                 break
 

--- a/custom_components/blueprints_updater/config_flow.py
+++ b/custom_components/blueprints_updater/config_flow.py
@@ -40,7 +40,13 @@ from .const import (
     MIN_UPDATE_INTERVAL,
 )
 from .coordinator import BlueprintUpdateCoordinator
-from .utils import get_max_backups, get_update_interval
+from .utils import (
+    get_config_bool,
+    get_config_str,
+    get_config_value,
+    get_max_backups,
+    get_update_interval,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -85,17 +91,10 @@ def _get_config_schema(
         A voluptuous Schema object.
 
     """
-    current_config: dict[str, Any] = {}
-    if config is not None:
-        if hasattr(config, "options"):
-            current_config = {**config.data, **config.options}
-        elif isinstance(config, dict):
-            current_config = config
-
-    auto_update = current_config.get(CONF_AUTO_UPDATE, DEFAULT_AUTO_UPDATE)
-    use_cdn = current_config.get(CONF_USE_CDN, DEFAULT_USE_CDN)
-    filter_mode = current_config.get(CONF_FILTER_MODE, FILTER_MODE_ALL)
-    selected_blueprints = current_config.get(CONF_SELECTED_BLUEPRINTS, [])
+    auto_update = get_config_bool(config, CONF_AUTO_UPDATE, DEFAULT_AUTO_UPDATE)
+    use_cdn = get_config_bool(config, CONF_USE_CDN, DEFAULT_USE_CDN)
+    filter_mode = get_config_str(config, CONF_FILTER_MODE, FILTER_MODE_ALL)
+    selected_blueprints = get_config_value(config, CONF_SELECTED_BLUEPRINTS, [])
 
     return vol.Schema(
         {

--- a/custom_components/blueprints_updater/const.py
+++ b/custom_components/blueprints_updater/const.py
@@ -69,7 +69,6 @@ class IntegrationService(StrEnum):
 class BlueprintRiskType(StrEnum):
     """Risk types for breaking change detection."""
 
-    LEGACY = "legacy_risk"
     NEW_MANDATORY = "new_mandatory"
     MISSING_INPUT = "missing_input"
     REMOVED_INPUT = "removed_input"
@@ -87,7 +86,6 @@ class BlueprintBlockingReason(StrEnum):
 
 
 RISK_TYPE_TRANSLATIONS = {
-    BlueprintRiskType.LEGACY: "risk_legacy",
     BlueprintRiskType.NEW_MANDATORY: "risk_new_mandatory",
     BlueprintRiskType.MISSING_INPUT: "risk_missing_input",
     BlueprintRiskType.REMOVED_INPUT: "risk_removed_input",

--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -139,19 +139,6 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
         combined = f"{entry_id}_{rel_path}"
         return f"blueprint_{hashlib.sha256(combined.encode()).hexdigest()}"
 
-    @staticmethod
-    def generate_legacy_unique_id(rel_path: str) -> str:
-        """Generate a legacy unique ID from rel_path only.
-
-        Args:
-            rel_path: The blueprint's relative path.
-
-        Returns:
-            The legacy generated unique ID.
-
-        """
-        return f"blueprint_{hashlib.sha256(rel_path.encode()).hexdigest()}"
-
     config_entry: ConfigEntry
 
     def __init__(
@@ -1011,17 +998,6 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             if not os.path.isfile(file_path):
                 return
 
-            legacy_bak = f"{file_path}.bak"
-            try:
-                if os.path.isfile(legacy_bak):
-                    bak1 = f"{file_path}.bak.1"
-                    if not os.path.isfile(bak1):
-                        os.rename(legacy_bak, bak1)
-                    else:
-                        os.remove(legacy_bak)
-            except OSError as err:
-                _LOGGER.warning("Error migrating legacy backup %s: %s", legacy_bak, err)
-
             for i in range(max_bak, 0, -1):
                 src = f"{file_path}.bak.{i}"
                 dst = f"{file_path}.bak.{i + 1}"
@@ -1539,30 +1515,22 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
         return risks
 
     @staticmethod
-    def _dedupe_risks(risks: Iterable[StructuredRisk | str]) -> list[StructuredRisk]:
-        """De-duplicate risks and convert legacy string risks to structured format.
+    def _dedupe_risks(risks: Iterable[StructuredRisk]) -> list[StructuredRisk]:
+        """De-duplicate risks by type and arguments.
 
         This ensures that identical risks (by type and arguments) are only
         reported once, even if they originate from different detection passes.
 
         Args:
-            risks: An iterable of structured risks or bare error strings.
+            risks: An iterable of structured risks.
 
         Returns:
             A list of unique structured risks.
 
         """
-        seen = set()
-        unique_risks = []
+        seen: set[tuple[str, str]] = set()
+        unique_risks: list[StructuredRisk] = []
         for risk in risks:
-            if isinstance(risk, str):
-                if risk not in seen:
-                    seen.add(risk)
-                    unique_risks.append(
-                        {"type": BlueprintRiskType.LEGACY, "args": {"message": risk}}
-                    )
-                continue
-
             if not isinstance(risk, dict) or "type" not in risk or "args" not in risk:
                 _LOGGER.debug("Skipping malformed risk: %s", risk)
                 continue
@@ -1817,13 +1785,6 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             lines.append(f"- {msg}")
         return "\n".join(lines)
 
-    async def _get_risk_summary(self, risks: list[StructuredRisk]) -> str:
-        """Internal legacy shim for risk summarization.
-
-        Deprecated in favor of async_summarize_risks.
-        """
-        return await self.async_summarize_risks(risks)
-
     def _get_entities_using_blueprint(self, rel_path: str) -> list[str]:
         """Get entity IDs of automations and scripts using the given blueprint.
 
@@ -1983,8 +1944,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
     def is_auto_update_enabled(self) -> bool:
         """Return whether auto-update is enabled.
 
-        Checks configuration options with fallback to internal data (legacy)
-        and finally the system default.
+        Checks configuration options and falls back to the system default.
 
         Returns:
             Boolean indicating auto-update preference.
@@ -1993,10 +1953,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
         if not self.config_entry:
             return DEFAULT_AUTO_UPDATE
 
-        return self.config_entry.options.get(
-            CONF_AUTO_UPDATE,
-            self.config_entry.data.get(CONF_AUTO_UPDATE, DEFAULT_AUTO_UPDATE),
-        )
+        return self.config_entry.options.get(CONF_AUTO_UPDATE, DEFAULT_AUTO_UPDATE)
 
     def is_cdn_enabled(self) -> bool:
         """Return whether jsDelivr CDN usage is enabled.
@@ -2008,10 +1965,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
         if not self.config_entry:
             return DEFAULT_USE_CDN
 
-        return self.config_entry.options.get(
-            CONF_USE_CDN,
-            self.config_entry.data.get(CONF_USE_CDN, DEFAULT_USE_CDN),
-        )
+        return self.config_entry.options.get(CONF_USE_CDN, DEFAULT_USE_CDN)
 
     def _update_error_state(
         self, path: str, error_type: str, detail: Any, clear_etag: bool = False
@@ -2472,7 +2426,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             else "auto_update_blocked_by_breaking_change"
         )
         title = await self.async_translate(title_key, name=info["name"])
-        risk_summary = await self._get_risk_summary(risks)
+        risk_summary = await self.async_summarize_risks(risks)
         message = await self.async_translate(
             "breaking_risks_report", name=info["name"], risks=risk_summary
         )

--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -72,6 +72,7 @@ from .const import (
 )
 from .providers import registry
 from .utils import (
+    get_config_bool,
     get_max_backups,
     redact_url,
     retry_async,
@@ -1528,7 +1529,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             A list of unique structured risks.
 
         """
-        seen: set[tuple[str, str]] = set()
+        seen: set[tuple[BlueprintRiskType, str]] = set()
         unique_risks: list[StructuredRisk] = []
         for risk in risks:
             if not isinstance(risk, dict) or "type" not in risk or "args" not in risk:
@@ -1950,10 +1951,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             Boolean indicating auto-update preference.
 
         """
-        if not self.config_entry:
-            return DEFAULT_AUTO_UPDATE
-
-        return self.config_entry.options.get(CONF_AUTO_UPDATE, DEFAULT_AUTO_UPDATE)
+        return get_config_bool(self.config_entry, CONF_AUTO_UPDATE, DEFAULT_AUTO_UPDATE)
 
     def is_cdn_enabled(self) -> bool:
         """Return whether jsDelivr CDN usage is enabled.
@@ -1962,10 +1960,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             Boolean indicating CDN preference.
 
         """
-        if not self.config_entry:
-            return DEFAULT_USE_CDN
-
-        return self.config_entry.options.get(CONF_USE_CDN, DEFAULT_USE_CDN)
+        return get_config_bool(self.config_entry, CONF_USE_CDN, DEFAULT_USE_CDN)
 
     def _update_error_state(
         self, path: str, error_type: str, detail: Any, clear_etag: bool = False

--- a/custom_components/blueprints_updater/strings.json
+++ b/custom_components/blueprints_updater/strings.json
@@ -132,7 +132,6 @@
     "risk_selector_mismatch": "Selector type changed for {input}: from {old_type} to {new_type} (affects {count} entities).",
     "risk_validation_failed_blueprint": "New blueprint content is invalid: {error}",
     "risk_unknown": "Unknown risk",
-    "risk_legacy": "{message}",
     "risk_compatibility": "Compatibility Error for {entity}: {error}",
     "risk_system_error": "System error: {error}",
     "breaking_risks_report": "Auto-update for {name} was blocked as a precaution. Detected risks:\n{risks}\n\nPlease review and install manually if correct.",

--- a/custom_components/blueprints_updater/translations/de.json
+++ b/custom_components/blueprints_updater/translations/de.json
@@ -132,7 +132,6 @@
     "risk_selector_mismatch": "Selector-Typ für {input} geändert: von {old_type} zu {new_type} (betrifft {count} Entitäten).",
     "risk_validation_failed_blueprint": "Neuer Blueprint-Inhalt ist ungültig: {error}",
     "risk_unknown": "Unbekannter Fehler",
-    "risk_legacy": "{message}",
     "risk_compatibility": "Kompatibilitätsfehler für {entity}: {error}",
     "risk_system_error": "Systemfehler: {error}",
     "breaking_risks_report": "Das automatische Update für {name} wurde vorsorglich blockiert. Erkannte Risiken:\n{risks}\n\nBitte überprüfen Sie diese und installieren Sie sie manuell, falls sie korrekt sind.",

--- a/custom_components/blueprints_updater/translations/en.json
+++ b/custom_components/blueprints_updater/translations/en.json
@@ -132,7 +132,6 @@
     "risk_selector_mismatch": "Selector type changed for {input}: from {old_type} to {new_type} (affects {count} entities).",
     "risk_validation_failed_blueprint": "New blueprint content is invalid: {error}",
     "risk_unknown": "Unknown risk",
-    "risk_legacy": "{message}",
     "risk_compatibility": "Compatibility Error for {entity}: {error}",
     "risk_system_error": "System error: {error}",
     "breaking_risks_report": "Auto-update for {name} was blocked as a precaution. Detected risks:\n{risks}\n\nPlease review and install manually if correct.",

--- a/custom_components/blueprints_updater/translations/es.json
+++ b/custom_components/blueprints_updater/translations/es.json
@@ -132,7 +132,6 @@
     "risk_selector_mismatch": "El tipo de selector cambió para {input}: de {old_type} a {new_type} (afecta a {count} entidades).",
     "risk_validation_failed_blueprint": "El nuevo contenido del blueprint no es válido: {error}",
     "risk_unknown": "Error desconocido",
-    "risk_legacy": "{message}",
     "risk_compatibility": "Error de compatibilidad para {entity}: {error}",
     "risk_system_error": "Error del sistema: {error}",
     "breaking_risks_report": "La actualización automática para {name} se bloqueó como precaución. Riesgos detectados:\n{risks}\n\nPor favor, revise e instale manualmente si es correcto.",

--- a/custom_components/blueprints_updater/translations/fr.json
+++ b/custom_components/blueprints_updater/translations/fr.json
@@ -132,7 +132,6 @@
     "risk_selector_mismatch": "Type de sélecteur modifié pour {input} : de {old_type} à {new_type} (affecte {count} entités).",
     "risk_validation_failed_blueprint": "Le nouveau contenu du blueprint est invalide : {error}",
     "risk_unknown": "Erreur inconnue",
-    "risk_legacy": "{message}",
     "risk_compatibility": "Erreur de compatibilité pour {entity} : {error}",
     "risk_system_error": "Erreur système : {error}",
     "breaking_risks_report": "La mise à jour automatique pour {name} a été bloquée par précaution. Risques détectés :\n{risks}\n\nVeuillez vérifier et installer manuellement si c'est correct.",

--- a/custom_components/blueprints_updater/translations/it.json
+++ b/custom_components/blueprints_updater/translations/it.json
@@ -132,7 +132,6 @@
     "risk_selector_mismatch": "Tipo di selettore modificato per {input}: da {old_type} a {new_type} (interessa {count} entità).",
     "risk_validation_failed_blueprint": "Il nuovo contenuto del blueprint non è valido: {error}",
     "risk_unknown": "Errore sconosciuto",
-    "risk_legacy": "{message}",
     "risk_compatibility": "Errore di compatibilità per {entity}: {error}",
     "risk_system_error": "Errore di sistema: {error}",
     "breaking_risks_report": "L'aggiornamento automatico per {name} è stato bloccato a scopo precauzionale. Rischi rilevati:\n{risks}\n\nSi prega di rivedere e installare manualmente se corretto.",

--- a/custom_components/blueprints_updater/translations/nl.json
+++ b/custom_components/blueprints_updater/translations/nl.json
@@ -132,7 +132,6 @@
     "risk_selector_mismatch": "Selector-type gewijzigd voor {input}: van {old_type} naar {new_type} (beïnvloedt {count} entiteiten).",
     "risk_validation_failed_blueprint": "Nieuwe blueprint inhoud is ongeldig: {error}",
     "risk_unknown": "Onbekende fout",
-    "risk_legacy": "{message}",
     "risk_compatibility": "Compatibiliteitsfout voor {entity}: {error}",
     "risk_system_error": "Systeemfout: {error}",
     "breaking_risks_report": "Automatische update voor {name} is uit voorzorg geblokkeerd. Gedetecteerde risico's:\n{risks}\n\nControleer dit en installeer handmatig als het correct is.",

--- a/custom_components/blueprints_updater/translations/pl.json
+++ b/custom_components/blueprints_updater/translations/pl.json
@@ -132,7 +132,6 @@
     "risk_selector_mismatch": "Typ selektora zmienił się dla {input}: z {old_type} na {new_type} (dotyczy {count} encji).",
     "risk_validation_failed_blueprint": "Nowa treść blueprintu jest nieprawidłowa: {error}",
     "risk_unknown": "Nieznany błąd",
-    "risk_legacy": "{message}",
     "risk_compatibility": "Błąd kompatybilności dla {entity}: {error}",
     "risk_system_error": "Błąd systemu: {error}",
     "breaking_risks_report": "Automatyczna aktualizacja dla {name} została zablokowana zapobiegawczo. Wykryte zagrożenia:\n{risks}\n\nProszę sprawdź i zainstaluj ręcznie, jeśli są poprawne.",

--- a/custom_components/blueprints_updater/translations/pt.json
+++ b/custom_components/blueprints_updater/translations/pt.json
@@ -132,7 +132,6 @@
     "risk_selector_mismatch": "Tipo de seletor alterado para {input}: de {old_type} para {new_type} (afeta {count} entidades).",
     "risk_validation_failed_blueprint": "O novo conteúdo do blueprint é inválido: {error}",
     "risk_unknown": "Erro desconhecido",
-    "risk_legacy": "{message}",
     "risk_compatibility": "Erro de compatibilidade para {entity}: {error}",
     "risk_system_error": "Erro do sistema: {error}",
     "breaking_risks_report": "A atualização automática para {name} foi bloqueada por precaução. Riscos detetados:\n{risks}\n\nPor favor, reveja e instale manualmente se estiver correto.",

--- a/custom_components/blueprints_updater/translations/ru.json
+++ b/custom_components/blueprints_updater/translations/ru.json
@@ -132,7 +132,6 @@
     "risk_selector_mismatch": "Тип селектора изменен для {input}: с {old_type} на {new_type} (влияет на {count} сущностей).",
     "risk_validation_failed_blueprint": "Новое содержимое чертежа недействительно: {error}",
     "risk_unknown": "Неизвестная ошибка",
-    "risk_legacy": "{message}",
     "risk_compatibility": "Ошибка совместимости для {entity}: {error}",
     "risk_system_error": "Системная ошибка: {error}",
     "breaking_risks_report": "Автоматическое обновление {name} было заблокировано в целях предосторожности. Обнаруженные риски:\n{risks}\n\nПожалуйста, проверьте и установите вручную, если всё верно.",

--- a/custom_components/blueprints_updater/translations/sv.json
+++ b/custom_components/blueprints_updater/translations/sv.json
@@ -132,7 +132,6 @@
     "risk_selector_mismatch": "Selectortyp har ändrats för {input}: från {old_type} till {new_type} (påverkar {count} entiteter).",
     "risk_validation_failed_blueprint": "Nytt blueprint-innehåll är ogiltigt: {error}",
     "risk_unknown": "Okänt fel",
-    "risk_legacy": "{message}",
     "risk_compatibility": "Kompatibilitetsfel för {entity}: {error}",
     "risk_system_error": "Systemfel: {error}",
     "breaking_risks_report": "Automatisk uppdatering för {name} blockerades som en försiktighetsåtgärd. Upptäckta risker:\n{risks}\n\nGranska och installera manuellt om det är korrekt.",

--- a/custom_components/blueprints_updater/translations/vi.json
+++ b/custom_components/blueprints_updater/translations/vi.json
@@ -132,7 +132,6 @@
     "risk_selector_mismatch": "Sai lệch kiểu selector cho {input}: từ {old_type} sang {new_type} (ảnh hưởng {count} thực thể).",
     "risk_validation_failed_blueprint": "Nội dung blueprint mới không hợp lệ: {error}",
     "risk_unknown": "Rủi ro không xác định",
-    "risk_legacy": "{message}",
     "risk_compatibility": "Lỗi tương thích cho {entity}: {error}",
     "risk_system_error": "Lỗi hệ thống: {error}",
     "breaking_risks_report": "Tự động cập nhật cho {name} đã bị chặn để đảm bảo an toàn. Các rủi ro phát hiện được:\n{risks}\n\nVui lòng xem xét và cài đặt thủ công nếu thấy đúng.",

--- a/custom_components/blueprints_updater/translations/zh-Hans.json
+++ b/custom_components/blueprints_updater/translations/zh-Hans.json
@@ -132,7 +132,6 @@
     "risk_selector_mismatch": "{input} 的选择器类型已更改：从 {old_type} 更改为 {new_type}（影响 {count} 个实体）。",
     "risk_validation_failed_blueprint": "新的蓝图内容无效：{error}",
     "risk_unknown": "未知错误",
-    "risk_legacy": "{message}",
     "risk_compatibility": "{entity} 的兼容性错误：{error}",
     "risk_system_error": "系统错误：{error}",
     "breaking_risks_report": "为了预防起见，{name} 的自动更新已阻止。检测到的风险：\n{risks}\n\n如果正确，请检查并手动安装。",

--- a/custom_components/blueprints_updater/update.py
+++ b/custom_components/blueprints_updater/update.py
@@ -94,31 +94,16 @@ def async_update_entities(
     entity_registry = er.async_get(hass)
 
     entries = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
-    new_id_to_path: dict[str, str] = {}
-    legacy_id_to_new_id: dict[str, str] = {}
+    known_ids: set[str] = set()
     for info in coordinator.data.values():
         rel_path = info["rel_path"]
-        new_id = BlueprintUpdateCoordinator.generate_unique_id(entry.entry_id, rel_path)
-        legacy_id = BlueprintUpdateCoordinator.generate_legacy_unique_id(rel_path)
-        new_id_to_path[new_id] = rel_path
-        legacy_id_to_new_id[legacy_id] = new_id
+        known_ids.add(BlueprintUpdateCoordinator.generate_unique_id(entry.entry_id, rel_path))
 
     for entity_entry in entries:
         if entity_entry.domain != "update":
             continue
 
-        unique_id = entity_entry.unique_id
-        if unique_id in new_id_to_path:
-            continue
-
-        if new_id := legacy_id_to_new_id.get(unique_id):
-            _LOGGER.info(
-                "Migrating legacy unique_id for %s: %s -> %s",
-                entity_entry.entity_id,
-                unique_id,
-                new_id,
-            )
-            entity_registry.async_update_entity(entity_entry.entity_id, new_unique_id=new_id)
+        if entity_entry.unique_id in known_ids:
             continue
 
         _LOGGER.debug("Removing orphaned registry entry for entity: %s", entity_entry.entity_id)

--- a/custom_components/blueprints_updater/update.py
+++ b/custom_components/blueprints_updater/update.py
@@ -94,10 +94,10 @@ def async_update_entities(
     entity_registry = er.async_get(hass)
 
     entries = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
-    known_ids: set[str] = set()
-    for info in coordinator.data.values():
-        rel_path = info["rel_path"]
-        known_ids.add(BlueprintUpdateCoordinator.generate_unique_id(entry.entry_id, rel_path))
+    known_ids = {
+        BlueprintUpdateCoordinator.generate_unique_id(entry.entry_id, info["rel_path"])
+        for info in coordinator.data.values()
+    }
 
     for entity_entry in entries:
         if entity_entry.domain != "update":

--- a/custom_components/blueprints_updater/update.py
+++ b/custom_components/blueprints_updater/update.py
@@ -106,7 +106,7 @@ def async_update_entities(
         if entity_entry.unique_id in known_ids:
             continue
 
-        _LOGGER.debug("Removing orphaned registry entry for entity: %s", entity_entry.entity_id)
+        _LOGGER.info("Removing orphaned registry entry for entity: %s", entity_entry.entity_id)
         entity_registry.async_remove(entity_entry.entity_id)
         hass.states.async_remove(entity_entry.entity_id)
 

--- a/custom_components/blueprints_updater/utils.py
+++ b/custom_components/blueprints_updater/utils.py
@@ -7,7 +7,7 @@ import random
 import textwrap
 from collections.abc import Callable, Coroutine
 from functools import wraps
-from typing import Any, TypeVar
+from typing import Any, TypeVar, cast
 
 import httpx
 
@@ -116,6 +116,81 @@ def retry_async(
     return decorator
 
 
+def get_config_value[T](config: Any, key: str, default: T) -> T:
+    """Get a value from config entry options strictly (no data fallback).
+
+    Args:
+        config: ConfigEntry, dict or None.
+        key: Configuration key.
+        default: Default value if not found.
+
+    Returns:
+        The configuration value.
+
+    """
+    if config is None:
+        return default
+
+    if hasattr(config, "options"):
+        val = config.options.get(key, default)
+    elif isinstance(config, dict):
+        val = config.get(key, default)
+    else:
+        val = default
+
+    return cast(T, val)
+
+
+def get_config_bool(config: Any, key: str, default: bool) -> bool:
+    """Get a boolean value from config entry options strictly (no data fallback).
+
+    Args:
+        config: ConfigEntry, dict or None.
+        key: Configuration key.
+        default: Default value if not found.
+
+    Returns:
+        The boolean value.
+
+    """
+    if config is None:
+        return default
+
+    if hasattr(config, "options"):
+        val = config.options.get(key, default)
+    elif isinstance(config, dict):
+        val = config.get(key, default)
+    else:
+        val = default
+
+    return bool(val)
+
+
+def get_config_str(config: Any, key: str, default: str) -> str:
+    """Get a string value from config entry options strictly (no data fallback).
+
+    Args:
+        config: ConfigEntry, dict or None.
+        key: Configuration key.
+        default: Default value if not found.
+
+    Returns:
+        The string value.
+
+    """
+    if config is None:
+        return default
+
+    if hasattr(config, "options"):
+        val = config.options.get(key, default)
+    elif isinstance(config, dict):
+        val = config.get(key, default)
+    else:
+        val = default
+
+    return str(val)
+
+
 def get_config_int(
     config: Any,
     key: str,
@@ -123,7 +198,7 @@ def get_config_int(
     min_val: int | None = None,
     max_val: int | None = None,
 ) -> int:
-    """Get an integer value from config entry options or data with clamping.
+    """Get an integer value from config entry options strictly (no data fallback).
 
     Args:
         config: ConfigEntry, dict or None.
@@ -140,7 +215,7 @@ def get_config_int(
         return default
 
     if hasattr(config, "options"):
-        val = config.options.get(key, config.data.get(key, default))
+        val = config.options.get(key, default)
     elif isinstance(config, dict):
         val = config.get(key, default)
     else:

--- a/custom_components/blueprints_updater/utils.py
+++ b/custom_components/blueprints_updater/utils.py
@@ -157,7 +157,7 @@ def get_config_bool(config: Any, key: str, default: bool) -> bool:
     if isinstance(val, bool):
         return val
     if isinstance(val, str):
-        return val.lower() in ("true", "yes", "on", "1")
+        return val.strip().lower() in ("true", "yes", "on", "1")
     return bool(val)
 
 

--- a/custom_components/blueprints_updater/utils.py
+++ b/custom_components/blueprints_updater/utils.py
@@ -153,17 +153,7 @@ def get_config_bool(config: Any, key: str, default: bool) -> bool:
         The boolean value.
 
     """
-    if config is None:
-        return default
-
-    if hasattr(config, "options"):
-        val = config.options.get(key, default)
-    elif isinstance(config, dict):
-        val = config.get(key, default)
-    else:
-        val = default
-
-    return bool(val)
+    return bool(get_config_value(config, key, default))
 
 
 def get_config_str(config: Any, key: str, default: str) -> str:
@@ -178,17 +168,7 @@ def get_config_str(config: Any, key: str, default: str) -> str:
         The string value.
 
     """
-    if config is None:
-        return default
-
-    if hasattr(config, "options"):
-        val = config.options.get(key, default)
-    elif isinstance(config, dict):
-        val = config.get(key, default)
-    else:
-        val = default
-
-    return str(val)
+    return str(get_config_value(config, key, default))
 
 
 def get_config_int(
@@ -211,15 +191,7 @@ def get_config_int(
         The coerced and clamped integer value.
 
     """
-    if config is None:
-        return default
-
-    if hasattr(config, "options"):
-        val = config.options.get(key, default)
-    elif isinstance(config, dict):
-        val = config.get(key, default)
-    else:
-        val = default
+    val = get_config_value(config, key, default)
 
     try:
         res = int(float(str(val).strip()))

--- a/custom_components/blueprints_updater/utils.py
+++ b/custom_components/blueprints_updater/utils.py
@@ -153,7 +153,12 @@ def get_config_bool(config: Any, key: str, default: bool) -> bool:
         The boolean value.
 
     """
-    return bool(get_config_value(config, key, default))
+    val = get_config_value(config, key, default)
+    if isinstance(val, bool):
+        return val
+    if isinstance(val, str):
+        return val.lower() in ("true", "yes", "on", "1")
+    return bool(val)
 
 
 def get_config_str(config: Any, key: str, default: str) -> str:

--- a/tests/coordinator/test_compatibility_guard.py
+++ b/tests/coordinator/test_compatibility_guard.py
@@ -173,34 +173,6 @@ async def test_async_summarize_risks_formatting_and_translation_fallback(coordin
 
 
 @pytest.mark.asyncio
-async def test_get_risk_summary_shim(coordinator: BlueprintUpdateCoordinator, monkeypatch):
-    """Verify that the _get_risk_summary legacy shim correctly calls async_summarize_risks."""
-    translated_keys = []
-
-    async def fake_async_translate(key, **kwargs):
-        translated_keys.append(key)
-        return f"translated:{key}"
-
-    monkeypatch.setattr(coordinator, "async_translate", fake_async_translate)
-
-    risks: list[StructuredRisk] = cast(
-        list[StructuredRisk],
-        [
-            {"type": BlueprintRiskType.NEW_MANDATORY, "args": {"input": "input1"}},
-            {"type": "unknown_risk_type", "args": {"foo": "bar"}},
-        ],
-    )
-
-    summary = await coordinator._get_risk_summary(risks)
-
-    assert "- translated:risk_new_mandatory" in summary
-    assert "- translated:risk_unknown" in summary
-    assert "\n" in summary
-    assert any("risk_new_mandatory" in k for k in translated_keys)
-    assert any("risk_unknown" in k for k in translated_keys)
-
-
-@pytest.mark.asyncio
 async def test_auto_update_guard_blocks_on_system_error(coordinator: BlueprintUpdateCoordinator):
     """Auto-update is blocked when a system error risk is present, even without consumers."""
     blueprint_path = "automation/system_error.yaml"

--- a/tests/coordinator/test_core.py
+++ b/tests/coordinator/test_core.py
@@ -29,8 +29,7 @@ def test_coordinator_protocol_conformance(coordinator):
     assert isinstance(coordinator, BlueprintCoordinatorProtocol)
 
 
-@pytest.mark.asyncio
-async def test_coordinator_data_initialized_to_empty_dict(hass):
+def test_coordinator_data_initialized_to_empty_dict(hass):
     """Confirm BlueprintUpdateCoordinator sets self.data to {} after initialization."""
     entry = MagicMock()
     entry.options = MappingProxyType({})

--- a/tests/coordinator/test_data_robustness.py
+++ b/tests/coordinator/test_data_robustness.py
@@ -33,8 +33,7 @@ def mock_coordinator(hass):
         return BlueprintUpdateCoordinator(hass, entry, timedelta(hours=24))
 
 
-@pytest.mark.asyncio
-async def test_coordinator_data_initialized_to_empty_dict(hass, mock_coordinator):
+def test_coordinator_data_initialized_to_empty_dict(hass, mock_coordinator):
     """Confirm BlueprintUpdateCoordinator sets self.data to {} after initialization."""
     assert mock_coordinator.data == {}
 

--- a/tests/coordinator/test_storage.py
+++ b/tests/coordinator/test_storage.py
@@ -337,27 +337,6 @@ async def test_backup_max_limit(coordinator, tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_backup_migration_old_bak(coordinator, tmp_path):
-    """Test migration of old .bak format to .bak.1 on next backup."""
-    bp_file = tmp_path / "test.yaml"
-    bp_file.write_text("current")
-    (tmp_path / "test.yaml.bak").write_text("old_backup")
-
-    coordinator.config_entry = MagicMock()
-    coordinator.config_entry.options = MappingProxyType({"max_backups": 3})
-    coordinator.hass.async_add_executor_job = AsyncMock(side_effect=lambda fn, *args: fn(*args))
-
-    await coordinator.async_install_blueprint(
-        str(bp_file), "new_version", reload_services=False, backup=True
-    )
-
-    assert bp_file.read_text() == "new_version"
-    assert (tmp_path / "test.yaml.bak.1").read_text() == "current"
-    assert (tmp_path / "test.yaml.bak.2").read_text() == "old_backup"
-    assert not (tmp_path / "test.yaml.bak").exists()
-
-
-@pytest.mark.asyncio
 async def test_backup_rotation(coordinator, tmp_path):
     """Test that backups rotate correctly: .bak.1 is newest, .bak.3 is oldest."""
     bp_file = tmp_path / "test.yaml"

--- a/tests/coordinator/test_update_cycle.py
+++ b/tests/coordinator/test_update_cycle.py
@@ -530,8 +530,6 @@ async def test_yaml_normalization_ignores_comments(coordinator):
     path = "/config/blueprints/automation/test.yaml"
     url = "https://github.com/user/repo/blob/main/test.yaml"
     content = f"blueprint:\n  name: Test\n  domain: automation\n  source_url: {url}\n"
-
-    # Use semantic normalization to get the expected local state
     normalized_content = coordinator._ensure_source_url(content, url)
     local_hash = coordinator._hash_content(normalized_content, already_normalized=True)
 

--- a/tests/entities/test_update_entity.py
+++ b/tests/entities/test_update_entity.py
@@ -485,8 +485,8 @@ async def test_entity_skip_version(coordinator):
 
 
 @pytest.mark.asyncio
-async def test_async_update_entities_migration(hass):
-    """Validate legacy rel_path IDs are migrated and unknown entities removed."""
+async def test_async_update_entities_orphan_cleanup(hass):
+    """Validate that entities with unknown unique_ids are removed as orphans."""
     entry = MagicMock()
     entry.entry_id = "test_entry"
 
@@ -506,13 +506,12 @@ async def test_async_update_entities_migration(hass):
 
     mock_entity_registry = MagicMock()
 
-    legacy_id = BlueprintUpdateCoordinator.generate_legacy_unique_id("kept.yaml")
-    new_id = BlueprintUpdateCoordinator.generate_unique_id(entry.entry_id, "kept.yaml")
+    known_id = BlueprintUpdateCoordinator.generate_unique_id(entry.entry_id, "kept.yaml")
 
-    legacy_entity = MagicMock()
-    legacy_entity.domain = "update"
-    legacy_entity.unique_id = legacy_id
-    legacy_entity.entity_id = "update.kept"
+    known_entity = MagicMock()
+    known_entity.domain = "update"
+    known_entity.unique_id = known_id
+    known_entity.entity_id = "update.kept"
 
     orphan_entity = MagicMock()
     orphan_entity.domain = "update"
@@ -526,15 +525,13 @@ async def test_async_update_entities_migration(hass):
         ),
         patch(
             "custom_components.blueprints_updater.update.er.async_entries_for_config_entry",
-            return_value=[legacy_entity, orphan_entity],
+            return_value=[known_entity, orphan_entity],
         ),
     ):
         async_add_entities = MagicMock()
         await async_setup_entry(hass, entry, async_add_entities)
 
-        mock_entity_registry.async_update_entity.assert_called_once_with(
-            "update.kept", new_unique_id=new_id
-        )
+        mock_entity_registry.async_update_entity.assert_not_called()
         mock_entity_registry.async_remove.assert_called_once_with("update.orphan")
         hass.states.async_remove.assert_called_once_with("update.orphan")
 

--- a/tests/entities/test_update_entity.py
+++ b/tests/entities/test_update_entity.py
@@ -1,6 +1,7 @@
 """Tests for Blueprints Updater update entities."""
 
 import asyncio
+import logging
 from unittest.mock import AsyncMock, MagicMock, mock_open, patch
 
 import pytest
@@ -485,7 +486,7 @@ async def test_entity_skip_version(coordinator):
 
 
 @pytest.mark.asyncio
-async def test_async_update_entities_orphan_cleanup(hass):
+async def test_async_update_entities_orphan_cleanup(hass, caplog):
     """Validate that entities with unknown unique_ids are removed as orphans."""
     entry = MagicMock()
     entry.entry_id = "test_entry"
@@ -493,16 +494,12 @@ async def test_async_update_entities_orphan_cleanup(hass):
     coordinator = MagicMock(spec=BlueprintUpdateCoordinator)
     coordinator.config_entry = entry
     coordinator.data = {
-        "/config/blueprints/kept.yaml": {
+        "kept.yaml": {
             "rel_path": "kept.yaml",
             "name": "Kept",
             "local_hash": "hash",
         },
     }
-    coordinator.async_add_listener = MagicMock()
-
-    hass.data = {DOMAIN: {"coordinators": {entry.entry_id: coordinator}}}
-    hass.states = MagicMock()
 
     mock_entity_registry = MagicMock()
 
@@ -518,6 +515,9 @@ async def test_async_update_entities_orphan_cleanup(hass):
     orphan_entity.unique_id = "test_entry_orphan.yaml"
     orphan_entity.entity_id = "update.orphan"
 
+    hass.data = {DOMAIN: {"coordinators": {entry.entry_id: coordinator}}}
+    hass.states = MagicMock()
+
     with (
         patch(
             "custom_components.blueprints_updater.update.er.async_get",
@@ -527,13 +527,14 @@ async def test_async_update_entities_orphan_cleanup(hass):
             "custom_components.blueprints_updater.update.er.async_entries_for_config_entry",
             return_value=[known_entity, orphan_entity],
         ),
+        caplog.at_level(logging.INFO),
     ):
         async_add_entities = MagicMock()
         await async_setup_entry(hass, entry, async_add_entities)
 
-        mock_entity_registry.async_update_entity.assert_not_called()
         mock_entity_registry.async_remove.assert_called_once_with("update.orphan")
         hass.states.async_remove.assert_called_once_with("update.orphan")
+        assert "Removing orphaned registry entry for entity: update.orphan" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -667,6 +668,7 @@ async def test_entity_release_notes_git_diff_source_url_normalization(coordinato
     assert notes is not None
     assert "<summary>git_diff_title</summary>" not in notes
     assert "<details>" not in notes
+    assert "<summary>git_diff_title</summary>" not in notes
 
 
 @pytest.mark.asyncio

--- a/tests/entities/test_update_entity.py
+++ b/tests/entities/test_update_entity.py
@@ -533,6 +533,7 @@ async def test_async_update_entities_orphan_cleanup(hass, caplog):
         await async_setup_entry(hass, entry, async_add_entities)
 
         mock_entity_registry.async_remove.assert_called_once_with("update.orphan")
+        mock_entity_registry.async_update_entity.assert_not_called()
         hass.states.async_remove.assert_called_once_with("update.orphan")
         assert "Removing orphaned registry entry for entity: update.orphan" in caplog.text
 

--- a/tests/entities/test_update_entity.py
+++ b/tests/entities/test_update_entity.py
@@ -668,7 +668,6 @@ async def test_entity_release_notes_git_diff_source_url_normalization(coordinato
     assert notes is not None
     assert "<summary>git_diff_title</summary>" not in notes
     assert "<details>" not in notes
-    assert "<summary>git_diff_title</summary>" not in notes
 
 
 @pytest.mark.asyncio

--- a/tests/ui/test_config_logic.py
+++ b/tests/ui/test_config_logic.py
@@ -60,6 +60,21 @@ def test_config_helpers_no_entry(hass):
     assert coordinator.is_cdn_enabled() is DEFAULT_USE_CDN
 
 
+def test_is_auto_update_enabled_ignores_legacy_data(hass):
+    """Test is_auto_update_enabled ignores values in config_entry.data.
+
+    This verifies the breaking change in v2.0.0 where legacy data fallback
+    was removed.
+    """
+    entry = MagicMock()
+    # Setting data to opposite of default to ensure we are testing the override
+    entry.data = {CONF_AUTO_UPDATE: not DEFAULT_AUTO_UPDATE}
+    entry.options = {}
+
+    coordinator = create_mock_coordinator(hass, entry)
+    assert coordinator.is_auto_update_enabled() is DEFAULT_AUTO_UPDATE
+
+
 def create_mock_coordinator(
     hass, entry: Any | None, interval: timedelta = timedelta(hours=24)
 ) -> BlueprintUpdateCoordinator:
@@ -103,19 +118,19 @@ def test_get_config_schema_entry_precedence(hass):
     assert get_schema_default(schema, CONF_USE_CDN) is True
 
 
-def test_get_config_schema_fallback_to_data(hass):
-    """Test that _get_config_schema falls back to data when options are missing."""
+def test_get_config_schema_ignores_legacy_data(hass):
+    """Test that _get_config_schema ignores data even when options are missing."""
     entry = MagicMock()
     entry.data = {
-        CONF_AUTO_UPDATE: False,
-        CONF_USE_CDN: False,
+        CONF_AUTO_UPDATE: not DEFAULT_AUTO_UPDATE,
+        CONF_USE_CDN: not DEFAULT_USE_CDN,
     }
     entry.options = {}
 
     schema = _get_config_schema(entry, [])
 
-    assert get_schema_default(schema, CONF_AUTO_UPDATE) is False
-    assert get_schema_default(schema, CONF_USE_CDN) is False
+    assert get_schema_default(schema, CONF_AUTO_UPDATE) is DEFAULT_AUTO_UPDATE
+    assert get_schema_default(schema, CONF_USE_CDN) is DEFAULT_USE_CDN
 
 
 def test_get_config_schema_initial_defaults(hass):

--- a/tests/ui/test_config_logic.py
+++ b/tests/ui/test_config_logic.py
@@ -17,7 +17,6 @@ from custom_components.blueprints_updater.const import (
 from custom_components.blueprints_updater.coordinator import BlueprintUpdateCoordinator
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("options", "expected"),
     [
@@ -26,7 +25,7 @@ from custom_components.blueprints_updater.coordinator import BlueprintUpdateCoor
         ({CONF_AUTO_UPDATE: True}, True),
     ],
 )
-async def test_is_auto_update_enabled_config_logic(hass, options, expected):
+def test_is_auto_update_enabled_config_logic(hass, options, expected):
     """Test is_auto_update_enabled respects default and options precedence."""
     entry = MagicMock()
     entry.data = {}
@@ -36,7 +35,6 @@ async def test_is_auto_update_enabled_config_logic(hass, options, expected):
     assert coordinator.is_auto_update_enabled() is expected
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("options", "expected"),
     [
@@ -45,7 +43,7 @@ async def test_is_auto_update_enabled_config_logic(hass, options, expected):
         ({CONF_USE_CDN: True}, True),
     ],
 )
-async def test_is_cdn_enabled_config_logic(hass, options, expected):
+def test_is_cdn_enabled_config_logic(hass, options, expected):
     """Test is_cdn_enabled respects default and options."""
     entry = MagicMock()
     entry.data = {}
@@ -55,8 +53,7 @@ async def test_is_cdn_enabled_config_logic(hass, options, expected):
     assert coordinator.is_cdn_enabled() is expected
 
 
-@pytest.mark.asyncio
-async def test_config_helpers_no_entry(hass):
+def test_config_helpers_no_entry(hass):
     """Test config helpers handle missing config_entry."""
     coordinator = create_mock_coordinator(hass, None)
     assert coordinator.is_auto_update_enabled() is DEFAULT_AUTO_UPDATE
@@ -88,8 +85,7 @@ def get_schema_default(schema: vol.Schema, key_name: str) -> Any:
     raise KeyError(f"Key {key_name} not found in schema")
 
 
-@pytest.mark.asyncio
-async def test_get_config_schema_entry_precedence(hass):
+def test_get_config_schema_entry_precedence(hass):
     """Test that _get_config_schema uses options over data for defaults."""
     entry = MagicMock()
     entry.data = {
@@ -107,8 +103,7 @@ async def test_get_config_schema_entry_precedence(hass):
     assert get_schema_default(schema, CONF_USE_CDN) is True
 
 
-@pytest.mark.asyncio
-async def test_get_config_schema_fallback_to_data(hass):
+def test_get_config_schema_fallback_to_data(hass):
     """Test that _get_config_schema falls back to data when options are missing."""
     entry = MagicMock()
     entry.data = {
@@ -123,8 +118,7 @@ async def test_get_config_schema_fallback_to_data(hass):
     assert get_schema_default(schema, CONF_USE_CDN) is False
 
 
-@pytest.mark.asyncio
-async def test_get_config_schema_initial_defaults(hass):
+def test_get_config_schema_initial_defaults(hass):
     """Test that _get_config_schema falls back to system defaults for initial config."""
     schema = _get_config_schema({}, [])
 

--- a/tests/ui/test_config_logic.py
+++ b/tests/ui/test_config_logic.py
@@ -67,12 +67,25 @@ def test_is_auto_update_enabled_ignores_legacy_data(hass):
     was removed.
     """
     entry = MagicMock()
-    # Setting data to opposite of default to ensure we are testing the override
     entry.data = {CONF_AUTO_UPDATE: not DEFAULT_AUTO_UPDATE}
     entry.options = {}
 
     coordinator = create_mock_coordinator(hass, entry)
     assert coordinator.is_auto_update_enabled() is DEFAULT_AUTO_UPDATE
+
+
+def test_is_cdn_enabled_ignores_legacy_data(hass):
+    """Test is_cdn_enabled ignores values in config_entry.data.
+
+    This verifies the breaking change in v2.0.0 where legacy data fallback
+    was removed.
+    """
+    entry = MagicMock()
+    entry.data = {CONF_USE_CDN: not DEFAULT_USE_CDN}
+    entry.options = {}
+
+    coordinator = create_mock_coordinator(hass, entry)
+    assert coordinator.is_cdn_enabled() is DEFAULT_USE_CDN
 
 
 def create_mock_coordinator(

--- a/tests/ui/test_config_logic.py
+++ b/tests/ui/test_config_logic.py
@@ -19,19 +19,17 @@ from custom_components.blueprints_updater.coordinator import BlueprintUpdateCoor
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("data", "options", "expected"),
+    ("options", "expected"),
     [
-        ({}, {}, DEFAULT_AUTO_UPDATE),
-        ({CONF_AUTO_UPDATE: False}, {}, False),
-        ({CONF_AUTO_UPDATE: True}, {}, True),
-        ({CONF_AUTO_UPDATE: False}, {CONF_AUTO_UPDATE: True}, True),
-        ({CONF_AUTO_UPDATE: True}, {CONF_AUTO_UPDATE: False}, False),
+        ({}, DEFAULT_AUTO_UPDATE),
+        ({CONF_AUTO_UPDATE: False}, False),
+        ({CONF_AUTO_UPDATE: True}, True),
     ],
 )
-async def test_is_auto_update_enabled_config_logic(hass, data, options, expected):
-    """Test is_auto_update_enabled respects default and config_entry precedence."""
+async def test_is_auto_update_enabled_config_logic(hass, options, expected):
+    """Test is_auto_update_enabled respects default and options precedence."""
     entry = MagicMock()
-    entry.data = data
+    entry.data = {}
     entry.options = options
 
     coordinator = create_mock_coordinator(hass, entry)
@@ -52,24 +50,6 @@ async def test_is_cdn_enabled_config_logic(hass, options, expected):
     entry = MagicMock()
     entry.data = {}
     entry.options = options
-
-    coordinator = create_mock_coordinator(hass, entry)
-    assert coordinator.is_cdn_enabled() is expected
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("data", "expected"),
-    [
-        ({CONF_USE_CDN: False}, False),
-        ({CONF_USE_CDN: True}, True),
-    ],
-)
-async def test_is_cdn_enabled_fallback_logic(hass, data, expected):
-    """Test is_cdn_enabled falls back to data when options are missing it."""
-    entry = MagicMock()
-    entry.data = data
-    entry.options = {}
 
     coordinator = create_mock_coordinator(hass, entry)
     assert coordinator.is_cdn_enabled() is expected

--- a/tests/ui/test_init.py
+++ b/tests/ui/test_init.py
@@ -285,9 +285,6 @@ async def test_restore_blueprint_handler(hass: HomeAssistant):
                 )
             assert exc.value.translation_key == "invalid_version"
 
-            good_entity.unique_id = BlueprintUpdateCoordinator.generate_unique_id(
-                "test_entry", "test.yaml"
-            )
             coordinator_mock.async_restore_blueprint = AsyncMock(
                 return_value={"success": True, "translation_key": "success"}
             )

--- a/tests/ui/test_init.py
+++ b/tests/ui/test_init.py
@@ -613,3 +613,63 @@ async def test_init_unload_path(hass: HomeAssistant):
     assert await async_unload_entry(hass, entry) is True
     assert "test_entry" not in hass.data[DOMAIN]["coordinators"]
     mock_coord.async_shutdown.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_restore_blueprint_fails_with_legacy_id(hass: HomeAssistant):
+    """Ensure restore fails when only legacy-style unique IDs exist in the registry.
+
+    Legacy ID format was: f"{DOMAIN}-{blueprint_path}"
+    """
+    entry = MagicMock()
+    entry.entry_id = "test_entry"
+    entry.options = {}
+    entry.data = {}
+
+    coordinator_mock = MagicMock(spec=BlueprintUpdateCoordinator)
+    coordinator_mock.config_entry = entry
+    coordinator_mock.data = {"test.yaml": {"rel_path": "test.yaml", "updatable": True}}
+
+    _setup_test_coordinator(hass, entry.entry_id, coordinator_mock)
+
+    with (
+        patch(
+            "custom_components.blueprints_updater.__init__.BlueprintUpdateCoordinator",
+            return_value=coordinator_mock,
+        ) as mock_coord_class,
+        patch(
+            "custom_components.blueprints_updater.__init__.async_register_admin_service"
+        ) as mock_register,
+        patch.object(hass.services, "has_service", return_value=False),
+        patch("homeassistant.helpers.entity_registry.async_get") as mock_er,
+    ):
+        mock_coord_class.generate_unique_id = BlueprintUpdateCoordinator.generate_unique_id
+        hass.config_entries = MagicMock()
+        hass.config_entries.async_forward_entry_setups = AsyncMock()
+        await async_setup(hass, {})
+        await async_setup_entry(hass, entry)
+
+        restore_handler = next(
+            (
+                call.args[3] if len(call.args) > 3 else call.kwargs.get("service_func")
+                for call in mock_register.call_args_list
+                if (len(call.args) > 2 and call.args[2] == "restore_blueprint")
+                or call.kwargs.get("service") == "restore_blueprint"
+            ),
+            None,
+        )
+
+        assert restore_handler is not None
+
+        good_entity = MagicMock()
+        good_entity.domain = "update"
+        good_entity.config_entry_id = entry.entry_id
+        good_entity.unique_id = f"{DOMAIN}-test.yaml"
+
+        mock_er.return_value.async_get.return_value = good_entity
+
+        with pytest.raises(ServiceValidationError) as exc:
+            await restore_handler(
+                ServiceCall(hass, DOMAIN, "restore_blueprint", {"entity_id": "update.test"})
+            )
+        assert exc.value.translation_key == "not_found"

--- a/tests/ui/test_init.py
+++ b/tests/ui/test_init.py
@@ -210,9 +210,6 @@ async def test_restore_blueprint_handler(hass: HomeAssistant):
         patch.object(hass.services, "has_service", return_value=False),
     ):
         mock_coordinator_class.generate_unique_id = BlueprintUpdateCoordinator.generate_unique_id
-        mock_coordinator_class.generate_legacy_unique_id = (
-            BlueprintUpdateCoordinator.generate_legacy_unique_id
-        )
         hass.config_entries = MagicMock()
         hass.config_entries.async_forward_entry_setups = AsyncMock()
         await async_setup(hass, {})
@@ -288,8 +285,9 @@ async def test_restore_blueprint_handler(hass: HomeAssistant):
                 )
             assert exc.value.translation_key == "invalid_version"
 
-            legacy_id = BlueprintUpdateCoordinator.generate_legacy_unique_id("test.yaml")
-            good_entity.unique_id = legacy_id
+            good_entity.unique_id = BlueprintUpdateCoordinator.generate_unique_id(
+                "test_entry", "test.yaml"
+            )
             coordinator_mock.async_restore_blueprint = AsyncMock(
                 return_value={"success": True, "translation_key": "success"}
             )

--- a/tests/utils/test_core_utils.py
+++ b/tests/utils/test_core_utils.py
@@ -8,7 +8,10 @@ import pytest
 
 from custom_components.blueprints_updater.const import CONF_MAX_BACKUPS, CONF_UPDATE_INTERVAL
 from custom_components.blueprints_updater.utils import (
+    get_config_bool,
     get_config_int,
+    get_config_str,
+    get_config_value,
     get_max_backups,
     get_update_interval,
     redact_url,
@@ -180,6 +183,42 @@ def test_get_config_int():
 
     config.options = {"key": " 12.7 "}
     assert get_config_int(config, "key", 5) == 12
+
+
+def test_get_config_bool():
+    """Test get_config_bool helper."""
+    config = MagicMock()
+    config.options = {"key": True}
+    assert get_config_bool(config, "key", False) is True
+    assert get_config_bool(config, "missing", False) is False
+    assert get_config_bool(None, "key", True) is True
+
+    config.options = {"key": 0}
+    assert get_config_bool(config, "key", True) is False
+
+    assert get_config_bool({"key": "anything"}, "key", False) is True
+
+
+def test_get_config_str():
+    """Test get_config_str helper."""
+    config = MagicMock()
+    config.options = {"key": "value"}
+    assert get_config_str(config, "key", "default") == "value"
+    assert get_config_str(config, "missing", "default") == "default"
+    assert get_config_str(None, "key", "default") == "default"
+
+    assert get_config_str({"key": 123}, "key", "default") == "123"
+
+
+def test_get_config_value():
+    """Test get_config_value helper."""
+    config = MagicMock()
+    config.options = {"key": [1, 2, 3]}
+    assert get_config_value(config, "key", []) == [1, 2, 3]
+    assert get_config_value(config, "missing", ["default"]) == ["default"]
+    assert get_config_value(None, "key", ["none"]) == ["none"]
+
+    assert get_config_value({"key": {"a": 1}}, "key", {}) == {"a": 1}
 
 
 def test_get_update_interval():

--- a/tests/utils/test_core_utils.py
+++ b/tests/utils/test_core_utils.py
@@ -196,18 +196,21 @@ def test_get_config_bool():
     config.options = {"key": 0}
     assert get_config_bool(config, "key", True) is False
 
-    assert get_config_bool({"key": "anything"}, "key", False) is True
-
-
-def test_get_config_str():
-    """Test get_config_str helper."""
-    config = MagicMock()
-    config.options = {"key": "value"}
-    assert get_config_str(config, "key", "default") == "value"
-    assert get_config_str(config, "missing", "default") == "default"
-    assert get_config_str(None, "key", "default") == "default"
+    assert get_config_bool({"key": "anything"}, "key", False) is False
 
     assert get_config_str({"key": 123}, "key", "default") == "123"
+
+
+def test_get_config_bool_string_handling():
+    """Test get_config_bool handles string boolean values correctly."""
+    assert get_config_bool({"key": "true"}, "key", False) is True
+    assert get_config_bool({"key": "TRUE"}, "key", False) is True
+    assert get_config_bool({"key": "yes"}, "key", False) is True
+    assert get_config_bool({"key": "on"}, "key", False) is True
+    assert get_config_bool({"key": "1"}, "key", False) is True
+    assert get_config_bool({"key": "false"}, "key", True) is False
+    assert get_config_bool({"key": "0"}, "key", True) is False
+    assert get_config_bool({"key": "anything else"}, "key", True) is False
 
 
 def test_get_config_value():
@@ -219,6 +222,11 @@ def test_get_config_value():
     assert get_config_value(None, "key", ["none"]) == ["none"]
 
     assert get_config_value({"key": {"a": 1}}, "key", {}) == {"a": 1}
+
+    config_with_both = MagicMock()
+    config_with_both.options = {"key": "from_options"}
+    config_with_both.data = {"key": "from_data"}
+    assert get_config_value(config_with_both, "key", "default") == "from_options"
 
 
 def test_get_update_interval():


### PR DESCRIPTION
## Summary by Sourcery

Remove legacy configuration, ID, and risk handling paths in preparation for v2-only behavior and tighten entity/backup handling around the new formats.

Bug Fixes:
- Ensure orphaned update entities are reliably cleaned up and logged when they no longer match any known blueprint.

Enhancements:
- Standardize config access through new strict helpers that read only from options (no data fallback) for bool, string, int and generic values.
- Update coordinator auto-update and CDN toggles, config schema, and related tests to ignore legacy config_entry.data values and rely on options/defaults only.
- Simplify update entity management to drop legacy unique_id migration and treat unknown entries as orphans to remove.
- Remove legacy backup migration from .bak to numbered backups, relying solely on the current rotation scheme.
- Drop legacy risk types, summaries, and shims so only structured risk handling and async_summarize_risks remain.
- Convert several tests from async to synchronous where appropriate and expand coverage for the new config helpers and legacy behavior removal.

Tests:
- Add tests for the new config helper functions and for strict option-only behavior in config logic and schemas.
- Adjust update entity, restore service, and coordinator tests to validate removal of legacy IDs, backups, and risk shims, plus explicit orphan cleanup behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed legacy unique-ID migration and matching for blueprints; restoration and registry reconciliation now use current IDs only.
  * Configuration now reads exclusively from modern options (no fallback to legacy data); legacy backup migration removed.
  * Legacy risk handling removed; orphaned update entities are now cleaned up (logged at info).

* **Localization**
  * Removed legacy risk translation entries across locales.

* **Tests**
  * Updated and added tests to reflect removed legacy compatibility and new config helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->