### PR TITLE
Implement custom Home Assistant event and update the dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
 
       - id: prettier
         name: prettier
-        entry: npx prettier --write .
+        entry: npx prettier --log-level warn --write .
         language: system
         pass_filenames: false
         always_run: true

--- a/custom_components/blueprints_updater/const.py
+++ b/custom_components/blueprints_updater/const.py
@@ -4,6 +4,7 @@ import re
 from enum import StrEnum
 
 DOMAIN = "blueprints_updater"
+EVENT_BLUEPRINTS_UPDATER_UPDATED = f"{DOMAIN}_updated"
 BLUEPRINTS_DATA_DIR = "blueprints"
 CONF_UPDATE_INTERVAL = "update_interval"
 CONF_FILTER_MODE = "filter_mode"

--- a/custom_components/blueprints_updater/const.py
+++ b/custom_components/blueprints_updater/const.py
@@ -4,7 +4,6 @@ import re
 from enum import StrEnum
 
 DOMAIN = "blueprints_updater"
-EVENT_BLUEPRINTS_UPDATER_UPDATED = f"{DOMAIN}_updated"
 BLUEPRINTS_DATA_DIR = "blueprints"
 CONF_UPDATE_INTERVAL = "update_interval"
 CONF_FILTER_MODE = "filter_mode"
@@ -12,6 +11,7 @@ CONF_SELECTED_BLUEPRINTS = "selected_blueprints"
 CONF_AUTO_UPDATE = "auto_update"
 CONF_MAX_BACKUPS = "max_backups"
 CONF_USE_CDN = "use_cdn"
+EVENT_BLUEPRINTS_UPDATER_UPDATED = f"{DOMAIN}_updated"
 
 DEFAULT_AUTO_UPDATE = False
 DEFAULT_USE_CDN = True

--- a/custom_components/blueprints_updater/const.py
+++ b/custom_components/blueprints_updater/const.py
@@ -58,6 +58,7 @@ SPECIAL_USE_TLDS = {
     "example",
     "internal",
     "onion",
+    "home.arpa",
 }
 
 

--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -1206,12 +1206,12 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             relative_path = metadata["relative_path"]
 
             if final_source_url:
-                remote_content = self._ensure_source_url(remote_content, final_source_url)
+                final_content = self._ensure_source_url(remote_content, final_source_url)
             else:
-                remote_content = self._normalize_content(remote_content)
+                final_content = self._normalize_content(remote_content)
 
             await self.hass.async_add_executor_job(
-                _save_file, real_path, remote_content, max_backups
+                _save_file, real_path, final_content, max_backups
             )
 
             if parsed:
@@ -1244,13 +1244,13 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
 
             cached_remote_hash = (
                 current.get("remote_hash")
-                if current and current.get("remote_content") == remote_content
+                if current and current.get("remote_content") == final_content
                 else None
             )
             final_hash = (
                 remote_hash
                 or cached_remote_hash
-                or self._hash_content(remote_content, already_normalized=True)
+                or self._hash_content(final_content, already_normalized=True)
             )
             final_etag = etag if etag is not None else (current.get("etag") if current else None)
 

--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -56,6 +56,7 @@ from .const import (
     DEFAULT_AUTO_UPDATE,
     DEFAULT_USE_CDN,
     DOMAIN,
+    EVENT_BLUEPRINTS_UPDATER_UPDATED,
     FILTER_MODE_ALL,
     FILTER_MODE_BLACKLIST,
     FILTER_MODE_WHITELIST,
@@ -1081,6 +1082,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
         backup: bool = True,
         remote_hash: str | None = None,
         etag: str | None = None,
+        is_auto_update: bool = False,
     ) -> None:
         """Install a blueprint to the local filesystem.
 
@@ -1091,6 +1093,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             backup: Whether to create backup files of the old version.
             remote_hash: Optional pre-computed hash of the remote content.
             etag: Optional ETag associated with the remote content.
+            is_auto_update: Whether this is an automatic update.
 
         """
         real_path = os.path.realpath(path)
@@ -1124,28 +1127,34 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
                 _save_file, real_path, remote_content, max_backups
             )
 
+            domain = "automation"
+            if bp_block := self._get_blueprint_block(path, remote_content):
+                domain = self._normalize_domain(bp_block.get("domain"))
+            elif self.data and path in self.data:
+                domain = self.data[path].get("domain", "automation")
+                _LOGGER.debug(
+                    "Blueprint metadata at %s is malformed; using cached domain '%s' for reload",
+                    path,
+                    domain,
+                )
+            else:
+                _LOGGER.info(
+                    "Blueprint metadata at %s is malformed and not cached; "
+                    "falling back to 'automation' domain for reload",
+                    path,
+                )
+
             if reload_services:
-                domain = "automation"
-                if bp_block := self._get_blueprint_block(path, remote_content):
-                    domain = self._normalize_domain(bp_block.get("domain"))
-                elif self.data and path in self.data:
-                    domain = self.data[path].get("domain", "automation")
-                    _LOGGER.debug(
-                        "Blueprint metadata at %s is malformed; "
-                        "using cached domain '%s' for reload",
-                        path,
-                        domain,
-                    )
-                else:
-                    _LOGGER.info(
-                        "Blueprint metadata at %s is malformed and not cached; "
-                        "falling back to 'automation' domain for reload",
-                        path,
-                    )
                 await self.async_reload_services([domain])
 
             if self.data and path in self.data:
                 current = self.data[path]
+                previous_hash = current.get("local_hash")
+                had_breaking_risks = bool(current.get("breaking_risks"))
+                blueprint_name = current.get("name", "Unknown")
+                source_url = current.get("source_url", "")
+                relative_path = current.get("relative_path", "")
+
                 cached_remote_hash = (
                     current.get("remote_hash")
                     if current.get("remote_content") == remote_content
@@ -1174,6 +1183,20 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
                 )
                 self.async_set_updated_data(self.data)
                 await self._async_save_metadata(force=True)
+
+                self.hass.bus.async_fire(
+                    EVENT_BLUEPRINTS_UPDATER_UPDATED,
+                    {
+                        "blueprint_name": blueprint_name,
+                        "domain": domain,
+                        "relative_path": relative_path,
+                        "source_url": source_url,
+                        "previous_hash": previous_hash,
+                        "new_hash": final_hash,
+                        "is_auto_update": is_auto_update,
+                        "had_breaking_risks": had_breaking_risks,
+                    },
+                )
 
             _LOGGER.info("Blueprint at %s updated successfully", real_path)
         except Exception:
@@ -2435,6 +2458,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
                 backup=True,
                 remote_hash=remote_hash,
                 etag=new_etag,
+                is_auto_update=True,
             )
             results_to_notify.append(info["name"])
             updated_domains.add(info.get("domain", "automation"))

--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -1307,7 +1307,6 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
         if not hostname:
             return False
 
-        # Normalize hostname by stripping trailing dot for absolute domain names
         hostname_lower = hostname.rstrip(".").lower()
 
         for tld in SPECIAL_USE_TLDS:

--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -1008,12 +1008,10 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
         if self.data and path in self.data:
             return self.data[path].get("domain", "automation")
 
-        norm_path = os.path.normpath(path)
-        parts = norm_path.split(os.sep)
-        if len(parts) >= 2:
-            parent = parts[-2]
-            if parent in ALLOWED_RELOAD_DOMAINS:
-                return parent
+        if relative_path := get_blueprint_relative_path(self.hass, path):
+            domain = relative_path.split("/", 1)[0]
+            if domain in ALLOWED_RELOAD_DOMAINS:
+                return domain
 
         if content and (bp_block := self._get_blueprint_block(path, content)):
             return self._normalize_domain(bp_block.get("domain"))
@@ -1194,20 +1192,13 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             current = self.data.get(path) if self.data else None
             previous_hash = current.get("local_hash") if current else None
             had_breaking_risks = bool(current.get("breaking_risks")) if current else False
-            blueprint_name = (
-                current.get("name")
-                if current
-                else (
-                    bp_block.get("name")
-                    if (bp_block := self._get_blueprint_block(path, remote_content))
-                    else "Unknown"
-                )
-            )
-            source_url = current.get("source_url", "") if current else ""
+            bp_block = current or self._get_blueprint_block(path, remote_content) or {}
+            blueprint_name = bp_block.get("name", "Unknown")
+            source_url = bp_block.get("source_url", "")
             relative_path = (
                 current.get("relative_path")
                 if current
-                else os.path.relpath(path, self.hass.config.path("blueprints"))
+                else get_blueprint_relative_path(self.hass, real_path)
             )
 
             cached_remote_hash = (

--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -947,9 +947,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             _LOGGER.exception("Failed to send auto-update notification")
 
     @staticmethod
-    def _validate_blueprint(
-        data: Any, source_url: str, expected_domain: str | None = None
-    ) -> str | None:
+    def _validate_blueprint(data: Any, source_url: str, expected_domain: str) -> str | None:
         """Validate blueprint data using HA Core's Blueprint class.
 
         Performs basic structure check, structural validation,
@@ -997,6 +995,30 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             )
             return f"validation_error|{sanitize_error_detail(str(err))}"
         return None
+
+    def _get_functional_domain(self, path: str, content: str | None = None) -> str:
+        """Determine the functional domain for a blueprint path.
+
+        Priority:
+        1. Cached domain in self.data (set during scan based on directory).
+        2. Directory structure parsing from path.
+        3. Metadata parsing from content.
+        4. Default to 'automation'.
+        """
+        if self.data and path in self.data:
+            return self.data[path].get("domain", "automation")
+
+        norm_path = os.path.normpath(path)
+        parts = norm_path.split(os.sep)
+        if len(parts) >= 2:
+            parent = parts[-2]
+            if parent in ALLOWED_RELOAD_DOMAINS:
+                return parent
+
+        if content and (bp_block := self._get_blueprint_block(path, content)):
+            return self._normalize_domain(bp_block.get("domain"))
+
+        return "automation"
 
     async def async_reload_services(self, domains: list[str] | set[str] | None = None) -> None:
         """Reload specific domains or default ones if they are allowed.
@@ -1093,6 +1115,14 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
     ) -> None:
         """Install a blueprint to the local filesystem.
 
+        This method validates the blueprint path, creates a backup if requested,
+        writes the new content, and optionally reloads the associated services.
+        It also performs domain validation, logging a warning if the declared
+        domain in the YAML does not match the functional domain derived from
+        the directory structure. If YAML parsing fails during this validation,
+        a warning is logged but the installation continues using the functional
+        domain.
+
         Fires EVENT_BLUEPRINTS_UPDATER_UPDATED upon success.
 
         Args:
@@ -1103,6 +1133,9 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             remote_hash: Optional pre-computed hash of the remote content.
             etag: Optional ETag associated with the remote content.
             is_auto_update: Whether this is an automatic update.
+
+        Raises:
+            HomeAssistantError: If the path is unsafe or content is empty.
 
         """
         real_path = os.path.realpath(path)
@@ -1136,35 +1169,58 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
                 _save_file, real_path, remote_content, max_backups
             )
 
-            domain = "automation"
-            if self.data and path in self.data:
-                domain = self.data[path].get("domain", "automation")
-            elif bp_block := self._get_blueprint_block(path, remote_content):
-                domain = self._normalize_domain(bp_block.get("domain"))
+            functional_domain = self._get_functional_domain(path, remote_content)
+            try:
+                parsed = yaml_util.parse_yaml(remote_content)
+                declared_domain = (
+                    parsed.get("blueprint", {}).get("domain") if isinstance(parsed, dict) else None
+                )
 
+                if declared_domain and declared_domain != functional_domain:
+                    _LOGGER.warning(
+                        "Blueprint at %s has unknown domain '%s', "
+                        "falling back to functional domain '%s'",
+                        path,
+                        declared_domain,
+                        functional_domain,
+                    )
+            except (HomeAssistantError, yaml.YAMLError):
+                _LOGGER.warning("Failed to parse blueprint at %s", path)
+
+            domain = functional_domain
             if reload_services:
                 await self.async_reload_services([domain])
 
+            current = self.data.get(path) if self.data else None
+            previous_hash = current.get("local_hash") if current else None
+            had_breaking_risks = bool(current.get("breaking_risks")) if current else False
+            blueprint_name = (
+                current.get("name")
+                if current
+                else (
+                    bp_block.get("name")
+                    if (bp_block := self._get_blueprint_block(path, remote_content))
+                    else "Unknown"
+                )
+            )
+            source_url = current.get("source_url", "") if current else ""
+            relative_path = (
+                current.get("relative_path")
+                if current
+                else os.path.relpath(path, self.hass.config.path("blueprints"))
+            )
+
+            cached_remote_hash = (
+                current.get("remote_hash")
+                if current and current.get("remote_content") == remote_content
+                else None
+            )
+            final_hash = (
+                remote_hash or cached_remote_hash or self._hash_content(remote_content, source_url)
+            )
+            final_etag = etag if etag is not None else (current.get("etag") if current else None)
+
             if self.data and path in self.data:
-                current = self.data[path]
-                previous_hash = current.get("local_hash")
-                had_breaking_risks = bool(current.get("breaking_risks"))
-                blueprint_name = current.get("name", "Unknown")
-                source_url = current.get("source_url", "")
-                relative_path = current.get("relative_path", "")
-
-                cached_remote_hash = (
-                    current.get("remote_hash")
-                    if current.get("remote_content") == remote_content
-                    else None
-                )
-                final_hash = (
-                    remote_hash
-                    or cached_remote_hash
-                    or self._hash_content(remote_content, current.get("source_url", ""))
-                )
-                final_etag = etag if etag is not None else current.get("etag")
-
                 self.data[path].update(
                     {
                         "updatable": False,
@@ -1182,19 +1238,19 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
                 self.async_set_updated_data(self.data)
                 await self._async_save_metadata(force=True)
 
-                self.hass.bus.async_fire(
-                    EVENT_BLUEPRINTS_UPDATER_UPDATED,
-                    {
-                        "blueprint_name": blueprint_name,
-                        "domain": domain,
-                        "relative_path": relative_path,
-                        "source_url": source_url,
-                        "previous_hash": previous_hash,
-                        "new_hash": final_hash,
-                        "is_auto_update": is_auto_update,
-                        "had_breaking_risks": had_breaking_risks,
-                    },
-                )
+            self.hass.bus.async_fire(
+                EVENT_BLUEPRINTS_UPDATER_UPDATED,
+                {
+                    "blueprint_name": blueprint_name,
+                    "domain": domain,
+                    "relative_path": relative_path,
+                    "source_url": source_url,
+                    "previous_hash": previous_hash,
+                    "new_hash": final_hash,
+                    "is_auto_update": is_auto_update,
+                    "had_breaking_risks": had_breaking_risks,
+                },
+            )
 
             _LOGGER.info("Blueprint at %s updated successfully", real_path)
         except Exception:
@@ -1218,8 +1274,9 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
 
         hostname_lower = hostname.lower()
 
-        if hostname_lower.rsplit(".", 1)[-1] in SPECIAL_USE_TLDS:
-            return False
+        for tld in SPECIAL_USE_TLDS:
+            if hostname_lower == tld or hostname_lower.endswith("." + tld):
+                return False
 
         if hostname_lower in self._safe_hostname_cache:
             return self._safe_hostname_cache[hostname_lower]
@@ -1456,7 +1513,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
 
         """
         configs: dict[str, dict[str, Any]] = {}
-        for domain in ("automation", "script"):
+        for domain in ALLOWED_RELOAD_DOMAINS:
             if domain not in self.hass.data:
                 continue
 
@@ -1935,7 +1992,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
         remote_content_with_url = self._ensure_source_url(remote_content, source_url)
         try:
             blueprint_dict = yaml_util.parse_yaml(remote_content_with_url)
-            expected_domain = self.data[path].get("domain") if path in self.data else None
+            expected_domain = self._get_functional_domain(path, remote_content_with_url)
             last_error = self._validate_blueprint(
                 blueprint_dict, source_url, expected_domain=expected_domain
             )
@@ -2281,8 +2338,9 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             updatable = bool(remote_hash and remote_hash != local_hash)
 
             blueprint_dict = yaml_util.parse_yaml(remote_content)
+            expected_domain = self._get_functional_domain(path, remote_content)
             last_error = self._validate_blueprint(
-                blueprint_dict, source_url, expected_domain=info.get("domain")
+                blueprint_dict, source_url, expected_domain=expected_domain
             )
         except (HomeAssistantError, InvalidBlueprint) as err:
             _LOGGER.warning(

--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -1185,10 +1185,6 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
 
                 os.replace(tmp_path, file_path)
 
-            await self.hass.async_add_executor_job(
-                _save_file, real_path, remote_content, max_backups
-            )
-
             parsed_raw = None
             try:
                 parsed_raw = yaml_util.parse_yaml(remote_content)
@@ -1201,6 +1197,21 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
                 path, content=remote_content if parsed else None, parsed_data=parsed
             )
             bp_block = self._get_blueprint_block(path, parsed_data=parsed)
+
+            metadata = self._resolve_blueprint_metadata(path, bp_block, source_url, real_path)
+            current = metadata["current"]
+            blueprint_name = metadata["name"]
+            final_source_url = metadata["source_url"]
+            relative_path = metadata["relative_path"]
+
+            if final_source_url:
+                remote_content = self._ensure_source_url(remote_content, final_source_url)
+            else:
+                remote_content = self._normalize_content(remote_content)
+
+            await self.hass.async_add_executor_job(
+                _save_file, real_path, remote_content, max_backups
+            )
 
             if parsed:
                 blueprint_meta = parsed.get("blueprint")
@@ -1222,12 +1233,6 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             if reload_services:
                 await self.async_reload_services([domain])
 
-            metadata = self._resolve_blueprint_metadata(path, bp_block, source_url, real_path)
-            current = metadata["current"]
-            blueprint_name = metadata["name"]
-            final_source_url = metadata["source_url"]
-            relative_path = metadata["relative_path"]
-
             previous_hash = current.get("local_hash") if current else None
             had_breaking_risks = bool(current.get("breaking_risks")) if current else False
 
@@ -1239,7 +1244,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             final_hash = (
                 remote_hash
                 or cached_remote_hash
-                or self._hash_content(remote_content, final_source_url)
+                or self._hash_content(remote_content, already_normalized=True)
             )
             final_etag = etag if etag is not None else (current.get("etag") if current else None)
 
@@ -1363,21 +1368,21 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
         if not hostname:
             return False
 
-        hostname_lower = hostname.rstrip(".").lower()
+        hostname = hostname.rstrip(".").lower()
 
         for tld in SPECIAL_USE_TLDS:
-            if hostname_lower == tld or hostname_lower.endswith("." + tld):
+            if hostname == tld or hostname.endswith("." + tld):
                 return False
 
-        if hostname_lower in self._safe_hostname_cache:
-            return self._safe_hostname_cache[hostname_lower]
+        if hostname in self._safe_hostname_cache:
+            return self._safe_hostname_cache[hostname]
 
         async with self._safe_hostname_lock:
-            if hostname_lower in self._safe_hostname_cache:
-                return self._safe_hostname_cache[hostname_lower]
+            if hostname in self._safe_hostname_cache:
+                return self._safe_hostname_cache[hostname]
 
-            result = await self._perform_safe_hostname_check(hostname_lower)
-            self._safe_hostname_cache[hostname_lower] = result
+            result = await self._perform_safe_hostname_check(hostname)
+            self._safe_hostname_cache[hostname] = result
             return result
 
     async def _perform_safe_hostname_check(self, hostname: str) -> bool:

--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -1225,14 +1225,19 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             current = self.data.get(path) if self.data else None
             previous_hash = current.get("local_hash") if current else None
             had_breaking_risks = bool(current.get("breaking_risks")) if current else False
-            active_bp_block = current or bp_block or {}
-            blueprint_name = active_bp_block.get("name", "Unknown")
-            final_source_url = source_url or active_bp_block.get("source_url", "")
-            relative_path = (
-                current.get("relative_path")
-                if current
-                else get_blueprint_relative_path(self.hass, real_path)
-            ) or ""
+            blueprint_name = (
+                (bp_block.get("name") if bp_block else None)
+                or (current.get("name") if current else None)
+                or "Unknown"
+            )
+            final_source_url = (
+                (current.get("source_url") if current else None)
+                or source_url
+                or (bp_block.get("source_url") if bp_block else "")
+            )
+            relative_path = get_blueprint_relative_path(self.hass, real_path) or (
+                current.get("relative_path") if current else ""
+            )
 
             cached_remote_hash = (
                 current.get("remote_hash")
@@ -1249,6 +1254,10 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             if self.data and path in self.data:
                 self.data[path].update(
                     {
+                        "name": blueprint_name,
+                        "domain": domain,
+                        "source_url": final_source_url,
+                        "relative_path": relative_path,
                         "updatable": False,
                         "local_hash": final_hash,
                         "remote_hash": final_hash,
@@ -1298,7 +1307,8 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
         if not hostname:
             return False
 
-        hostname_lower = hostname.lower()
+        # Normalize hostname by stripping trailing dot for absolute domain names
+        hostname_lower = hostname.rstrip(".").lower()
 
         for tld in SPECIAL_USE_TLDS:
             if hostname_lower == tld or hostname_lower.endswith("." + tld):

--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -1316,11 +1316,23 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             or "Unknown"
         )
 
-        final_source_url = (
+        raw_source_url = (
             (current.get("source_url") if current else None)
             or source_url
-            or (bp_block.get("source_url") if bp_block else "")
+            or (bp_block.get("source_url") if bp_block else None)
         )
+
+        if isinstance(raw_source_url, str):
+            final_source_url = raw_source_url
+        elif raw_source_url is None:
+            final_source_url = None
+        else:
+            _LOGGER.warning(
+                "Blueprint metadata for %s contains non-string source_url (%r); ignoring it",
+                path,
+                raw_source_url,
+            )
+            final_source_url = None
 
         relative_path = get_blueprint_relative_path(self.hass, real_path) or (
             current.get("relative_path") if current else ""

--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -1188,8 +1188,9 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             parsed_raw = None
             try:
                 parsed_raw = yaml_util.parse_yaml(remote_content)
-            except HomeAssistantError:
+            except HomeAssistantError as err:
                 _LOGGER.warning("Failed to parse blueprint at %s", path)
+                _LOGGER.debug("Blueprint YAML parse error at %s: %s", path, err, exc_info=err)
 
             parsed = cast(dict[str, Any], parsed_raw) if isinstance(parsed_raw, dict) else None
 

--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -1222,22 +1222,14 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             if reload_services:
                 await self.async_reload_services([domain])
 
-            current = self.data.get(path) if self.data else None
+            metadata = self._resolve_blueprint_metadata(path, bp_block, source_url, real_path)
+            current = metadata["current"]
+            blueprint_name = metadata["name"]
+            final_source_url = metadata["source_url"]
+            relative_path = metadata["relative_path"]
+
             previous_hash = current.get("local_hash") if current else None
             had_breaking_risks = bool(current.get("breaking_risks")) if current else False
-            blueprint_name = (
-                (bp_block.get("name") if bp_block else None)
-                or (current.get("name") if current else None)
-                or "Unknown"
-            )
-            final_source_url = (
-                (current.get("source_url") if current else None)
-                or source_url
-                or (bp_block.get("source_url") if bp_block else "")
-            )
-            relative_path = get_blueprint_relative_path(self.hass, real_path) or (
-                current.get("relative_path") if current else ""
-            )
 
             cached_remote_hash = (
                 current.get("remote_hash")
@@ -1273,24 +1265,88 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
                 self.async_set_updated_data(self.data)
                 await self._async_save_metadata(force=True)
 
-            self.hass.bus.async_fire(
-                EVENT_BLUEPRINTS_UPDATER_UPDATED,
-                {
-                    "blueprint_name": blueprint_name,
-                    "domain": domain,
-                    "relative_path": relative_path,
-                    "source_url": final_source_url,
-                    "previous_hash": previous_hash,
-                    "new_hash": final_hash,
-                    "is_auto_update": is_auto_update,
-                    "had_breaking_risks": had_breaking_risks,
-                },
+            self._fire_update_event(
+                blueprint_name=blueprint_name,
+                domain=domain,
+                relative_path=relative_path,
+                source_url=final_source_url,
+                previous_hash=previous_hash,
+                new_hash=final_hash,
+                is_auto_update=is_auto_update,
+                had_breaking_risks=had_breaking_risks,
             )
 
             _LOGGER.info("Blueprint at %s updated successfully", real_path)
         except Exception:
             _LOGGER.exception("Failed to update blueprint at %s", path)
             raise
+
+    def _resolve_blueprint_metadata(
+        self,
+        path: str,
+        bp_block: dict[str, Any] | None,
+        source_url: str | None,
+        real_path: str,
+    ) -> dict[str, Any]:
+        """Resolve blueprint metadata merging new content with cached data.
+
+        This method merges newly parsed content with existing cache. It:
+        1. Resolves the blueprint name, preferring the new content.
+        2. Implements Strict URL Persistence: the cached source_url is always
+           preserved if it exists to maintain update tracking stability and
+           prevent URL hijacking from blueprint content.
+        3. Resolves the relative path based on the actual file location.
+        """
+        current = self.data.get(path) if self.data else None
+
+        name = (
+            (bp_block.get("name") if bp_block else None)
+            or (current.get("name") if current else None)
+            or "Unknown"
+        )
+
+        final_source_url = (
+            (current.get("source_url") if current else None)
+            or source_url
+            or (bp_block.get("source_url") if bp_block else "")
+        )
+
+        relative_path = get_blueprint_relative_path(self.hass, real_path) or (
+            current.get("relative_path") if current else ""
+        )
+
+        return {
+            "name": name,
+            "source_url": final_source_url,
+            "relative_path": relative_path,
+            "current": current,
+        }
+
+    def _fire_update_event(
+        self,
+        blueprint_name: str,
+        domain: str,
+        relative_path: str,
+        source_url: str,
+        previous_hash: str | None,
+        new_hash: str,
+        is_auto_update: bool,
+        had_breaking_risks: bool,
+    ) -> None:
+        """Fire a standardized update event for external consumers."""
+        self.hass.bus.async_fire(
+            EVENT_BLUEPRINTS_UPDATER_UPDATED,
+            {
+                "blueprint_name": blueprint_name,
+                "domain": domain,
+                "relative_path": relative_path,
+                "source_url": source_url,
+                "previous_hash": previous_hash,
+                "new_hash": new_hash,
+                "is_auto_update": is_auto_update,
+                "had_breaking_risks": had_breaking_risks,
+            },
+        )
 
     async def _is_safe_url(self, url: str) -> bool:
         """Check if the URL is safe (not an internal network address).

--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -996,25 +996,50 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             return f"validation_error|{sanitize_error_detail(str(err))}"
         return None
 
-    def _get_functional_domain(self, path: str, content: str | None = None) -> str:
+    def _get_functional_domain(
+        self,
+        path: str,
+        content: str | None = None,
+        parsed_data: dict[str, Any] | None = None,
+    ) -> str:
         """Determine the functional domain for a blueprint path.
 
         Priority:
-        1. Cached domain in self.data (set during scan based on directory).
+        1. Cached domain in self.data (normalized and validated).
         2. Directory structure parsing from path.
-        3. Metadata parsing from content.
+        3. Metadata parsing from content or pre-parsed data.
         4. Default to 'automation'.
+
+        Args:
+            path: Local path to the blueprint.
+            content: Raw YAML content.
+            parsed_data: Pre-parsed YAML content dictionary.
+
+        Returns:
+            The determined domain string.
+
         """
         if self.data and path in self.data:
-            return self.data[path].get("domain", "automation")
+            cached_domain = self.data[path].get("domain")
+            if cached_domain:
+                normalized_domain = self._normalize_domain(cached_domain)
+                if normalized_domain in ALLOWED_RELOAD_DOMAINS:
+                    return normalized_domain
+            return "automation"
 
         if relative_path := get_blueprint_relative_path(self.hass, path):
             domain = relative_path.split("/", 1)[0]
             if domain in ALLOWED_RELOAD_DOMAINS:
                 return domain
 
-        if content and (bp_block := self._get_blueprint_block(path, content)):
-            return self._normalize_domain(bp_block.get("domain"))
+        bp_block = parsed_data or (self._get_blueprint_block(path, content) if content else None)
+        if bp_block:
+            domain = (
+                bp_block.get("blueprint", {}).get("domain")
+                if "blueprint" in bp_block
+                else bp_block.get("domain")
+            )
+            return self._normalize_domain(domain)
 
         return "automation"
 
@@ -1167,23 +1192,31 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
                 _save_file, real_path, remote_content, max_backups
             )
 
-            functional_domain = self._get_functional_domain(path, remote_content)
+            parsed_raw = None
             try:
-                parsed = yaml_util.parse_yaml(remote_content)
-                declared_domain = (
-                    parsed.get("blueprint", {}).get("domain") if isinstance(parsed, dict) else None
-                )
+                parsed_raw = yaml_util.parse_yaml(remote_content)
+            except (HomeAssistantError, yaml.YAMLError):
+                _LOGGER.warning("Failed to parse blueprint at %s", path)
+
+            parsed = cast(dict[str, Any], parsed_raw) if isinstance(parsed_raw, dict) else None
+
+            functional_domain = self._get_functional_domain(
+                path, remote_content, parsed_data=parsed
+            )
+            bp_block = self._get_blueprint_block(path, parsed_data=parsed)
+
+            if parsed:
+                declared_domain = parsed.get("blueprint", {}).get("domain")
 
                 if declared_domain and declared_domain != functional_domain:
                     _LOGGER.warning(
-                        "Blueprint at %s has unknown domain '%s', "
-                        "falling back to functional domain '%s'",
+                        "Blueprint at %s has declared domain '%s' that does "
+                        "not match functional domain '%s'; falling back to "
+                        "functional domain",
                         path,
                         declared_domain,
                         functional_domain,
                     )
-            except (HomeAssistantError, yaml.YAMLError):
-                _LOGGER.warning("Failed to parse blueprint at %s", path)
 
             domain = functional_domain
             if reload_services:
@@ -3193,31 +3226,37 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
         return []
 
     @staticmethod
-    def _get_blueprint_block(path: str, content: str) -> dict[str, Any] | None:
-        """Extract the 'blueprint' metadata block from YAML content."""
-        try:
-            blueprint_dict = yaml_util.parse_yaml(content)
-        except HomeAssistantError as err:
-            _LOGGER.warning("Failed to parse blueprint at %s", path)
-            _LOGGER.debug("Blueprint parse error at %s: %s", path, err)
-            return None
+    def _get_blueprint_block(
+        path: str,
+        content: str | None = None,
+        parsed_data: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        """Extract the blueprint block from YAML content or pre-parsed data."""
+        parsed = parsed_data
+        if not parsed and content:
+            try:
+                parsed = yaml_util.parse_yaml(content)
+            except HomeAssistantError as err:
+                _LOGGER.warning("Failed to parse blueprint at %s", path)
+                _LOGGER.debug("Blueprint parse error at %s: %s", path, err)
+                return None
 
-        if not isinstance(blueprint_dict, dict):
+        if not isinstance(parsed, dict):
             _LOGGER.debug(
                 "Skipping blueprint at %s: parsed YAML is not a mapping (got %s)",
                 path,
-                type(blueprint_dict).__name__,
+                type(parsed).__name__,
             )
             return None
 
-        if "blueprint" not in blueprint_dict:
+        if "blueprint" not in parsed:
             _LOGGER.debug(
                 "Skipping blueprint at %s: missing top-level 'blueprint' key",
                 path,
             )
             return None
 
-        bp_info = blueprint_dict["blueprint"]
+        bp_info = parsed["blueprint"]
         if not isinstance(bp_info, dict):
             _LOGGER.debug(
                 "Skipping blueprint at %s: 'blueprint' key is not a mapping (got %s)",

--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -1020,10 +1020,10 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             The determined domain string.
 
         """
-        if self.data and path in self.data:
-            cached_domain = self.data[path].get("domain")
-            if cached_domain:
-                normalized_domain = self._normalize_domain(cached_domain)
+        if self.data and (cached_info := self.data.get(path)):
+            cached_domain = cached_info.get("domain")
+            if isinstance(cached_domain, str):
+                normalized_domain = cached_domain.strip().lower()
                 if normalized_domain in ALLOWED_RELOAD_DOMAINS:
                     return normalized_domain
 

--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -947,7 +947,9 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             _LOGGER.exception("Failed to send auto-update notification")
 
     @staticmethod
-    def _validate_blueprint(data: Any, source_url: str) -> str | None:
+    def _validate_blueprint(
+        data: Any, source_url: str, expected_domain: str | None = None
+    ) -> str | None:
         """Validate blueprint data using HA Core's Blueprint class.
 
         Performs basic structure check, structural validation,
@@ -956,6 +958,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
         Args:
             data: Parsed YAML dictionary of the blueprint.
             source_url: The URL the blueprint was loaded from (for logging).
+            expected_domain: The expected domain (automation/script/template) based on folder.
 
         Returns:
             An error string key if validation fails, or None if valid.
@@ -972,8 +975,12 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             )
             return "invalid_blueprint"
 
+        schema = (
+            AUTOMATION_BLUEPRINT_SCHEMA if expected_domain == "automation" else BLUEPRINT_SCHEMA
+        )
+
         try:
-            bp = Blueprint(data, schema=BLUEPRINT_SCHEMA)
+            bp = Blueprint(data, expected_domain=expected_domain, schema=schema)
             if errors := bp.validate():
                 error_msg = "; ".join(errors)
                 _LOGGER.warning(
@@ -1086,6 +1093,8 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
     ) -> None:
         """Install a blueprint to the local filesystem.
 
+        Fires EVENT_BLUEPRINTS_UPDATER_UPDATED upon success.
+
         Args:
             path: Target filesystem path for the blueprint.
             remote_content: Raw YAML content to write.
@@ -1128,21 +1137,10 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             )
 
             domain = "automation"
-            if bp_block := self._get_blueprint_block(path, remote_content):
-                domain = self._normalize_domain(bp_block.get("domain"))
-            elif self.data and path in self.data:
+            if self.data and path in self.data:
                 domain = self.data[path].get("domain", "automation")
-                _LOGGER.debug(
-                    "Blueprint metadata at %s is malformed; using cached domain '%s' for reload",
-                    path,
-                    domain,
-                )
-            else:
-                _LOGGER.info(
-                    "Blueprint metadata at %s is malformed and not cached; "
-                    "falling back to 'automation' domain for reload",
-                    path,
-                )
+            elif bp_block := self._get_blueprint_block(path, remote_content):
+                domain = self._normalize_domain(bp_block.get("domain"))
 
             if reload_services:
                 await self.async_reload_services([domain])
@@ -1937,7 +1935,10 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
         remote_content_with_url = self._ensure_source_url(remote_content, source_url)
         try:
             blueprint_dict = yaml_util.parse_yaml(remote_content_with_url)
-            last_error = self._validate_blueprint(blueprint_dict, source_url)
+            expected_domain = self.data[path].get("domain") if path in self.data else None
+            last_error = self._validate_blueprint(
+                blueprint_dict, source_url, expected_domain=expected_domain
+            )
         except (HomeAssistantError, InvalidBlueprint) as err:
             last_error = f"yaml_syntax_error|{sanitize_error_detail(str(err))}"
 
@@ -2280,7 +2281,9 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             updatable = bool(remote_hash and remote_hash != local_hash)
 
             blueprint_dict = yaml_util.parse_yaml(remote_content)
-            last_error = self._validate_blueprint(blueprint_dict, source_url)
+            last_error = self._validate_blueprint(
+                blueprint_dict, source_url, expected_domain=info.get("domain")
+            )
         except (HomeAssistantError, InvalidBlueprint) as err:
             _LOGGER.warning(
                 "Invalid blueprint content from %s: %s",

--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -1215,8 +1215,13 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
 
             if parsed:
                 blueprint_meta = parsed.get("blueprint")
-                declared_domain = (
+                declared_domain_raw = (
                     blueprint_meta.get("domain") if isinstance(blueprint_meta, dict) else None
+                )
+                declared_domain = (
+                    declared_domain_raw.strip().lower()
+                    if isinstance(declared_domain_raw, str)
+                    else None
                 )
 
                 if declared_domain and declared_domain != functional_domain:

--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -1198,7 +1198,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             parsed = cast(dict[str, Any], parsed_raw) if isinstance(parsed_raw, dict) else None
 
             functional_domain = self._get_functional_domain(
-                path, remote_content, parsed_data=parsed
+                path, content=remote_content if parsed else None, parsed_data=parsed
             )
             bp_block = self._get_blueprint_block(path, parsed_data=parsed)
 
@@ -1232,7 +1232,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
                 current.get("relative_path")
                 if current
                 else get_blueprint_relative_path(self.hass, real_path)
-            )
+            ) or ""
 
             cached_remote_hash = (
                 current.get("remote_hash")

--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -79,6 +79,7 @@ from .utils import (
     get_blueprint_relative_path,
     get_config_bool,
     get_max_backups,
+    is_ip_safe,
     redact_url,
     retry_async,
     sanitize_error_detail,
@@ -1025,21 +1026,15 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
                 normalized_domain = self._normalize_domain(cached_domain)
                 if normalized_domain in ALLOWED_RELOAD_DOMAINS:
                     return normalized_domain
-            return "automation"
 
         if relative_path := get_blueprint_relative_path(self.hass, path):
             domain = relative_path.split("/", 1)[0]
             if domain in ALLOWED_RELOAD_DOMAINS:
                 return domain
 
-        bp_block = parsed_data or (self._get_blueprint_block(path, content) if content else None)
+        bp_block = self._get_blueprint_block(path, content, parsed_data=parsed_data)
         if bp_block:
-            domain = (
-                bp_block.get("blueprint", {}).get("domain")
-                if "blueprint" in bp_block
-                else bp_block.get("domain")
-            )
-            return self._normalize_domain(domain)
+            return self._normalize_domain(bp_block.get("domain"))
 
         return "automation"
 
@@ -1195,7 +1190,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             parsed_raw = None
             try:
                 parsed_raw = yaml_util.parse_yaml(remote_content)
-            except (HomeAssistantError, yaml.YAMLError):
+            except HomeAssistantError:
                 _LOGGER.warning("Failed to parse blueprint at %s", path)
 
             parsed = cast(dict[str, Any], parsed_raw) if isinstance(parsed_raw, dict) else None
@@ -1206,7 +1201,10 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             bp_block = self._get_blueprint_block(path, parsed_data=parsed)
 
             if parsed:
-                declared_domain = parsed.get("blueprint", {}).get("domain")
+                blueprint_meta = parsed.get("blueprint")
+                declared_domain = (
+                    blueprint_meta.get("domain") if isinstance(blueprint_meta, dict) else None
+                )
 
                 if declared_domain and declared_domain != functional_domain:
                     _LOGGER.warning(
@@ -1225,9 +1223,9 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             current = self.data.get(path) if self.data else None
             previous_hash = current.get("local_hash") if current else None
             had_breaking_risks = bool(current.get("breaking_risks")) if current else False
-            bp_block = current or self._get_blueprint_block(path, remote_content) or {}
-            blueprint_name = bp_block.get("name", "Unknown")
-            source_url = bp_block.get("source_url", "")
+            active_bp_block = current or bp_block or {}
+            blueprint_name = active_bp_block.get("name", "Unknown")
+            source_url = active_bp_block.get("source_url", "")
             relative_path = (
                 current.get("relative_path")
                 if current
@@ -1325,7 +1323,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
         """
         with contextlib.suppress(ValueError):
             ip = ipaddress.ip_address(hostname)
-            return self._is_ip_safe(ip)
+            return is_ip_safe(ip)
 
         try:
             async with asyncio.timeout(REQUEST_TIMEOUT):
@@ -1339,33 +1337,13 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
                     ip = ipaddress.ip_address(ip_str)
                 except ValueError:
                     continue
-                if not self._is_ip_safe(ip):
-                    return False
-                found_safe_ip = True
+                if is_ip_safe(ip):
+                    found_safe_ip = True
+                    break
         except (TimeoutError, socket.gaierror):
             return False
 
         return found_safe_ip
-
-    @staticmethod
-    def _is_ip_safe(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
-        """Check if an IP address is safe (public).
-
-        Args:
-            ip: The IP address to check.
-
-        Returns:
-            True if the IP is public and safe.
-
-        """
-        return not (
-            ip.is_private
-            or ip.is_loopback
-            or ip.is_link_local
-            or ip.is_multicast
-            or ip.is_reserved
-            or ip.is_unspecified
-        )
 
     def _is_safe_path(self, path: str) -> bool:
         """Check if the path is within the blueprints' directory.

--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -1130,6 +1130,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
         remote_hash: str | None = None,
         etag: str | None = None,
         is_auto_update: bool = False,
+        source_url: str | None = None,
     ) -> None:
         """Install a blueprint to the local filesystem.
 
@@ -1151,6 +1152,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             remote_hash: Optional pre-computed hash of the remote content.
             etag: Optional ETag associated with the remote content.
             is_auto_update: Whether this is an automatic update.
+            source_url: Optional source URL for event reporting.
 
         Raises:
             HomeAssistantError: If the path is unsafe or content is empty.
@@ -1225,7 +1227,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             had_breaking_risks = bool(current.get("breaking_risks")) if current else False
             active_bp_block = current or bp_block or {}
             blueprint_name = active_bp_block.get("name", "Unknown")
-            source_url = active_bp_block.get("source_url", "")
+            final_source_url = source_url or active_bp_block.get("source_url", "")
             relative_path = (
                 current.get("relative_path")
                 if current
@@ -1238,7 +1240,9 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
                 else None
             )
             final_hash = (
-                remote_hash or cached_remote_hash or self._hash_content(remote_content, source_url)
+                remote_hash
+                or cached_remote_hash
+                or self._hash_content(remote_content, final_source_url)
             )
             final_etag = etag if etag is not None else (current.get("etag") if current else None)
 
@@ -1266,7 +1270,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
                     "blueprint_name": blueprint_name,
                     "domain": domain,
                     "relative_path": relative_path,
-                    "source_url": source_url,
+                    "source_url": final_source_url,
                     "previous_hash": previous_hash,
                     "new_hash": final_hash,
                     "is_auto_update": is_auto_update,
@@ -1337,9 +1341,9 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
                     ip = ipaddress.ip_address(ip_str)
                 except ValueError:
                     continue
-                if is_ip_safe(ip):
-                    found_safe_ip = True
-                    break
+                if not is_ip_safe(ip):
+                    return False
+                found_safe_ip = True
         except (TimeoutError, socket.gaierror):
             return False
 
@@ -2363,21 +2367,24 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
         if self.data and path in self.data:
             self.data[path]["breaking_risks"] = risks
 
-        if updatable and not last_error and self.is_auto_update_enabled():
-            auto_update_handled = await self._handle_auto_update_step(
-                path,
-                info,
-                remote_content,
-                remote_hash,
-                new_etag,
-                risks,
-                results_to_notify,
-                updated_domains,
-            )
-            if auto_update_handled or (
-                self.data and path in self.data and self.data[path].get("update_blocking_reason")
-            ):
-                return
+            if updatable and not last_error and self.is_auto_update_enabled():
+                auto_update_handled = await self._handle_auto_update_step(
+                    path,
+                    info,
+                    remote_content,
+                    remote_hash,
+                    new_etag,
+                    risks,
+                    results_to_notify,
+                    updated_domains,
+                    source_url,
+                )
+                if auto_update_handled or (
+                    self.data
+                    and path in self.data
+                    and self.data[path].get("update_blocking_reason")
+                ):
+                    return
 
         self._update_coordinator_status_data(
             path, updatable, last_error, remote_hash, remote_content, new_etag, risks
@@ -2479,6 +2486,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
         risks: list[StructuredRisk],
         results_to_notify: list[str],
         updated_domains: set[str],
+        source_url: str | None = None,
     ) -> bool:
         """Execute auto-update flow if safe.
 
@@ -2491,6 +2499,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             risks: Detected risks.
             results_to_notify: Accumulator for notifications.
             updated_domains: Accumulator for service reloads.
+            source_url: Original source URL for event reporting.
 
         Returns:
             True if processing for this blueprint should stop.
@@ -2522,6 +2531,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
                 remote_hash=remote_hash,
                 etag=new_etag,
                 is_auto_update=True,
+                source_url=source_url,
             )
             results_to_notify.append(info["name"])
             updated_domains.add(info.get("domain", "automation"))

--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -1197,7 +1197,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             functional_domain = self._get_functional_domain(
                 path, content=remote_content if parsed else None, parsed_data=parsed
             )
-            bp_block = self._get_blueprint_block(path, parsed_data=parsed)
+            bp_block = self._get_blueprint_block(path, parsed_data=parsed) if parsed else None
 
             metadata = self._resolve_blueprint_metadata(path, bp_block, source_url, real_path)
             current = metadata["current"]

--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -2455,24 +2455,22 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
         if self.data and path in self.data:
             self.data[path]["breaking_risks"] = risks
 
-            if updatable and not last_error and self.is_auto_update_enabled():
-                auto_update_handled = await self._handle_auto_update_step(
-                    path,
-                    info,
-                    remote_content,
-                    remote_hash,
-                    new_etag,
-                    risks,
-                    results_to_notify,
-                    updated_domains,
-                    source_url,
-                )
-                if auto_update_handled or (
-                    self.data
-                    and path in self.data
-                    and self.data[path].get("update_blocking_reason")
-                ):
-                    return
+        if updatable and not last_error and self.is_auto_update_enabled():
+            auto_update_handled = await self._handle_auto_update_step(
+                path,
+                info,
+                remote_content,
+                remote_hash,
+                new_etag,
+                risks,
+                results_to_notify,
+                updated_domains,
+                source_url,
+            )
+            if auto_update_handled or (
+                self.data and path in self.data and self.data[path].get("update_blocking_reason")
+            ):
+                return
 
         self._update_coordinator_status_data(
             path, updatable, last_error, remote_hash, remote_content, new_etag, risks

--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -105,6 +105,19 @@ class StructuredRisk(TypedDict):
     args: JSONDict
 
 
+class BlueprintUpdateEventPayload(TypedDict):
+    """Payload for the blueprint update event."""
+
+    blueprint_name: str
+    domain: str
+    relative_path: str
+    source_url: str | None
+    previous_hash: str | None
+    new_hash: str
+    is_auto_update: bool
+    had_breaking_risks: bool
+
+
 class ParsedBlueprintData(TypedDict):
     """Data extracted from a blueprint YAML file."""
 
@@ -1357,19 +1370,17 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
         had_breaking_risks: bool,
     ) -> None:
         """Fire a standardized update event for external consumers."""
-        self.hass.bus.async_fire(
-            EVENT_BLUEPRINTS_UPDATER_UPDATED,
-            {
-                "blueprint_name": blueprint_name,
-                "domain": domain,
-                "relative_path": relative_path,
-                "source_url": source_url,
-                "previous_hash": previous_hash,
-                "new_hash": new_hash,
-                "is_auto_update": is_auto_update,
-                "had_breaking_risks": had_breaking_risks,
-            },
-        )
+        payload: BlueprintUpdateEventPayload = {
+            "blueprint_name": blueprint_name,
+            "domain": domain,
+            "relative_path": relative_path,
+            "source_url": source_url,
+            "previous_hash": previous_hash,
+            "new_hash": new_hash,
+            "is_auto_update": is_auto_update,
+            "had_breaking_risks": had_breaking_risks,
+        }
+        self.hass.bus.async_fire(EVENT_BLUEPRINTS_UPDATER_UPDATED, payload)
 
     async def _is_safe_url(self, url: str) -> bool:
         """Check if the URL is safe (not an internal network address).

--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -1337,7 +1337,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
         blueprint_name: str,
         domain: str,
         relative_path: str,
-        source_url: str,
+        source_url: str | None,
         previous_hash: str | None,
         new_hash: str,
         is_auto_update: bool,

--- a/custom_components/blueprints_updater/update.py
+++ b/custom_components/blueprints_updater/update.py
@@ -463,6 +463,10 @@ class BlueprintUpdateEntity(CoordinatorEntity[BlueprintUpdateCoordinator], Updat
             )
 
         await self.coordinator.async_install_blueprint(
-            self._path, remote_content, reload_services=True, backup=backup
+            self._path,
+            remote_content,
+            reload_services=True,
+            backup=backup,
+            is_auto_update=False,
         )
         await self.coordinator.async_refresh()

--- a/custom_components/blueprints_updater/utils.py
+++ b/custom_components/blueprints_updater/utils.py
@@ -360,11 +360,4 @@ def is_ip_safe(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
         True if the IP is public and safe.
 
     """
-    return not (
-        ip.is_private
-        or ip.is_loopback
-        or ip.is_link_local
-        or ip.is_multicast
-        or ip.is_reserved
-        or ip.is_unspecified
-    )
+    return ip.is_global

--- a/custom_components/blueprints_updater/utils.py
+++ b/custom_components/blueprints_updater/utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import ipaddress
 import logging
 import os
 import random
@@ -347,3 +348,23 @@ def get_blueprint_relative_path(hass: HomeAssistant, path: str) -> str | None:
     except (ValueError, TypeError, OSError) as err:
         _LOGGER.debug("Skipping invalid blueprint path %s: %s", path, err)
         return None
+
+
+def is_ip_safe(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """Check if an IP address is safe (public).
+
+    Args:
+        ip: The IP address to check.
+
+    Returns:
+        True if the IP is public and safe.
+
+    """
+    return not (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,9 +52,10 @@ indent-style = "space"
 [tool.pytest]
 asyncio_mode = "auto"
 pythonpath = ["."]
+testpaths = ["tests"]
 filterwarnings = ["ignore::DeprecationWarning"]
 addopts = ["--cov=custom_components", "--cov-fail-under=90", "--timeout=60"]
-testpaths = ["tests"]
+markers = ["real_network: tests that require real network access"]
 
 [tool.pyright]
 typeCheckingMode = "standard"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = []
 [dependency-groups]
 dev = [
   "h2>=4,<5",
-  "homeassistant>=2026.4",
+  "homeassistant>=2026.5.0",
   "interrogate",
   "packaging",
   "prek",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,12 @@ asyncio_mode = "auto"
 pythonpath = ["."]
 testpaths = ["tests"]
 filterwarnings = ["ignore::DeprecationWarning"]
-addopts = ["--cov=custom_components", "--cov-fail-under=90", "--timeout=60"]
+addopts = [
+  "--cov=custom_components",
+  "--cov-fail-under=90",
+  "--timeout=60",
+  "--strict-markers",
+]
 markers = ["real_network: tests that require real network access"]
 
 [tool.pyright]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,26 +92,31 @@ def mock_getaddrinfo(request, monkeypatch):
         if is_local and hostname in ("localhost", "127.0.0.1", "::1"):
             return real_getaddrinfo(host, port, family, type, proto, flags)
 
-        effective_family = family or socket.AF_INET
-        if effective_family == socket.AF_INET:
-            dummy_ip = "127.0.0.2" if is_local else "1.1.1.1"
-            addr_tuple = (dummy_ip, port)
-        elif effective_family == socket.AF_INET6:
-            dummy_ip = "::2" if is_local else "2606:4700:4700::1111"
-            addr_tuple = (dummy_ip, port, 0, 0)
-        else:
-            msg = f"Address family {family} not supported in tests"
-            raise socket.gaierror(socket.EAI_FAMILY, msg)
+        results = []
+        families = [socket.AF_INET, socket.AF_INET6] if family == socket.AF_UNSPEC else [family]
 
-        return [
-            (
-                effective_family,
-                socket.SOCK_STREAM,
-                socket.IPPROTO_TCP,
-                "",
-                addr_tuple,
+        for f in families:
+            if f == socket.AF_INET:
+                dummy_ip = "127.0.0.2" if is_local else "1.1.1.1"
+                addr_tuple = (dummy_ip, port)
+            elif f == socket.AF_INET6:
+                dummy_ip = "::2" if is_local else "2606:4700:4700::1111"
+                addr_tuple = (dummy_ip, port, 0, 0)
+            else:
+                msg = f"Address family {f} not supported in tests"
+                raise socket.gaierror(socket.EAI_FAMILY, msg)
+
+            results.append(
+                (
+                    f,
+                    socket.SOCK_STREAM,
+                    socket.IPPROTO_TCP,
+                    "",
+                    addr_tuple,
+                )
             )
-        ]
+
+        return results
 
     monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo)
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,7 @@ def _mock_hass():
 
 
 @pytest.fixture(autouse=True)
-def mock_getaddrinfo(monkeypatch):
+def mock_getaddrinfo(request, monkeypatch):
     """Mock getaddrinfo to block external network access.
 
     Delegates localhost, 127.0.0.1, and ::1 to the real resolver.
@@ -66,7 +66,12 @@ def mock_getaddrinfo(monkeypatch):
     127.0.0.2 to avoid HA's network security filters without triggering
     actual DNS resolution. All other hosts resolve to 1.1.1.1 (a dummy
     external IP) to prevent tests from touching the real network.
+
+    Can be bypassed using @pytest.mark.real_network.
     """
+    if "real_network" in request.keywords:
+        return
+
     real_getaddrinfo = socket.getaddrinfo
 
     def _fake_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ import pytest
 from homeassistant.core import HomeAssistant
 
 from custom_components.blueprints_updater.const import SPECIAL_USE_TLDS
-from custom_components.blueprints_updater.coordinator import BlueprintUpdateCoordinator
+from custom_components.blueprints_updater.utils import is_ip_safe
 
 
 @pytest.fixture(autouse=True)
@@ -76,7 +76,7 @@ def mock_getaddrinfo(monkeypatch):
         is_local = False
         try:
             ip = ipaddress.ip_address(host)
-            is_local = not BlueprintUpdateCoordinator._is_ip_safe(ip)
+            is_local = not is_ip_safe(ip)
         except ValueError:
             hostname_lower = host.lower()
             for tld in SPECIAL_USE_TLDS:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,19 +78,19 @@ def mock_getaddrinfo(request, monkeypatch):
         if host is None:
             return real_getaddrinfo(host, port, family, type, proto, flags)
 
+        hostname = host.rstrip(".").lower()
         is_local = False
         try:
-            ip = ipaddress.ip_address(host)
+            ip = ipaddress.ip_address(hostname)
             is_local = not is_ip_safe(ip)
         except ValueError:
-            hostname_lower = host.lower()
             for tld in SPECIAL_USE_TLDS:
-                if hostname_lower == tld or hostname_lower.endswith("." + tld):
+                if hostname == tld or hostname.endswith("." + tld):
                     is_local = True
                     break
 
         if is_local:
-            if host in ("localhost", "127.0.0.1", "::1"):
+            if hostname in ("localhost", "127.0.0.1", "::1"):
                 return real_getaddrinfo(host, port, family, type, proto, flags)
             return [
                 (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,3 +50,18 @@ def _mock_hass():
 
     hass_mock.data = {}
     return hass_mock
+
+
+@pytest.fixture(autouse=True)
+def mock_getaddrinfo():
+    """Mock socket.getaddrinfo to avoid DNS resolution blocking in tests.
+
+    This returns a safe dummy IP for all non-local hostnames, preventing
+    the 'DNS resolution disabled in tests' error while allowing the
+    integration's safety checks to proceed.
+    """
+    import socket
+
+    with patch("socket.getaddrinfo") as mock_get:
+        mock_get.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("1.2.3.4", 443))]
+        yield mock_get

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,26 +89,26 @@ def mock_getaddrinfo(request, monkeypatch):
                     is_local = True
                     break
 
-        if is_local:
-            if hostname in ("localhost", "127.0.0.1", "::1"):
-                return real_getaddrinfo(host, port, family, type, proto, flags)
-            return [
-                (
-                    socket.AF_INET,
-                    socket.SOCK_STREAM,
-                    socket.IPPROTO_TCP,
-                    "",
-                    ("127.0.0.2", port),
-                )
-            ]
+        if is_local and hostname in ("localhost", "127.0.0.1", "::1"):
+            return real_getaddrinfo(host, port, family, type, proto, flags)
+
+        effective_family = family or socket.AF_INET
+        if effective_family == socket.AF_INET:
+            dummy_ip = "127.0.0.2" if is_local else "1.1.1.1"
+            addr_tuple = (dummy_ip, port)
+        elif effective_family == socket.AF_INET6:
+            dummy_ip = "::2" if is_local else "2606:4700:4700::1111"
+            addr_tuple = (dummy_ip, port, 0, 0)
+        else:
+            return real_getaddrinfo(host, port, family, type, proto, flags)
 
         return [
             (
-                socket.AF_INET,
+                effective_family,
                 socket.SOCK_STREAM,
                 socket.IPPROTO_TCP,
                 "",
-                ("1.1.1.1", port),
+                addr_tuple,
             )
         ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,7 +100,8 @@ def mock_getaddrinfo(request, monkeypatch):
             dummy_ip = "::2" if is_local else "2606:4700:4700::1111"
             addr_tuple = (dummy_ip, port, 0, 0)
         else:
-            return real_getaddrinfo(host, port, family, type, proto, flags)
+            msg = f"Address family {family} not supported in tests"
+            raise socket.gaierror(socket.EAI_FAMILY, msg)
 
         return [
             (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,33 +58,54 @@ def _mock_hass():
 
 
 @pytest.fixture(autouse=True)
-def mock_getaddrinfo():
-    """Mock socket.getaddrinfo to avoid DNS resolution blocking in tests.
+def mock_getaddrinfo(monkeypatch):
+    """Mock getaddrinfo to block external network access.
 
-    This returns a safe dummy IP for all non-local hostnames, preventing
-    the 'DNS resolution disabled in tests' error while allowing the
-    integration's safety checks to proceed.
+    Delegates localhost, 127.0.0.1, and ::1 to the real resolver.
+    For other special-use domains (e.g., .local, .home.arpa), returns
+    127.0.0.2 to avoid HA's network security filters without triggering
+    actual DNS resolution. All other hosts resolve to 1.1.1.1 (a dummy
+    external IP) to prevent tests from touching the real network.
     """
-    original_getaddrinfo = socket.getaddrinfo
+    real_getaddrinfo = socket.getaddrinfo
 
-    def side_effect(host, port, family=0, type=0, proto=0, flags=0):
+    def _fake_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
+        if host is None:
+            return real_getaddrinfo(host, port, family, type, proto, flags)
+
         is_local = False
         try:
             ip = ipaddress.ip_address(host)
             is_local = not BlueprintUpdateCoordinator._is_ip_safe(ip)
         except ValueError:
             hostname_lower = host.lower()
-            if hostname_lower in SPECIAL_USE_TLDS:
-                is_local = True
-            else:
-                parts = hostname_lower.rsplit(".", 1)
-                if len(parts) > 1 and parts[-1] in SPECIAL_USE_TLDS:
+            for tld in SPECIAL_USE_TLDS:
+                if hostname_lower == tld or hostname_lower.endswith("." + tld):
                     is_local = True
+                    break
 
         if is_local:
-            return original_getaddrinfo(host, port, family, type, proto, flags)
+            if host in ("localhost", "127.0.0.1", "::1"):
+                return real_getaddrinfo(host, port, family, type, proto, flags)
+            return [
+                (
+                    socket.AF_INET,
+                    socket.SOCK_STREAM,
+                    socket.IPPROTO_TCP,
+                    "",
+                    ("127.0.0.2", port),
+                )
+            ]
 
-        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("1.2.3.4", 443))]
+        return [
+            (
+                socket.AF_INET,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                "",
+                ("1.1.1.1", port),
+            )
+        ]
 
-    with patch("socket.getaddrinfo", side_effect=side_effect) as mock_get:
-        yield mock_get
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo)
+    yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,15 @@
 """Fixtures for Blueprints Updater tests."""
 
 import asyncio
+import ipaddress
+import socket
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.core import HomeAssistant
+
+from custom_components.blueprints_updater.const import SPECIAL_USE_TLDS
+from custom_components.blueprints_updater.coordinator import BlueprintUpdateCoordinator
 
 
 @pytest.fixture(autouse=True)
@@ -60,8 +65,26 @@ def mock_getaddrinfo():
     the 'DNS resolution disabled in tests' error while allowing the
     integration's safety checks to proceed.
     """
-    import socket
+    original_getaddrinfo = socket.getaddrinfo
 
-    with patch("socket.getaddrinfo") as mock_get:
-        mock_get.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("1.2.3.4", 443))]
+    def side_effect(host, port, family=0, type=0, proto=0, flags=0):
+        is_local = False
+        try:
+            ip = ipaddress.ip_address(host)
+            is_local = not BlueprintUpdateCoordinator._is_ip_safe(ip)
+        except ValueError:
+            hostname_lower = host.lower()
+            if hostname_lower in SPECIAL_USE_TLDS:
+                is_local = True
+            else:
+                parts = hostname_lower.rsplit(".", 1)
+                if len(parts) > 1 and parts[-1] in SPECIAL_USE_TLDS:
+                    is_local = True
+
+        if is_local:
+            return original_getaddrinfo(host, port, family, type, proto, flags)
+
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("1.2.3.4", 443))]
+
+    with patch("socket.getaddrinfo", side_effect=side_effect) as mock_get:
         yield mock_get

--- a/tests/coordinator/test_data_robustness.py
+++ b/tests/coordinator/test_data_robustness.py
@@ -54,7 +54,7 @@ async def test_async_prune_stale_metadata_empty_data(hass, mock_coordinator):
         ),
         patch(
             "custom_components.blueprints_updater.coordinator.get_blueprint_relative_path",
-            side_effect=lambda hass, path: None,  # Simulate missing/invalid path for pruning
+            side_effect=lambda hass, path: None,
         ),
         patch.object(coordinator, "_async_save_metadata", new_callable=AsyncMock) as mock_save,
     ):

--- a/tests/coordinator/test_metadata.py
+++ b/tests/coordinator/test_metadata.py
@@ -288,6 +288,39 @@ def test_validate_blueprint_valid(coordinator):
     assert result is None
 
 
+def test_validate_blueprint_script_valid(coordinator):
+    """Test _validate_blueprint with valid script data."""
+    data = {
+        "blueprint": {
+            "name": "Test Script",
+            "domain": "script",
+            "input": {},
+        },
+        "sequence": [],
+    }
+    coordinator.hass.data = {}
+    result = coordinator._validate_blueprint(
+        data, "https://example.com/script.yaml", expected_domain="script"
+    )
+    assert result is None
+
+
+def test_validate_blueprint_template_valid(coordinator):
+    """Test _validate_blueprint with valid template data."""
+    data = {
+        "blueprint": {
+            "name": "Test Template",
+            "domain": "template",
+            "input": {},
+        },
+    }
+    coordinator.hass.data = {}
+    result = coordinator._validate_blueprint(
+        data, "https://example.com/template.yaml", expected_domain="template"
+    )
+    assert result is None
+
+
 def test_validate_blueprint_incompatible_version(coordinator):
     """Test _validate_blueprint blocks when min_version is too high."""
     data = {

--- a/tests/coordinator/test_metadata.py
+++ b/tests/coordinator/test_metadata.py
@@ -282,7 +282,9 @@ def test_validate_blueprint_valid(coordinator):
         "action": [],
     }
     coordinator.hass.data = {}
-    result = coordinator._validate_blueprint(data, "https://example.com/bp.yaml")
+    result = coordinator._validate_blueprint(
+        data, "https://example.com/bp.yaml", expected_domain="automation"
+    )
     assert result is None
 
 
@@ -299,7 +301,9 @@ def test_validate_blueprint_incompatible_version(coordinator):
         "action": [],
     }
     coordinator.hass.data = {}
-    result = coordinator._validate_blueprint(data, "https://example.com/bp.yaml")
+    result = coordinator._validate_blueprint(
+        data, "https://example.com/bp.yaml", expected_domain="automation"
+    )
     assert result is not None
     assert "incompatible" in result
     assert "2099.1.0" in result
@@ -309,7 +313,9 @@ def test_validate_blueprint_schema_error(coordinator):
     """Test _validate_blueprint catches schema validation errors."""
     data = {"blueprint": {"name": "Test"}}
     coordinator.hass.data = {}
-    result = coordinator._validate_blueprint(data, "https://example.com/bp.yaml")
+    result = coordinator._validate_blueprint(
+        data, "https://example.com/bp.yaml", expected_domain="automation"
+    )
     assert result is not None
     assert "validation_error" in result
 
@@ -317,7 +323,9 @@ def test_validate_blueprint_schema_error(coordinator):
 def test_validate_blueprint_missing_key(coordinator):
     """Test _validate_blueprint with data missing the 'blueprint' key."""
     coordinator.hass.data = {}
-    result = coordinator._validate_blueprint({"not_blueprint": {}}, "https://example.com/bp.yaml")
+    result = coordinator._validate_blueprint(
+        {"not_blueprint": {}}, "https://example.com/bp.yaml", expected_domain="automation"
+    )
     assert result is not None
     assert "invalid_blueprint" in result
 

--- a/tests/coordinator/test_metadata.py
+++ b/tests/coordinator/test_metadata.py
@@ -321,6 +321,24 @@ def test_validate_blueprint_template_valid(coordinator):
     assert result is None
 
 
+def test_validate_blueprint_domain_mismatch(coordinator):
+    """Test _validate_blueprint returns error on domain mismatch."""
+    data = {
+        "blueprint": {
+            "name": "Mismatch",
+            "domain": "script",
+            "input": {},
+        },
+        "sequence": [],
+    }
+    coordinator.hass.data = {}
+    result = coordinator._validate_blueprint(
+        data, "https://example.com/bp.yaml", expected_domain="automation"
+    )
+    assert result is not None
+    assert "Found incorrect blueprint type script, expected automation" in result
+
+
 def test_validate_blueprint_incompatible_version(coordinator):
     """Test _validate_blueprint blocks when min_version is too high."""
     data = {

--- a/tests/coordinator/test_update_cycle.py
+++ b/tests/coordinator/test_update_cycle.py
@@ -305,6 +305,7 @@ async def test_async_update_data_auto_update(mock_translate, coordinator):
         remote_hash=ANY,
         etag="new_etag",
         is_auto_update=True,
+        source_url=url,
     )
 
 

--- a/tests/coordinator/test_update_cycle.py
+++ b/tests/coordinator/test_update_cycle.py
@@ -830,8 +830,8 @@ async def test_async_install_blueprint_missing_cache_fallback(hass, coordinator)
 
 
 @pytest.mark.asyncio
-async def test_async_install_blueprint_manual_install_overrides(hass, coordinator):
-    """Test that manual install with explicit source_url overrides cache."""
+async def test_async_install_blueprint_manual_install_preserves_url(hass, coordinator):
+    """Test that manual install preserves the cached source_url."""
     path = "/config/blueprints/automation/override.yaml"
     content = "blueprint:\n  name: Override\n  domain: automation\n"
     cached_url = "https://example.com/cached.yaml"

--- a/tests/coordinator/test_update_cycle.py
+++ b/tests/coordinator/test_update_cycle.py
@@ -16,6 +16,7 @@ from homeassistant.exceptions import HomeAssistantError
 from custom_components.blueprints_updater.const import (
     CONF_USE_CDN,
     DOMAIN_JSDELIVR,
+    EVENT_BLUEPRINTS_UPDATER_UPDATED,
     FILTER_MODE_ALL,
     MAX_CONCURRENT_REQUESTS,
     REQUEST_TIMEOUT,
@@ -302,6 +303,7 @@ async def test_async_update_data_auto_update(mock_translate, coordinator):
         backup=True,
         remote_hash=ANY,
         etag="new_etag",
+        is_auto_update=True,
     )
 
 
@@ -1269,3 +1271,42 @@ async def test_async_handle_notifications_multiple_domains(coordinator):
     assert coordinator.hass.services.async_call.call_count >= 2
     coordinator.hass.services.async_call.assert_any_call("automation", "reload")
     coordinator.hass.services.async_call.assert_any_call("script", "reload")
+
+
+@pytest.mark.asyncio
+async def test_async_install_blueprint_fires_event(hass, coordinator):
+    """Test that async_install_blueprint fires the expected event."""
+    path = "/config/blueprints/automation/test.yaml"
+    remote_content = "blueprint:\n  name: Test\n  domain: automation\n"
+
+    coordinator.data = {
+        path: {
+            "name": "Test Blueprint",
+            "relative_path": "automation/test.yaml",
+            "domain": "automation",
+            "source_url": "https://example.com/source.yaml",
+            "local_hash": "old_hash",
+            "breaking_risks": [{"type": "risk_type", "args": {}}],
+        }
+    }
+
+    hass.bus.async_fire = MagicMock()
+
+    with (
+        patch("builtins.open", MagicMock()),
+        patch("custom_components.blueprints_updater.coordinator.os.replace"),
+        patch("custom_components.blueprints_updater.coordinator.os.path.isfile", return_value=True),
+    ):
+        await coordinator.async_install_blueprint(path, remote_content, is_auto_update=True)
+
+    assert hass.bus.async_fire.called
+    args, _kwargs = hass.bus.async_fire.call_args
+    assert args[0] == EVENT_BLUEPRINTS_UPDATER_UPDATED
+
+    payload = args[1]
+    assert payload["blueprint_name"] == "Test Blueprint"
+    assert payload["domain"] == "automation"
+    assert payload["is_auto_update"] is True
+    assert payload["had_breaking_risks"] is True
+    assert payload["previous_hash"] == "old_hash"
+    assert payload["new_hash"] is not None

--- a/tests/coordinator/test_update_cycle.py
+++ b/tests/coordinator/test_update_cycle.py
@@ -673,6 +673,7 @@ async def test_async_install_blueprint(hass, coordinator):
         patch("builtins.open", MagicMock()),
         patch("custom_components.blueprints_updater.coordinator.os.replace"),
         patch("custom_components.blueprints_updater.coordinator.os.path.isfile", return_value=True),
+        patch.object(coordinator, "_rotate_backups", MagicMock()),
     ):
         await coordinator.async_install_blueprint(path, remote_content)
 
@@ -963,6 +964,7 @@ async def test_async_install_blueprint_targeted_reload(coordinator):
         patch("builtins.open", MagicMock()),
         patch("custom_components.blueprints_updater.coordinator.os.replace"),
         patch("custom_components.blueprints_updater.coordinator.os.path.isfile", return_value=True),
+        patch.object(coordinator, "_rotate_backups", MagicMock()),
     ):
         await coordinator.async_install_blueprint(path, content)
 
@@ -1389,6 +1391,7 @@ async def test_async_install_blueprint_fires_event(hass, coordinator):
         patch("builtins.open", MagicMock()),
         patch("custom_components.blueprints_updater.coordinator.os.replace"),
         patch("custom_components.blueprints_updater.coordinator.os.path.isfile", return_value=True),
+        patch.object(coordinator, "_rotate_backups", MagicMock()),
     ):
         await coordinator.async_install_blueprint(path, remote_content, is_auto_update=True)
 

--- a/tests/coordinator/test_update_cycle.py
+++ b/tests/coordinator/test_update_cycle.py
@@ -1306,6 +1306,8 @@ async def test_async_install_blueprint_fires_event(hass, coordinator):
     payload = args[1]
     assert payload["blueprint_name"] == "Test Blueprint"
     assert payload["domain"] == "automation"
+    assert payload["relative_path"] == "automation/test.yaml"
+    assert payload["source_url"] == "https://example.com/source.yaml"
     assert payload["is_auto_update"] is True
     assert payload["had_breaking_risks"] is True
     assert payload["previous_hash"] == "old_hash"

--- a/tests/coordinator/test_update_cycle.py
+++ b/tests/coordinator/test_update_cycle.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import contextlib
+import logging
 import os
 from http import HTTPStatus
 from types import MappingProxyType
@@ -742,6 +743,32 @@ async def test_async_install_blueprint_domain_normalization(hass, coordinator):
             hass.services.async_call.assert_called_once_with("script", "reload")
             mock_logger.warning.assert_called()
             assert "unknown_domain" in mock_logger.warning.call_args[0][2]
+
+
+@pytest.mark.asyncio
+async def test_async_install_blueprint_domain_mismatch(hass, coordinator, caplog):
+    """Test that directory domain takes precedence and logs a warning."""
+    path = "/config/blueprints/automation/test.yaml"
+    remote_content = "blueprint:\n  name: Test automation as script\n  domain: script\n"
+
+    hass.services.has_service = MagicMock(return_value=True)
+    hass.services.async_call = AsyncMock()
+
+    with (
+        patch("builtins.open", MagicMock()),
+        patch("custom_components.blueprints_updater.coordinator.os.replace"),
+        patch("custom_components.blueprints_updater.coordinator.os.path.isfile", return_value=True),
+        patch.object(coordinator, "_rotate_backups", MagicMock()),
+        caplog.at_level(logging.WARNING),
+    ):
+        await coordinator.async_install_blueprint(path, remote_content)
+
+    hass.services.async_call.assert_awaited_once_with("automation", "reload")
+
+    assert any(
+        "automation" in record.getMessage() and "script" in record.getMessage()
+        for record in caplog.records
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/coordinator/test_update_cycle.py
+++ b/tests/coordinator/test_update_cycle.py
@@ -754,14 +754,23 @@ async def test_async_install_blueprint_error(coordinator):
 
 
 @pytest.mark.asyncio
-async def test_async_install_blueprint_reload_fallback(coordinator):
+async def test_async_install_blueprint_reload_fallback(hass, coordinator):
     """Test that reload fallback works when blueprint block is missing or malformed."""
     path = "automation/test.yaml"
     content = "invalid: yaml"
+    hass.services.has_service = MagicMock(return_value=True)
+    hass.services.async_call = AsyncMock()
+    with (
+        patch("builtins.open", MagicMock()),
+        patch("custom_components.blueprints_updater.coordinator.os.replace"),
+        patch("custom_components.blueprints_updater.coordinator.os.path.isfile", return_value=True),
+        patch.object(coordinator, "_rotate_backups", MagicMock()),
+    ):
+        await coordinator.async_install_blueprint(path, content)
+        hass.services.async_call.assert_called_once_with("automation", "reload")
 
     coordinator.async_reload_services = AsyncMock()
     coordinator._async_save_metadata = AsyncMock()
-
     with (
         patch("builtins.open", MagicMock()),
         patch("custom_components.blueprints_updater.coordinator.os.replace"),
@@ -779,7 +788,83 @@ async def test_async_install_blueprint_reload_fallback(coordinator):
     ):
         await coordinator.async_install_blueprint(path, content, reload_services=True)
     coordinator.async_reload_services.assert_called_once_with(["script"])
-    coordinator._async_save_metadata.assert_awaited_once_with(force=True)
+
+
+@pytest.mark.asyncio
+async def test_async_install_blueprint_missing_cache_fallback(hass, coordinator):
+    """Test fallback to blueprint defaults when path is missing from cache."""
+    path = "/config/blueprints/automation/new_bp.yaml"
+    content = "blueprint:\n  name: New BP\n  domain: automation\n  source_url: https://example.com/new.yaml\n"
+
+    if coordinator.data:
+        coordinator.data.pop(path, None)
+
+    hass.services.has_service = MagicMock(return_value=True)
+    hass.services.async_call = AsyncMock()
+
+    with (
+        patch("builtins.open", MagicMock()),
+        patch("custom_components.blueprints_updater.coordinator.os.replace"),
+        patch(
+            "custom_components.blueprints_updater.coordinator.os.path.isfile",
+            return_value=True,
+        ),
+        patch(
+            "custom_components.blueprints_updater.coordinator.get_blueprint_relative_path",
+            return_value="automation/new_bp.yaml",
+        ),
+        patch.object(coordinator, "_rotate_backups", MagicMock()),
+        patch.object(hass.bus, "async_fire") as mock_fire,
+    ):
+        await coordinator.async_install_blueprint(
+            path, content, is_auto_update=True, source_url=None
+        )
+
+        assert mock_fire.called
+        event_name, event_data = mock_fire.call_args[0]
+        assert event_name == EVENT_BLUEPRINTS_UPDATER_UPDATED
+        assert event_data["blueprint_name"] == "New BP"
+        assert event_data["relative_path"] == "automation/new_bp.yaml"
+        assert event_data["source_url"] == "https://example.com/new.yaml"
+        assert event_data["is_auto_update"] is True
+
+
+@pytest.mark.asyncio
+async def test_async_install_blueprint_manual_install_overrides(hass, coordinator):
+    """Test that manual install with explicit source_url overrides cache."""
+    path = "/config/blueprints/automation/override.yaml"
+    content = "blueprint:\n  name: Override\n  domain: automation\n"
+    cached_url = "https://example.com/cached.yaml"
+    explicit_url = "https://example.com/explicit.yaml"
+
+    coordinator.data[path] = {
+        "name": "Cached Name",
+        "source_url": cached_url,
+        "relative_path": "automation/override.yaml",
+    }
+
+    hass.services.has_service = MagicMock(return_value=True)
+    hass.services.async_call = AsyncMock()
+
+    with (
+        patch("builtins.open", MagicMock()),
+        patch("custom_components.blueprints_updater.coordinator.os.replace"),
+        patch(
+            "custom_components.blueprints_updater.coordinator.os.path.isfile",
+            return_value=True,
+        ),
+        patch.object(coordinator, "_rotate_backups", MagicMock()),
+        patch.object(hass.bus, "async_fire") as mock_fire,
+    ):
+        await coordinator.async_install_blueprint(
+            path, content, is_auto_update=False, source_url=explicit_url
+        )
+
+        assert mock_fire.called
+        event_name, event_data = mock_fire.call_args[0]
+        assert event_name == EVENT_BLUEPRINTS_UPDATER_UPDATED
+        assert event_data["source_url"] == cached_url
+        assert event_data["is_auto_update"] is False
 
 
 @pytest.mark.asyncio
@@ -1307,7 +1392,7 @@ async def test_async_install_blueprint_fires_event(hass, coordinator):
     assert args[0] == EVENT_BLUEPRINTS_UPDATER_UPDATED
 
     payload = args[1]
-    assert payload["blueprint_name"] == "Test Blueprint"
+    assert payload["blueprint_name"] == "Test"
     assert payload["domain"] == "automation"
     assert payload["relative_path"] == "automation/test.yaml"
     assert payload["source_url"] == "https://example.com/source.yaml"

--- a/tests/coordinator/test_update_cycle.py
+++ b/tests/coordinator/test_update_cycle.py
@@ -23,7 +23,10 @@ from custom_components.blueprints_updater.const import (
     MAX_CONCURRENT_REQUESTS,
     REQUEST_TIMEOUT,
 )
-from custom_components.blueprints_updater.coordinator import BlueprintUpdateCoordinator
+from custom_components.blueprints_updater.coordinator import (
+    BlueprintUpdateCoordinator,
+    BlueprintUpdateEventPayload,
+)
 
 
 @pytest.mark.asyncio
@@ -856,17 +859,22 @@ async def test_async_install_blueprint_missing_cache_fallback(hass, coordinator)
         assert mock_fire.called
         event_name, event_data = mock_fire.call_args[0]
         assert event_name == EVENT_BLUEPRINTS_UPDATER_UPDATED
-        assert event_data["blueprint_name"] == "New BP"
-        assert event_data["relative_path"] == "automation/new_bp.yaml"
-        assert event_data["source_url"] == "https://example.com/new.yaml"
-        assert event_data["is_auto_update"] is True
+        payload: BlueprintUpdateEventPayload = event_data
+        assert payload["blueprint_name"] == "New BP"
+        assert payload["domain"] == "automation"
+        assert payload["relative_path"] == "automation/new_bp.yaml"
+        assert payload["source_url"] == "https://example.com/new.yaml"
+        assert payload["previous_hash"] is None
+        assert isinstance(payload["new_hash"], str)
+        assert payload["is_auto_update"] is True
+        assert payload["had_breaking_risks"] is False
 
 
 @pytest.mark.asyncio
 async def test_async_install_blueprint_manual_install_preserves_url(hass, coordinator):
     """Test that manual install preserves the cached source_url."""
     path = "/config/blueprints/automation/override.yaml"
-    content = "blueprint:\n  name: Override\n  domain: automation\n"
+    content = "blueprint:\n  name: Manual Preserve\n  domain: automation\n"
     cached_url = "https://example.com/cached.yaml"
     explicit_url = "https://example.com/explicit.yaml"
 
@@ -896,8 +904,13 @@ async def test_async_install_blueprint_manual_install_preserves_url(hass, coordi
         assert mock_fire.called
         event_name, event_data = mock_fire.call_args[0]
         assert event_name == EVENT_BLUEPRINTS_UPDATER_UPDATED
-        assert event_data["source_url"] == cached_url
-        assert event_data["is_auto_update"] is False
+        payload: BlueprintUpdateEventPayload = event_data
+        assert payload["blueprint_name"] == "Manual Preserve"
+        assert payload["domain"] == "automation"
+        assert payload["relative_path"] == "automation/override.yaml"
+        assert payload["source_url"] == cached_url
+        assert payload["is_auto_update"] is False
+        assert payload["had_breaking_risks"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/coordinator/test_update_cycle.py
+++ b/tests/coordinator/test_update_cycle.py
@@ -1315,3 +1315,61 @@ async def test_async_install_blueprint_fires_event(hass, coordinator):
     assert payload["previous_hash"] == "old_hash"
     assert payload["new_hash"] is not None
     assert payload["new_hash"] != payload["previous_hash"]
+
+
+@pytest.mark.asyncio
+async def test_async_update_blueprint_blocks_special_use_tld_home_arpa(coordinator):
+    """Ensure updates from special-use TLDs like home.arpa are blocked and logged."""
+    path = "/config/blueprints/script/script.yaml"
+    unsafe_url = "http://test.home.arpa/blueprints/script/script.yaml"
+
+    info = {
+        "name": "Unsafe BP",
+        "relative_path": "script/script.yaml",
+        "domain": "script",
+        "source_url": unsafe_url,
+    }
+
+    coordinator.data = {path: info}
+
+    with patch("custom_components.blueprints_updater.coordinator._LOGGER") as mock_logger:
+        coordinator._is_safe_url = BlueprintUpdateCoordinator._is_safe_url.__get__(
+            coordinator, BlueprintUpdateCoordinator
+        )
+        await coordinator._async_update_blueprint_in_place(AsyncMock(), path, info, [], set())
+
+        last_error = coordinator.data[path].get("last_error")
+        assert last_error and last_error.startswith("unsafe_url|")
+
+        mock_logger.warning.assert_called()
+        warning_args = mock_logger.warning.call_args.args
+        assert any("Blocking update from untrusted URL" in str(arg) for arg in warning_args)
+
+
+@pytest.mark.asyncio
+async def test_async_update_blueprint_blocks_special_use_tld_local(coordinator):
+    """Ensure updates from special-use TLDs like .local are blocked and logged."""
+    path = "/config/blueprints/automation/automation.yaml"
+    unsafe_url = "http://test.local/blueprints/automation/automation.yaml"
+
+    info = {
+        "name": "Unsafe BP Local",
+        "relative_path": "automation/automation.yaml",
+        "domain": "automation",
+        "source_url": unsafe_url,
+    }
+
+    coordinator.data = {path: info}
+
+    with patch("custom_components.blueprints_updater.coordinator._LOGGER") as mock_logger:
+        coordinator._is_safe_url = BlueprintUpdateCoordinator._is_safe_url.__get__(
+            coordinator, BlueprintUpdateCoordinator
+        )
+        await coordinator._async_update_blueprint_in_place(AsyncMock(), path, info, [], set())
+
+        last_error = coordinator.data[path].get("last_error")
+        assert last_error and last_error.startswith("unsafe_url|")
+
+        mock_logger.warning.assert_called()
+        warning_args = mock_logger.warning.call_args.args
+        assert any("Blocking update from untrusted URL" in str(arg) for arg in warning_args)

--- a/tests/coordinator/test_update_cycle.py
+++ b/tests/coordinator/test_update_cycle.py
@@ -14,6 +14,7 @@ import pytest
 from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.blueprints_updater.const import (
+    ALLOWED_RELOAD_DOMAINS,
     CONF_USE_CDN,
     DOMAIN_JSDELIVR,
     EVENT_BLUEPRINTS_UPDATER_UPDATED,
@@ -662,7 +663,7 @@ async def test_async_install_blueprint(hass, coordinator):
 
     hass.services.has_service = MagicMock(
         side_effect=lambda domain, service: (
-            domain in ["automation", "script"] if service == "reload" else False
+            domain in ALLOWED_RELOAD_DOMAINS if service == "reload" else False
         )
     )
     hass.services.async_call = AsyncMock()
@@ -709,7 +710,7 @@ async def test_async_install_blueprint_backup(hass, coordinator):
 @pytest.mark.asyncio
 async def test_async_install_blueprint_domain_normalization(hass, coordinator):
     """Test that async_install_blueprint correctly normalizes the domain."""
-    path = "/config/blueprints/automation/test.yaml"
+    path = "/config/blueprints/script/test.yaml"
 
     hass.services.has_service = MagicMock(return_value=True)
     hass.services.async_call = AsyncMock()
@@ -718,6 +719,7 @@ async def test_async_install_blueprint_domain_normalization(hass, coordinator):
         patch("builtins.open", MagicMock()),
         patch("custom_components.blueprints_updater.coordinator.os.replace"),
         patch("custom_components.blueprints_updater.coordinator.os.path.isfile", return_value=True),
+        patch.object(coordinator, "_rotate_backups", MagicMock()),
     ):
         content_domain = "blueprint:\n  name: Test\n  domain:  script  "
         await coordinator.async_install_blueprint(path, content_domain)
@@ -725,19 +727,19 @@ async def test_async_install_blueprint_domain_normalization(hass, coordinator):
         hass.services.async_call.reset_mock()
         content_no_domain = "blueprint:\n  name: Test"
         await coordinator.async_install_blueprint(path, content_no_domain)
-        hass.services.async_call.assert_called_once_with("automation", "reload")
+        hass.services.async_call.assert_called_once_with("script", "reload")
         hass.services.async_call.reset_mock()
         content_empty_domain = "blueprint:\n  name: Test\n  domain: ''"
         await coordinator.async_install_blueprint(path, content_empty_domain)
-        hass.services.async_call.assert_called_once_with("automation", "reload")
+        hass.services.async_call.assert_called_once_with("script", "reload")
 
         hass.services.async_call.reset_mock()
         with patch("custom_components.blueprints_updater.coordinator._LOGGER") as mock_logger:
             content_invalid_domain = "blueprint:\n  name: Test\n  domain:  unknown_domain  "
             await coordinator.async_install_blueprint(path, content_invalid_domain)
-            hass.services.async_call.assert_called_once_with("automation", "reload")
+            hass.services.async_call.assert_called_once_with("script", "reload")
             mock_logger.warning.assert_called()
-            assert "unknown_domain" in mock_logger.warning.call_args[0][1]
+            assert "unknown_domain" in mock_logger.warning.call_args[0][2]
 
 
 @pytest.mark.asyncio
@@ -860,7 +862,7 @@ async def test_async_install_blueprint_state_synchronization(coordinator):
 @pytest.mark.asyncio
 async def test_async_install_blueprint_targeted_reload(coordinator):
     """Test that installing a blueprint with a specific domain only reloads that domain."""
-    path = "/config/blueprints/automation/script.yaml"
+    path = "/config/blueprints/script/script.yaml"
     content = "blueprint:\n  name: Test Script\n  domain: script"
 
     coordinator.hass.services.has_service = MagicMock(return_value=True)
@@ -1187,7 +1189,7 @@ async def test_async_update_blueprint_in_place_unsafe_url(coordinator):
 
     coordinator.data = {path: info}
     with patch("custom_components.blueprints_updater.coordinator._LOGGER") as mock_logger:
-        await coordinator._async_update_blueprint_in_place(MagicMock(), path, info, [], set())
+        await coordinator._async_update_blueprint_in_place(AsyncMock(), path, info, [], set())
         mock_logger.warning.assert_called()
         args = mock_logger.warning.call_args.args
         assert "Blocking update from untrusted URL" in args[0]
@@ -1265,7 +1267,7 @@ async def test_async_handle_notifications_multiple_domains(coordinator):
         patch.object(coordinator, "async_translate", side_effect=lambda x, **_kw: x),
     ):
         await coordinator._async_handle_notifications(
-            ["BP1", "BP2"], domains={"automation", "script"}
+            ["BP1", "BP2"], domains=ALLOWED_RELOAD_DOMAINS
         )
 
     assert coordinator.hass.services.async_call.call_count >= 2
@@ -1312,3 +1314,4 @@ async def test_async_install_blueprint_fires_event(hass, coordinator):
     assert payload["had_breaking_risks"] is True
     assert payload["previous_hash"] == "old_hash"
     assert payload["new_hash"] is not None
+    assert payload["new_hash"] != payload["previous_hash"]

--- a/tests/coordinator/test_update_cycle.py
+++ b/tests/coordinator/test_update_cycle.py
@@ -744,13 +744,18 @@ async def test_async_install_blueprint_domain_normalization(hass, coordinator):
 
 
 @pytest.mark.asyncio
-async def test_async_install_blueprint_error(coordinator):
+async def test_async_install_blueprint_error(hass, coordinator):
     """Test exception during blueprint installation."""
+    hass.bus.async_fire = MagicMock()
+    path = "/config/blueprints/automation/test.yaml"
     with (
-        patch("builtins.open", side_effect=Exception("Write failed")),
-        pytest.raises(Exception, match="Write failed"),
+        patch("builtins.open", side_effect=OSError("Write failed")),
+        patch("custom_components.blueprints_updater.coordinator.os.path.isfile", return_value=True),
+        pytest.raises(OSError, match="Write failed"),
     ):
-        await coordinator.async_install_blueprint("/fake/path.yaml", "content")
+        await coordinator.async_install_blueprint(path, "content")
+
+    assert not hass.bus.async_fire.called
 
 
 @pytest.mark.asyncio
@@ -1403,11 +1408,18 @@ async def test_async_install_blueprint_fires_event(hass, coordinator):
     assert payload["new_hash"] != payload["previous_hash"]
 
 
+@pytest.mark.parametrize(
+    "unsafe_url",
+    [
+        "http://test.home.arpa/blueprints/script/script.yaml",
+        "http://TEST.HOME.ARPA/blueprints/script/script.yaml",
+        "http://test.home.arpa./blueprints/script/script.yaml",
+    ],
+)
 @pytest.mark.asyncio
-async def test_async_update_blueprint_blocks_special_use_tld_home_arpa(coordinator):
+async def test_async_update_blueprint_blocks_special_use_tld_home_arpa(coordinator, unsafe_url):
     """Ensure updates from special-use TLDs like home.arpa are blocked and logged."""
     path = "/config/blueprints/script/script.yaml"
-    unsafe_url = "http://test.home.arpa/blueprints/script/script.yaml"
 
     info = {
         "name": "Unsafe BP",
@@ -1432,11 +1444,18 @@ async def test_async_update_blueprint_blocks_special_use_tld_home_arpa(coordinat
         assert any("Blocking update from untrusted URL" in str(arg) for arg in warning_args)
 
 
+@pytest.mark.parametrize(
+    "unsafe_url",
+    [
+        "http://test.local/blueprints/automation/automation.yaml",
+        "http://TEST.LOCAL/blueprints/automation/automation.yaml",
+        "http://test.local./blueprints/automation/automation.yaml",
+    ],
+)
 @pytest.mark.asyncio
-async def test_async_update_blueprint_blocks_special_use_tld_local(coordinator):
+async def test_async_update_blueprint_blocks_special_use_tld_local(coordinator, unsafe_url):
     """Ensure updates from special-use TLDs like .local are blocked and logged."""
     path = "/config/blueprints/automation/automation.yaml"
-    unsafe_url = "http://test.local/blueprints/automation/automation.yaml"
 
     info = {
         "name": "Unsafe BP Local",

--- a/tests/entities/test_update_entity.py
+++ b/tests/entities/test_update_entity.py
@@ -276,6 +276,7 @@ async def test_entity_async_install(coordinator):
         "blueprint:\n  name: Test",
         reload_services=True,
         backup=False,
+        is_auto_update=False,
     )
     coordinator.async_refresh.assert_called_once()
 
@@ -318,6 +319,7 @@ async def test_entity_async_install_on_demand_fetch(coordinator):
         "fetched content",
         reload_services=True,
         backup=False,
+        is_auto_update=False,
     )
 
 
@@ -352,6 +354,7 @@ async def test_entity_async_install_backup(coordinator):
         "blueprint:\n  name: Test",
         reload_services=True,
         backup=True,
+        is_auto_update=False,
     )
     coordinator.async_refresh.assert_called_once()
 

--- a/tests/entities/test_update_entity.py
+++ b/tests/entities/test_update_entity.py
@@ -9,7 +9,7 @@ import pytest
 from homeassistant.exceptions import HomeAssistantError
 
 import custom_components.blueprints_updater.update as update_module
-from custom_components.blueprints_updater.const import DOMAIN
+from custom_components.blueprints_updater.const import ALLOWED_RELOAD_DOMAINS, DOMAIN
 from custom_components.blueprints_updater.coordinator import (
     BlueprintUpdateCoordinator,
     GitDiffResult,
@@ -192,9 +192,7 @@ def coordinator():
     comp.is_auto_update_enabled = BlueprintUpdateCoordinator.is_auto_update_enabled.__get__(
         comp, BlueprintUpdateCoordinator
     )
-    comp._normalize_domain = lambda d: (
-        d if d in ["automation", "script", "template"] else "automation"
-    )
+    comp._normalize_domain = lambda d: d if d in ALLOWED_RELOAD_DOMAINS else "automation"
     return comp
 
 
@@ -430,9 +428,7 @@ async def test_entity_release_notes_encoding(coordinator):
         "remote_content": "",
     }
     coordinator.data[path] = info
-    coordinator._normalize_domain = lambda d: (
-        d if d in ["automation", "script", "template"] else "automation"
-    )
+    coordinator._normalize_domain = lambda d: d if d in ALLOWED_RELOAD_DOMAINS else "automation"
     entity = BlueprintUpdateEntity(coordinator, path, info)
     entity.hass = coordinator.hass
 
@@ -467,9 +463,7 @@ async def test_script_release_notes_encoding(coordinator):
         "remote_content": "",
     }
     coordinator.data[path] = info
-    coordinator._normalize_domain = lambda d: (
-        d if d in ["automation", "script", "template"] else "automation"
-    )
+    coordinator._normalize_domain = lambda d: d if d in ALLOWED_RELOAD_DOMAINS else "automation"
     entity = BlueprintUpdateEntity(coordinator, path, info)
     entity.hass = coordinator.hass
 
@@ -500,9 +494,7 @@ async def test_entity_release_notes_usage_error_handled(coordinator):
         "remote_content": "",
     }
     coordinator.data[path] = info
-    coordinator._normalize_domain = lambda d: (
-        d if d in ["automation", "script", "template"] else "automation"
-    )
+    coordinator._normalize_domain = lambda d: d if d in ALLOWED_RELOAD_DOMAINS else "automation"
     entity = BlueprintUpdateEntity(coordinator, path, info)
     entity.hass = coordinator.hass
 
@@ -529,9 +521,7 @@ async def test_entity_release_notes_usage_error_unhandled(coordinator):
         "remote_content": "",
     }
     coordinator.data[path] = info
-    coordinator._normalize_domain = lambda d: (
-        d if d in ["automation", "script", "template"] else "automation"
-    )
+    coordinator._normalize_domain = lambda d: d if d in ALLOWED_RELOAD_DOMAINS else "automation"
     entity = BlueprintUpdateEntity(coordinator, path, info)
     entity.hass = coordinator.hass
 
@@ -692,9 +682,7 @@ async def test_entity_release_notes_git_diff(coordinator):
         "  domain: automation\ncondition: []\naction: []\n"
     )
 
-    coordinator._normalize_domain = lambda d: (
-        d if d in ["automation", "script", "template"] else "automation"
-    )
+    coordinator._normalize_domain = lambda d: d if d in ALLOWED_RELOAD_DOMAINS else "automation"
     entity = BlueprintUpdateEntity(coordinator, path, info)
     entity.hass = coordinator.hass
 
@@ -723,9 +711,7 @@ async def test_entity_release_notes_git_diff_missing_remote(coordinator):
     }
     coordinator.data[path] = info
 
-    coordinator._normalize_domain = lambda d: (
-        d if d in ["automation", "script", "template"] else "automation"
-    )
+    coordinator._normalize_domain = lambda d: d if d in ALLOWED_RELOAD_DOMAINS else "automation"
     entity = BlueprintUpdateEntity(coordinator, path, info)
     entity.hass = coordinator.hass
 
@@ -758,9 +744,7 @@ async def test_entity_release_notes_git_diff_source_url_normalization(coordinato
     coordinator.data[path] = info
     info["remote_content"] = remote_content
 
-    coordinator._normalize_domain = lambda d: (
-        d if d in ["automation", "script", "template"] else "automation"
-    )
+    coordinator._normalize_domain = lambda d: d if d in ALLOWED_RELOAD_DOMAINS else "automation"
     entity = BlueprintUpdateEntity(coordinator, path, info)
     entity.hass = coordinator.hass
 
@@ -792,9 +776,7 @@ async def test_entity_release_notes_git_diff_cached(coordinator):
         diff_text=cached_diff, is_semantic_sync=False
     )
 
-    coordinator._normalize_domain = lambda d: (
-        d if d in ["automation", "script", "template"] else "automation"
-    )
+    coordinator._normalize_domain = lambda d: d if d in ALLOWED_RELOAD_DOMAINS else "automation"
     entity = BlueprintUpdateEntity(coordinator, path, info)
     entity.hass = coordinator.hass
 
@@ -819,9 +801,7 @@ async def test_async_install_bypass_protection(coordinator):
     }
     coordinator.data[path] = info
 
-    coordinator._normalize_domain = lambda d: (
-        d if d in ["automation", "script", "template"] else "automation"
-    )
+    coordinator._normalize_domain = lambda d: d if d in ALLOWED_RELOAD_DOMAINS else "automation"
     entity = BlueprintUpdateEntity(coordinator, path, info)
     entity.hass = coordinator.hass
 
@@ -860,9 +840,7 @@ async def test_async_install_unsafe_url_protection(coordinator):
     }
     coordinator.data[path] = info
 
-    coordinator._normalize_domain = lambda d: (
-        d if d in ["automation", "script", "template"] else "automation"
-    )
+    coordinator._normalize_domain = lambda d: d if d in ALLOWED_RELOAD_DOMAINS else "automation"
     entity = BlueprintUpdateEntity(coordinator, path, info)
     entity.hass = coordinator.hass
 
@@ -898,9 +876,7 @@ async def test_entity_release_notes_git_diff_with_backticks(coordinator):
         diff_text=diff_text, is_semantic_sync=False
     )
 
-    coordinator._normalize_domain = lambda d: (
-        d if d in ["automation", "script", "template"] else "automation"
-    )
+    coordinator._normalize_domain = lambda d: d if d in ALLOWED_RELOAD_DOMAINS else "automation"
     entity = BlueprintUpdateEntity(coordinator, path, info)
     entity.hass = coordinator.hass
 
@@ -923,9 +899,7 @@ async def test_entity_release_notes_semantic_sync_notice(coordinator):
     }
     coordinator.data[path] = info
 
-    coordinator._normalize_domain = lambda d: (
-        d if d in ["automation", "script", "template"] else "automation"
-    )
+    coordinator._normalize_domain = lambda d: d if d in ALLOWED_RELOAD_DOMAINS else "automation"
     entity = BlueprintUpdateEntity(coordinator, path, info)
     entity.hass = coordinator.hass
 

--- a/tests/entities/test_update_entity.py
+++ b/tests/entities/test_update_entity.py
@@ -9,7 +9,7 @@ import pytest
 from homeassistant.exceptions import HomeAssistantError
 
 import custom_components.blueprints_updater.update as update_module
-from custom_components.blueprints_updater.const import ALLOWED_RELOAD_DOMAINS, DOMAIN
+from custom_components.blueprints_updater.const import DOMAIN
 from custom_components.blueprints_updater.coordinator import (
     BlueprintUpdateCoordinator,
     GitDiffResult,
@@ -192,7 +192,7 @@ def coordinator():
     comp.is_auto_update_enabled = BlueprintUpdateCoordinator.is_auto_update_enabled.__get__(
         comp, BlueprintUpdateCoordinator
     )
-    comp._normalize_domain = lambda d: d if d in ALLOWED_RELOAD_DOMAINS else "automation"
+    comp._normalize_domain = BlueprintUpdateCoordinator._normalize_domain
     return comp
 
 
@@ -428,7 +428,7 @@ async def test_entity_release_notes_encoding(coordinator):
         "remote_content": "",
     }
     coordinator.data[path] = info
-    coordinator._normalize_domain = lambda d: d if d in ALLOWED_RELOAD_DOMAINS else "automation"
+    coordinator._normalize_domain = BlueprintUpdateCoordinator._normalize_domain
     entity = BlueprintUpdateEntity(coordinator, path, info)
     entity.hass = coordinator.hass
 
@@ -463,7 +463,7 @@ async def test_script_release_notes_encoding(coordinator):
         "remote_content": "",
     }
     coordinator.data[path] = info
-    coordinator._normalize_domain = lambda d: d if d in ALLOWED_RELOAD_DOMAINS else "automation"
+    coordinator._normalize_domain = BlueprintUpdateCoordinator._normalize_domain
     entity = BlueprintUpdateEntity(coordinator, path, info)
     entity.hass = coordinator.hass
 
@@ -494,7 +494,7 @@ async def test_entity_release_notes_usage_error_handled(coordinator):
         "remote_content": "",
     }
     coordinator.data[path] = info
-    coordinator._normalize_domain = lambda d: d if d in ALLOWED_RELOAD_DOMAINS else "automation"
+    coordinator._normalize_domain = BlueprintUpdateCoordinator._normalize_domain
     entity = BlueprintUpdateEntity(coordinator, path, info)
     entity.hass = coordinator.hass
 
@@ -521,7 +521,7 @@ async def test_entity_release_notes_usage_error_unhandled(coordinator):
         "remote_content": "",
     }
     coordinator.data[path] = info
-    coordinator._normalize_domain = lambda d: d if d in ALLOWED_RELOAD_DOMAINS else "automation"
+    coordinator._normalize_domain = BlueprintUpdateCoordinator._normalize_domain
     entity = BlueprintUpdateEntity(coordinator, path, info)
     entity.hass = coordinator.hass
 
@@ -682,7 +682,7 @@ async def test_entity_release_notes_git_diff(coordinator):
         "  domain: automation\ncondition: []\naction: []\n"
     )
 
-    coordinator._normalize_domain = lambda d: d if d in ALLOWED_RELOAD_DOMAINS else "automation"
+    coordinator._normalize_domain = BlueprintUpdateCoordinator._normalize_domain
     entity = BlueprintUpdateEntity(coordinator, path, info)
     entity.hass = coordinator.hass
 
@@ -711,7 +711,7 @@ async def test_entity_release_notes_git_diff_missing_remote(coordinator):
     }
     coordinator.data[path] = info
 
-    coordinator._normalize_domain = lambda d: d if d in ALLOWED_RELOAD_DOMAINS else "automation"
+    coordinator._normalize_domain = BlueprintUpdateCoordinator._normalize_domain
     entity = BlueprintUpdateEntity(coordinator, path, info)
     entity.hass = coordinator.hass
 
@@ -744,7 +744,7 @@ async def test_entity_release_notes_git_diff_source_url_normalization(coordinato
     coordinator.data[path] = info
     info["remote_content"] = remote_content
 
-    coordinator._normalize_domain = lambda d: d if d in ALLOWED_RELOAD_DOMAINS else "automation"
+    coordinator._normalize_domain = BlueprintUpdateCoordinator._normalize_domain
     entity = BlueprintUpdateEntity(coordinator, path, info)
     entity.hass = coordinator.hass
 
@@ -776,7 +776,7 @@ async def test_entity_release_notes_git_diff_cached(coordinator):
         diff_text=cached_diff, is_semantic_sync=False
     )
 
-    coordinator._normalize_domain = lambda d: d if d in ALLOWED_RELOAD_DOMAINS else "automation"
+    coordinator._normalize_domain = BlueprintUpdateCoordinator._normalize_domain
     entity = BlueprintUpdateEntity(coordinator, path, info)
     entity.hass = coordinator.hass
 
@@ -801,7 +801,7 @@ async def test_async_install_bypass_protection(coordinator):
     }
     coordinator.data[path] = info
 
-    coordinator._normalize_domain = lambda d: d if d in ALLOWED_RELOAD_DOMAINS else "automation"
+    coordinator._normalize_domain = BlueprintUpdateCoordinator._normalize_domain
     entity = BlueprintUpdateEntity(coordinator, path, info)
     entity.hass = coordinator.hass
 
@@ -840,7 +840,7 @@ async def test_async_install_unsafe_url_protection(coordinator):
     }
     coordinator.data[path] = info
 
-    coordinator._normalize_domain = lambda d: d if d in ALLOWED_RELOAD_DOMAINS else "automation"
+    coordinator._normalize_domain = BlueprintUpdateCoordinator._normalize_domain
     entity = BlueprintUpdateEntity(coordinator, path, info)
     entity.hass = coordinator.hass
 
@@ -876,7 +876,7 @@ async def test_entity_release_notes_git_diff_with_backticks(coordinator):
         diff_text=diff_text, is_semantic_sync=False
     )
 
-    coordinator._normalize_domain = lambda d: d if d in ALLOWED_RELOAD_DOMAINS else "automation"
+    coordinator._normalize_domain = BlueprintUpdateCoordinator._normalize_domain
     entity = BlueprintUpdateEntity(coordinator, path, info)
     entity.hass = coordinator.hass
 
@@ -899,7 +899,7 @@ async def test_entity_release_notes_semantic_sync_notice(coordinator):
     }
     coordinator.data[path] = info
 
-    coordinator._normalize_domain = lambda d: d if d in ALLOWED_RELOAD_DOMAINS else "automation"
+    coordinator._normalize_domain = BlueprintUpdateCoordinator._normalize_domain
     entity = BlueprintUpdateEntity(coordinator, path, info)
     entity.hass = coordinator.hass
 

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -1,6 +1,7 @@
 """Test the initialization of the integration."""
 
 from pathlib import Path
+from unittest.mock import patch
 
 import httpx
 from homeassistant.components.update import SERVICE_INSTALL
@@ -22,8 +23,11 @@ async def test_setup_integration(hass: HomeAssistant) -> None:
     )
     entry.add_to_hass(hass)
 
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
+    with patch(
+        "custom_components.blueprints_updater.coordinator.BlueprintUpdateCoordinator._async_background_refresh"
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
 
     assert DOMAIN in hass.data
     assert "coordinators" in hass.data[DOMAIN]

--- a/tests/integration/test_services.py
+++ b/tests/integration/test_services.py
@@ -30,8 +30,11 @@ async def test_reload_service(hass: HomeAssistant) -> None:
         entry_id="test_service_entry",
     )
     entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
+    with patch(
+        "custom_components.blueprints_updater.coordinator.BlueprintUpdateCoordinator._async_background_refresh"
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
 
     coordinator = hass.data[DOMAIN]["coordinators"][entry.entry_id]
 

--- a/tests/test_dns_mocking.py
+++ b/tests/test_dns_mocking.py
@@ -27,3 +27,19 @@ async def test_mock_getaddrinfo_logic():
 
     res = socket.getaddrinfo("8.8.8.8", 80)
     assert res[0][4][0] == "1.1.1.1"
+
+
+def test_mock_getaddrinfo_af_unspec():
+    """Verify that AF_UNSPEC returns both IPv4 and IPv6 results."""
+    res = socket.getaddrinfo("example.com", 80, family=socket.AF_UNSPEC)
+    families = [r[0] for r in res]
+    assert socket.AF_INET in families
+    assert socket.AF_INET6 in families
+
+    ips = [r[4][0] for r in res]
+    assert "1.1.1.1" in ips
+    assert "2606:4700:4700::1111" in ips
+
+    res_local = socket.getaddrinfo("localhost", 80, family=socket.AF_UNSPEC)
+    local_ips = [r[4][0] for r in res_local]
+    assert any(ip in ("127.0.0.1", "::1") for ip in local_ips)

--- a/tests/test_dns_mocking.py
+++ b/tests/test_dns_mocking.py
@@ -1,0 +1,29 @@
+"""Tests for DNS mocking logic in tests/conftest.py."""
+
+import socket
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_mock_getaddrinfo_logic():
+    """Verify that DNS mocking correctly routes requests.
+
+    Requests to localhost or special-use TLDs should resolve to local IPs,
+    while other requests should be forced to the dummy public IP (1.1.1.1)
+    defined in tests/conftest.py for safety.
+    """
+    res = socket.getaddrinfo("example.com", 80)
+    assert res[0][4][0] == "1.1.1.1"
+
+    res = socket.getaddrinfo("localhost", 80)
+    assert res[0][4][0] in ("127.0.0.1", "::1", "127.0.0.2")
+
+    res = socket.getaddrinfo("test.home.arpa", 80)
+    assert res[0][4][0] == "127.0.0.2"
+
+    res = socket.getaddrinfo("127.0.0.1", 80)
+    assert res[0][4][0] == "127.0.0.1"
+
+    res = socket.getaddrinfo("8.8.8.8", 80)
+    assert res[0][4][0] == "1.1.1.1"

--- a/tests/ui/test_update.py
+++ b/tests/ui/test_update.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from custom_components.blueprints_updater.const import DOMAIN
+from custom_components.blueprints_updater.const import ALLOWED_RELOAD_DOMAINS, DOMAIN
 from custom_components.blueprints_updater.coordinator import BlueprintUpdateCoordinator
 from custom_components.blueprints_updater.update import (
     BlueprintUpdateEntity,
@@ -19,9 +19,7 @@ async def test_async_setup_entry_update(hass):
     config_entry.entry_id = "test_entry"
 
     coordinator = MagicMock()
-    coordinator._normalize_domain = lambda d: (
-        d if d in ["automation", "script", "template"] else "automation"
-    )
+    coordinator._normalize_domain = lambda d: d if d in ALLOWED_RELOAD_DOMAINS else "automation"
     data = {
         "automation/test.yaml": {
             "name": "Test BP",
@@ -48,9 +46,7 @@ async def test_async_setup_entry_update(hass):
 def test_update_entity_properties():
     """Test properties of BlueprintUpdateEntity."""
     coordinator = MagicMock()
-    coordinator._normalize_domain = lambda d: (
-        d if d in ["automation", "script", "template"] else "automation"
-    )
+    coordinator._normalize_domain = lambda d: d if d in ALLOWED_RELOAD_DOMAINS else "automation"
     coordinator.config_entry.entry_id = "test_entry"
     info = {
         "name": "Test BP",

--- a/tools/validate.py
+++ b/tools/validate.py
@@ -27,9 +27,9 @@ def run_pipeline() -> None:
         )
         sys.exit(1)
 
-    print("\n" + "=" * 40, flush=True)
+    print("=" * 40, flush=True)
     print("STARTING UNIFIED VALIDATION PIPELINE", flush=True)
-    print("=" * 40 + "\n", flush=True)
+    print("=" * 40, flush=True)
 
     try:
         print("\n>>> STEP: uv run ruff format", flush=True)

--- a/tools/validate.py
+++ b/tools/validate.py
@@ -45,8 +45,8 @@ def run_pipeline() -> None:
         print("\n>>> STEP: uv run interrogate")
         subprocess.run(["uv", "run", "interrogate"], check=True)
 
-        print("\n>>> STEP: npx prettier --write .")
-        subprocess.run(["npx", "prettier", "--write", "."], check=True)
+        print("\n>>> STEP: npx prettier --log-level warn --write .")
+        subprocess.run(["npx", "prettier", "--log-level", "warn", "--write", "."], check=True)
 
         print("\n>>> STEP: uv run pytest")
         subprocess.run(["uv", "run", "pytest"], check=True)

--- a/tools/validate.py
+++ b/tools/validate.py
@@ -21,37 +21,57 @@ def run_pipeline() -> None:
     the static nature of the commands being executed, avoiding dynamic
     variable execution in subprocess calls.
     """
+    # Set environment variables to disable color
+    os.environ["NO_COLOR"] = "1"
+
     if os.name != "posix":
-        print(
-            "Error: This script is only supported on POSIX systems (Linux, WSL, macOS)", flush=True
-        )
+        print("VALIDATION_ERROR: Non-POSIX environment detected", flush=True)
         sys.exit(1)
 
-    print("=" * 40, flush=True)
-    print("STARTING UNIFIED VALIDATION PIPELINE", flush=True)
-    print("=" * 40, flush=True)
+    print("VALIDATION_START", flush=True)
 
     try:
-        print("\n>>> STEP: uv run ruff format", flush=True)
-        subprocess.run(["uv", "run", "ruff", "format"], check=True)
+        # 1. Ruff Format
+        ruff_format = ["uv", "run", "ruff", "format"]
+        print(f"STEP_START: {' '.join(ruff_format)}", flush=True)
+        subprocess.run(ruff_format, check=True)
+        print(f"STEP_OK: {' '.join(ruff_format)}", flush=True)
 
-        print("\n>>> STEP: uv run ruff check --fix", flush=True)
-        subprocess.run(["uv", "run", "ruff", "check", "--fix"], check=True)
+        # 2. Ruff Check
+        ruff_check = ["uv", "run", "ruff", "check", "--fix"]
+        print(f"STEP_START: {' '.join(ruff_check)}", flush=True)
+        subprocess.run(ruff_check, check=True)
+        print(f"STEP_OK: {' '.join(ruff_check)}", flush=True)
 
-        print("\n>>> STEP: uv run ty check", flush=True)
-        subprocess.run(["uv", "run", "ty", "check"], check=True)
+        # 3. Ty Check
+        ty_check = ["uv", "run", "ty", "check"]
+        print(f"STEP_START: {' '.join(ty_check)}", flush=True)
+        subprocess.run(ty_check, check=True)
+        print(f"STEP_OK: {' '.join(ty_check)}", flush=True)
 
-        print("\n>>> STEP: uv run pyright", flush=True)
-        subprocess.run(["uv", "run", "pyright"], check=True)
+        # 4. Pyright
+        pyright = ["uv", "run", "pyright"]
+        print(f"STEP_START: {' '.join(pyright)}", flush=True)
+        subprocess.run(pyright, check=True)
+        print(f"STEP_OK: {' '.join(pyright)}", flush=True)
 
-        print("\n>>> STEP: uv run interrogate", flush=True)
-        subprocess.run(["uv", "run", "interrogate"], check=True)
+        # 5. Interrogate
+        interrogate = ["uv", "run", "interrogate"]
+        print(f"STEP_START: {' '.join(interrogate)}", flush=True)
+        subprocess.run(interrogate, check=True)
+        print(f"STEP_OK: {' '.join(interrogate)}", flush=True)
 
-        print("\n>>> STEP: npx prettier --log-level warn --write .", flush=True)
-        subprocess.run(["npx", "prettier", "--log-level", "warn", "--write", "."], check=True)
+        # 6. Prettier
+        prettier = ["npx", "prettier", "--log-level", "warn", "--write", "."]
+        print(f"STEP_START: {' '.join(prettier)}", flush=True)
+        subprocess.run(prettier, check=True)
+        print(f"STEP_OK: {' '.join(prettier)}", flush=True)
 
-        print("\n>>> STEP: uv run pytest", flush=True)
-        subprocess.run(["uv", "run", "pytest"], check=True)
+        # 7. Pytest
+        pytest = ["uv", "run", "pytest"]
+        print(f"STEP_START: {' '.join(pytest)}", flush=True)
+        subprocess.run(pytest, check=True)
+        print(f"STEP_OK: {' '.join(pytest)}", flush=True)
 
     except (subprocess.CalledProcessError, FileNotFoundError) as e:
         ret_code = getattr(e, "returncode", 1)
@@ -62,20 +82,15 @@ def run_pipeline() -> None:
                 if isinstance(cmd_val, (list, tuple))
                 else str(cmd_val)
             )
+            print(f"STEP_FAILED: {cmd_str} EXIT_CODE={ret_code}", flush=True)
+            print("VALIDATION_FAILED", flush=True)
         else:
             cmd_str = getattr(e, "filename", "Unknown command")
+            print(f"VALIDATION_ERROR: '{cmd_str}' not found.", flush=True)
 
-        print(f"\nFAILED: {cmd_str} (Exit code: {ret_code})", flush=True)
-        if isinstance(e, FileNotFoundError):
-            print(
-                f"Error: '{cmd_str}' not found. Please ensure all dependencies are installed.",
-                flush=True,
-            )
         sys.exit(ret_code)
 
-    print("\n" + "=" * 40, flush=True)
-    print("ALL VALIDATION STEPS PASSED SUCCESSFULLY", flush=True)
-    print("=" * 40 + "\n", flush=True)
+    print("VALIDATION_SUCCESS", flush=True)
 
 
 def main() -> None:
@@ -83,7 +98,7 @@ def main() -> None:
     try:
         run_pipeline()
     except KeyboardInterrupt:
-        print("\nValidation interrupted by user.", flush=True)
+        print("VALIDATION_INTERRUPTED", flush=True)
         sys.exit(1)
 
 

--- a/tools/validate.py
+++ b/tools/validate.py
@@ -21,57 +21,42 @@ def run_pipeline() -> None:
     the static nature of the commands being executed, avoiding dynamic
     variable execution in subprocess calls.
     """
-    # Set environment variables to disable color
     os.environ["NO_COLOR"] = "1"
+
+    print("VALIDATION_START", flush=True)
 
     if os.name != "posix":
         print("VALIDATION_ERROR: Non-POSIX environment detected", flush=True)
         sys.exit(1)
 
-    print("VALIDATION_START", flush=True)
-
     try:
-        # 1. Ruff Format
-        ruff_format = ["uv", "run", "ruff", "format"]
-        print(f"STEP_START: {' '.join(ruff_format)}", flush=True)
-        subprocess.run(ruff_format, check=True)
-        print(f"STEP_OK: {' '.join(ruff_format)}", flush=True)
+        print("STEP_START: uv run ruff format", flush=True)
+        subprocess.run(["uv", "run", "ruff", "format"], check=True)
+        print("STEP_OK: uv run ruff format", flush=True)
 
-        # 2. Ruff Check
-        ruff_check = ["uv", "run", "ruff", "check", "--fix"]
-        print(f"STEP_START: {' '.join(ruff_check)}", flush=True)
-        subprocess.run(ruff_check, check=True)
-        print(f"STEP_OK: {' '.join(ruff_check)}", flush=True)
+        print("STEP_START: uv run ruff check --fix", flush=True)
+        subprocess.run(["uv", "run", "ruff", "check", "--fix"], check=True)
+        print("STEP_OK: uv run ruff check --fix", flush=True)
 
-        # 3. Ty Check
-        ty_check = ["uv", "run", "ty", "check"]
-        print(f"STEP_START: {' '.join(ty_check)}", flush=True)
-        subprocess.run(ty_check, check=True)
-        print(f"STEP_OK: {' '.join(ty_check)}", flush=True)
+        print("STEP_START: uv run ty check", flush=True)
+        subprocess.run(["uv", "run", "ty", "check"], check=True)
+        print("STEP_OK: uv run ty check", flush=True)
 
-        # 4. Pyright
-        pyright = ["uv", "run", "pyright"]
-        print(f"STEP_START: {' '.join(pyright)}", flush=True)
-        subprocess.run(pyright, check=True)
-        print(f"STEP_OK: {' '.join(pyright)}", flush=True)
+        print("STEP_START: uv run pyright", flush=True)
+        subprocess.run(["uv", "run", "pyright"], check=True)
+        print("STEP_OK: uv run pyright", flush=True)
 
-        # 5. Interrogate
-        interrogate = ["uv", "run", "interrogate"]
-        print(f"STEP_START: {' '.join(interrogate)}", flush=True)
-        subprocess.run(interrogate, check=True)
-        print(f"STEP_OK: {' '.join(interrogate)}", flush=True)
+        print("STEP_START: uv run interrogate", flush=True)
+        subprocess.run(["uv", "run", "interrogate"], check=True)
+        print("STEP_OK: uv run interrogate", flush=True)
 
-        # 6. Prettier
-        prettier = ["npx", "prettier", "--log-level", "warn", "--write", "."]
-        print(f"STEP_START: {' '.join(prettier)}", flush=True)
-        subprocess.run(prettier, check=True)
-        print(f"STEP_OK: {' '.join(prettier)}", flush=True)
+        print("STEP_START: npx prettier --log-level warn --write .", flush=True)
+        subprocess.run(["npx", "prettier", "--log-level", "warn", "--write", "."], check=True)
+        print("STEP_OK: npx prettier --log-level warn --write .", flush=True)
 
-        # 7. Pytest
-        pytest = ["uv", "run", "pytest"]
-        print(f"STEP_START: {' '.join(pytest)}", flush=True)
-        subprocess.run(pytest, check=True)
-        print(f"STEP_OK: {' '.join(pytest)}", flush=True)
+        print("STEP_START: uv run pytest", flush=True)
+        subprocess.run(["uv", "run", "pytest"], check=True)
+        print("STEP_OK: uv run pytest", flush=True)
 
     except (subprocess.CalledProcessError, FileNotFoundError) as e:
         ret_code = getattr(e, "returncode", 1)

--- a/tools/validate.py
+++ b/tools/validate.py
@@ -27,6 +27,7 @@ def run_pipeline() -> None:
 
     if os.name != "posix":
         print("VALIDATION_ERROR: Non-POSIX environment detected", flush=True)
+        print("VALIDATION_FAILED", flush=True)
         sys.exit(1)
 
     try:
@@ -68,11 +69,11 @@ def run_pipeline() -> None:
                 else str(cmd_val)
             )
             print(f"STEP_FAILED: {cmd_str} EXIT_CODE={ret_code}", flush=True)
-            print("VALIDATION_FAILED", flush=True)
         else:
             cmd_str = getattr(e, "filename", "Unknown command")
             print(f"VALIDATION_ERROR: '{cmd_str}' not found.", flush=True)
 
+        print("VALIDATION_FAILED", flush=True)
         sys.exit(ret_code)
 
     print("VALIDATION_SUCCESS", flush=True)

--- a/tools/validate.py
+++ b/tools/validate.py
@@ -22,33 +22,35 @@ def run_pipeline() -> None:
     variable execution in subprocess calls.
     """
     if os.name != "posix":
-        print("Error: This script is only supported on POSIX systems (Linux, WSL, macOS).")
+        print(
+            "Error: This script is only supported on POSIX systems (Linux, WSL, macOS)", flush=True
+        )
         sys.exit(1)
 
-    print("\n" + "=" * 40)
-    print("STARTING UNIFIED VALIDATION PIPELINE")
-    print("=" * 40 + "\n")
+    print("\n" + "=" * 40, flush=True)
+    print("STARTING UNIFIED VALIDATION PIPELINE", flush=True)
+    print("=" * 40 + "\n", flush=True)
 
     try:
-        print("\n>>> STEP: uv run ruff format")
+        print("\n>>> STEP: uv run ruff format", flush=True)
         subprocess.run(["uv", "run", "ruff", "format"], check=True)
 
-        print("\n>>> STEP: uv run ruff check --fix")
+        print("\n>>> STEP: uv run ruff check --fix", flush=True)
         subprocess.run(["uv", "run", "ruff", "check", "--fix"], check=True)
 
-        print("\n>>> STEP: uv run ty check")
+        print("\n>>> STEP: uv run ty check", flush=True)
         subprocess.run(["uv", "run", "ty", "check"], check=True)
 
-        print("\n>>> STEP: uv run pyright")
+        print("\n>>> STEP: uv run pyright", flush=True)
         subprocess.run(["uv", "run", "pyright"], check=True)
 
-        print("\n>>> STEP: uv run interrogate")
+        print("\n>>> STEP: uv run interrogate", flush=True)
         subprocess.run(["uv", "run", "interrogate"], check=True)
 
-        print("\n>>> STEP: npx prettier --log-level warn --write .")
+        print("\n>>> STEP: npx prettier --log-level warn --write .", flush=True)
         subprocess.run(["npx", "prettier", "--log-level", "warn", "--write", "."], check=True)
 
-        print("\n>>> STEP: uv run pytest")
+        print("\n>>> STEP: uv run pytest", flush=True)
         subprocess.run(["uv", "run", "pytest"], check=True)
 
     except (subprocess.CalledProcessError, FileNotFoundError) as e:
@@ -63,14 +65,17 @@ def run_pipeline() -> None:
         else:
             cmd_str = getattr(e, "filename", "Unknown command")
 
-        print(f"\nFAILED: {cmd_str} (Exit code: {ret_code})")
+        print(f"\nFAILED: {cmd_str} (Exit code: {ret_code})", flush=True)
         if isinstance(e, FileNotFoundError):
-            print(f"Error: '{cmd_str}' not found. Please ensure all dependencies are installed.")
+            print(
+                f"Error: '{cmd_str}' not found. Please ensure all dependencies are installed.",
+                flush=True,
+            )
         sys.exit(ret_code)
 
-    print("\n" + "=" * 40)
-    print("ALL VALIDATION STEPS PASSED SUCCESSFULLY")
-    print("=" * 40 + "\n")
+    print("\n" + "=" * 40, flush=True)
+    print("ALL VALIDATION STEPS PASSED SUCCESSFULLY", flush=True)
+    print("=" * 40 + "\n", flush=True)
 
 
 def main() -> None:
@@ -78,7 +83,7 @@ def main() -> None:
     try:
         run_pipeline()
     except KeyboardInterrupt:
-        print("\nValidation interrupted by user.")
+        print("\nValidation interrupted by user.", flush=True)
         sys.exit(1)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -546,30 +546,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.43.5"
+version = "1.43.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/71/b0/90ba01763dd483bb040d0815dc0ba893421e3f5926672ceab9acbb73b23f/boto3-1.43.5.tar.gz", hash = "sha256:414be7868f25c3b6a0232301c8ab40347911b6b191926b61f00a63f89b97b2bc", size = 113150, upload-time = "2026-05-06T19:56:49.629Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/37/78c630d1308964aa9abf44951d9c4df776546ff37251ec2434944e205c4e/boto3-1.43.6.tar.gz", hash = "sha256:e6315effaf12b890b99956e6f8e2c3000a3f64e4ee91943cec3895ce9a836afb", size = 113153, upload-time = "2026-05-07T20:49:59.694Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/bb/347307758c2003783df1d9a9b07596928d05a6ca0e17790cea3b18105244/boto3-1.43.5-py3-none-any.whl", hash = "sha256:aa8a296c8db55d812767b282cfe4c7977f0b0eeaa709abdaeb368b9c738e901f", size = 140502, upload-time = "2026-05-06T19:56:46.626Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/e2/3c2eef44f55eafab256836d1d9479bd6a74f70c26cbfdc0639a0e23e4327/boto3-1.43.6-py3-none-any.whl", hash = "sha256:179601ec2992726a718053bf41e43c223ceba397d31ceab11f64d9c910d9fc3a", size = 140502, upload-time = "2026-05-07T20:49:57.8Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.43.5"
+version = "1.43.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/a2/1285a22bf157f9e97a8fd236daea95d9b14cc8425ae5f8a616badf948408/botocore-1.43.5.tar.gz", hash = "sha256:5c7207816ab5e48382adcb2a64db388fa4abe9ee1d23f72c82ae62c51a0bc84e", size = 15321290, upload-time = "2026-05-06T19:56:35.658Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/a7/23d0f5028011455096a1eeac0ddf3cbe147b3e855e127342f8202552194d/botocore-1.43.6.tar.gz", hash = "sha256:b1e395b347356860398da42e61c808cf1e34b6fa7180cf2b9d87d986e1a06ba0", size = 15336070, upload-time = "2026-05-07T20:49:48.14Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/d2/99f1741b12e3cdba2e5370f6dafaab743a373c6f83592601ec75ff2cc47f/botocore-1.43.5-py3-none-any.whl", hash = "sha256:a1df6e0c6346735936f42e6b99f3b28f1e9397731c0bc2563c617df7965a0dc0", size = 15002116, upload-time = "2026-05-06T19:56:29.993Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/c8/6f47223840e8d8cfa8c9f7c0ec1b77970417f257fc885169ff4f6326ce09/botocore-1.43.6-py3-none-any.whl", hash = "sha256:b6d1fdbc6f65a5fe0b7e947823aa37535d3f39f3ba4d21110fab1f55bbbcc04b", size = 15017094, upload-time = "2026-05-07T20:49:44.964Z" },
 ]
 
 [[package]]
@@ -1354,14 +1354,14 @@ wheels = [
 
 [[package]]
 name = "mashumaro"
-version = "3.20"
+version = "3.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/64/3d/0f1bf475109a816c2a31a8b424750911343f0bce304827a5255df167547e/mashumaro-3.20.tar.gz", hash = "sha256:af4573f14ae61be3fbc3a473158ddfc1420f345410385809fd782e0d79e9215c", size = 191643, upload-time = "2026-02-09T21:53:55.24Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/61/bdbd92fd7684f31fe18982f5a3b9a6ab672ae81a7f52b8aceecb56143430/mashumaro-3.21.tar.gz", hash = "sha256:9bc53b0c7dbed0be80e3ccc3efe1d621ce146b4b7a673ec41ba001a417f2c4b4", size = 195595, upload-time = "2026-05-07T16:32:35.809Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/5a/4fed77781061647d3be98e2f235ef1869289dd839ca0451a8d50a30fcd5c/mashumaro-3.20-py3-none-any.whl", hash = "sha256:648bc326f64c55447988eab67d6bfe3b7958c0961c83590709b1f950f88f4a3c", size = 94942, upload-time = "2026-02-09T21:53:53.343Z" },
+    { url = "https://files.pythonhosted.org/packages/46/2e/d6a3410c11ac71e6031d7779d20700b43866e8166d56be86cf8bfcbb15de/mashumaro-3.21-py3-none-any.whl", hash = "sha256:b8e11e259a77d1c6e277c17909381448750956acee1eb79014b06704a10053d6", size = 95250, upload-time = "2026-05-07T16:32:34.341Z" },
 ]
 
 [[package]]
@@ -2579,11 +2579,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -248,6 +248,15 @@ wheels = [
 ]
 
 [[package]]
+name = "astroid"
+version = "4.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/63/0adf26577da5eff6eb7a177876c1cfa213856be9926a000f65c4add9692b/astroid-4.0.4.tar.gz", hash = "sha256:986fed8bcf79fb82c78b18a53352a0b287a73817d6dbcfba3162da36667c49a0", size = 406358, upload-time = "2026-02-07T23:35:07.509Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/cf/1c5f42b110e57bc5502eb80dbc3b03d256926062519224835ef08134f1f9/astroid-4.0.4-py3-none-any.whl", hash = "sha256:52f39653876c7dec3e3afd4c2696920e05c83832b9737afc21928f2d2eb7a753", size = 276445, upload-time = "2026-02-07T23:35:05.344Z" },
+]
+
+[[package]]
 name = "async-interrupt"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -267,35 +276,51 @@ wheels = [
 
 [[package]]
 name = "attrs"
-version = "25.4.0"
+version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11", size = 934251, upload-time = "2025-10-06T13:54:44.725Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373", size = 67615, upload-time = "2025-10-06T13:54:43.17Z" },
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
 ]
 
 [[package]]
 name = "audioop-lts"
-version = "0.2.1"
+version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/dd/3b/69ff8a885e4c1c42014c2765275c4bd91fe7bc9847e9d8543dbcbb09f820/audioop_lts-0.2.1.tar.gz", hash = "sha256:e81268da0baa880431b68b1308ab7257eb33f356e57a5f9b1f915dfb13dd1387", size = 30204, upload-time = "2024-08-04T21:14:43.957Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/53/946db57842a50b2da2e0c1e34bd37f36f5aadba1a929a3971c5d7841dbca/audioop_lts-0.2.2.tar.gz", hash = "sha256:64d0c62d88e67b98a1a5e71987b7aa7b5bcffc7dcee65b635823dbdd0a8dbbd0", size = 30686, upload-time = "2025-08-05T16:43:17.409Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/91/a219253cc6e92db2ebeaf5cf8197f71d995df6f6b16091d1f3ce62cb169d/audioop_lts-0.2.1-cp313-abi3-macosx_10_13_universal2.whl", hash = "sha256:fd1345ae99e17e6910f47ce7d52673c6a1a70820d78b67de1b7abb3af29c426a", size = 46252, upload-time = "2024-08-04T21:13:56.209Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/f6/3cb21e0accd9e112d27cee3b1477cd04dafe88675c54ad8b0d56226c1e0b/audioop_lts-0.2.1-cp313-abi3-macosx_10_13_x86_64.whl", hash = "sha256:e175350da05d2087e12cea8e72a70a1a8b14a17e92ed2022952a4419689ede5e", size = 27183, upload-time = "2024-08-04T21:13:59.966Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/7e/f94c8a6a8b2571694375b4cf94d3e5e0f529e8e6ba280fad4d8c70621f27/audioop_lts-0.2.1-cp313-abi3-macosx_11_0_arm64.whl", hash = "sha256:4a8dd6a81770f6ecf019c4b6d659e000dc26571b273953cef7cd1d5ce2ff3ae6", size = 26726, upload-time = "2024-08-04T21:14:00.846Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/f8/a0e8e7a033b03fae2b16bc5aa48100b461c4f3a8a38af56d5ad579924a3a/audioop_lts-0.2.1-cp313-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d1cd3c0b6f2ca25c7d2b1c3adeecbe23e65689839ba73331ebc7d893fcda7ffe", size = 80718, upload-time = "2024-08-04T21:14:01.989Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/ea/a98ebd4ed631c93b8b8f2368862cd8084d75c77a697248c24437c36a6f7e/audioop_lts-0.2.1-cp313-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ff3f97b3372c97782e9c6d3d7fdbe83bce8f70de719605bd7ee1839cd1ab360a", size = 88326, upload-time = "2024-08-04T21:14:03.509Z" },
-    { url = "https://files.pythonhosted.org/packages/33/79/e97a9f9daac0982aa92db1199339bd393594d9a4196ad95ae088635a105f/audioop_lts-0.2.1-cp313-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a351af79edefc2a1bd2234bfd8b339935f389209943043913a919df4b0f13300", size = 80539, upload-time = "2024-08-04T21:14:04.679Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/d3/1051d80e6f2d6f4773f90c07e73743a1e19fcd31af58ff4e8ef0375d3a80/audioop_lts-0.2.1-cp313-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2aeb6f96f7f6da80354330470b9134d81b4cf544cdd1c549f2f45fe964d28059", size = 78577, upload-time = "2024-08-04T21:14:09.038Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/1d/54f4c58bae8dc8c64a75071c7e98e105ddaca35449376fcb0180f6e3c9df/audioop_lts-0.2.1-cp313-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c589f06407e8340e81962575fcffbba1e92671879a221186c3d4662de9fe804e", size = 82074, upload-time = "2024-08-04T21:14:09.99Z" },
-    { url = "https://files.pythonhosted.org/packages/36/89/2e78daa7cebbea57e72c0e1927413be4db675548a537cfba6a19040d52fa/audioop_lts-0.2.1-cp313-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fbae5d6925d7c26e712f0beda5ed69ebb40e14212c185d129b8dfbfcc335eb48", size = 84210, upload-time = "2024-08-04T21:14:11.468Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/57/3ff8a74df2ec2fa6d2ae06ac86e4a27d6412dbb7d0e0d41024222744c7e0/audioop_lts-0.2.1-cp313-abi3-musllinux_1_2_i686.whl", hash = "sha256:d2d5434717f33117f29b5691fbdf142d36573d751716249a288fbb96ba26a281", size = 85664, upload-time = "2024-08-04T21:14:12.394Z" },
-    { url = "https://files.pythonhosted.org/packages/16/01/21cc4e5878f6edbc8e54be4c108d7cb9cb6202313cfe98e4ece6064580dd/audioop_lts-0.2.1-cp313-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:f626a01c0a186b08f7ff61431c01c055961ee28769591efa8800beadd27a2959", size = 93255, upload-time = "2024-08-04T21:14:13.707Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/28/7f7418c362a899ac3b0bf13b1fde2d4ffccfdeb6a859abd26f2d142a1d58/audioop_lts-0.2.1-cp313-abi3-musllinux_1_2_s390x.whl", hash = "sha256:05da64e73837f88ee5c6217d732d2584cf638003ac72df124740460531e95e47", size = 87760, upload-time = "2024-08-04T21:14:14.74Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/d8/577a8be87dc7dd2ba568895045cee7d32e81d85a7e44a29000fe02c4d9d4/audioop_lts-0.2.1-cp313-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:56b7a0a4dba8e353436f31a932f3045d108a67b5943b30f85a5563f4d8488d77", size = 84992, upload-time = "2024-08-04T21:14:19.155Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/9a/4699b0c4fcf89936d2bfb5425f55f1a8b86dff4237cfcc104946c9cd9858/audioop_lts-0.2.1-cp313-abi3-win32.whl", hash = "sha256:6e899eb8874dc2413b11926b5fb3857ec0ab55222840e38016a6ba2ea9b7d5e3", size = 26059, upload-time = "2024-08-04T21:14:20.438Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/1c/1f88e9c5dd4785a547ce5fd1eb83fff832c00cc0e15c04c1119b02582d06/audioop_lts-0.2.1-cp313-abi3-win_amd64.whl", hash = "sha256:64562c5c771fb0a8b6262829b9b4f37a7b886c01b4d3ecdbae1d629717db08b4", size = 30412, upload-time = "2024-08-04T21:14:21.342Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/e9/c123fd29d89a6402ad261516f848437472ccc602abb59bba522af45e281b/audioop_lts-0.2.1-cp313-abi3-win_arm64.whl", hash = "sha256:c45317debeb64002e980077642afbd977773a25fa3dfd7ed0c84dccfc1fafcb0", size = 23578, upload-time = "2024-08-04T21:14:22.193Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d4/94d277ca941de5a507b07f0b592f199c22454eeaec8f008a286b3fbbacd6/audioop_lts-0.2.2-cp313-abi3-macosx_10_13_universal2.whl", hash = "sha256:fd3d4602dc64914d462924a08c1a9816435a2155d74f325853c1f1ac3b2d9800", size = 46523, upload-time = "2025-08-05T16:42:20.836Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/5a/656d1c2da4b555920ce4177167bfeb8623d98765594af59702c8873f60ec/audioop_lts-0.2.2-cp313-abi3-macosx_10_13_x86_64.whl", hash = "sha256:550c114a8df0aafe9a05442a1162dfc8fec37e9af1d625ae6060fed6e756f303", size = 27455, upload-time = "2025-08-05T16:42:22.283Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/83/ea581e364ce7b0d41456fb79d6ee0ad482beda61faf0cab20cbd4c63a541/audioop_lts-0.2.2-cp313-abi3-macosx_11_0_arm64.whl", hash = "sha256:9a13dc409f2564de15dd68be65b462ba0dde01b19663720c68c1140c782d1d75", size = 26997, upload-time = "2025-08-05T16:42:23.849Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/3b/e8964210b5e216e5041593b7d33e97ee65967f17c282e8510d19c666dab4/audioop_lts-0.2.2-cp313-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:51c916108c56aa6e426ce611946f901badac950ee2ddaf302b7ed35d9958970d", size = 85844, upload-time = "2025-08-05T16:42:25.208Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/2e/0a1c52faf10d51def20531a59ce4c706cb7952323b11709e10de324d6493/audioop_lts-0.2.2-cp313-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:47eba38322370347b1c47024defbd36374a211e8dd5b0dcbce7b34fdb6f8847b", size = 85056, upload-time = "2025-08-05T16:42:26.559Z" },
+    { url = "https://files.pythonhosted.org/packages/75/e8/cd95eef479656cb75ab05dfece8c1f8c395d17a7c651d88f8e6e291a63ab/audioop_lts-0.2.2-cp313-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ba7c3a7e5f23e215cb271516197030c32aef2e754252c4c70a50aaff7031a2c8", size = 93892, upload-time = "2025-08-05T16:42:27.902Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/1e/a0c42570b74f83efa5cca34905b3eef03f7ab09fe5637015df538a7f3345/audioop_lts-0.2.2-cp313-abi3-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:def246fe9e180626731b26e89816e79aae2276f825420a07b4a647abaa84becc", size = 96660, upload-time = "2025-08-05T16:42:28.9Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d5/8a0ae607ca07dbb34027bac8db805498ee7bfecc05fd2c148cc1ed7646e7/audioop_lts-0.2.2-cp313-abi3-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e160bf9df356d841bb6c180eeeea1834085464626dc1b68fa4e1d59070affdc3", size = 79143, upload-time = "2025-08-05T16:42:29.929Z" },
+    { url = "https://files.pythonhosted.org/packages/12/17/0d28c46179e7910bfb0bb62760ccb33edb5de973052cb2230b662c14ca2e/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4b4cd51a57b698b2d06cb9993b7ac8dfe89a3b2878e96bc7948e9f19ff51dba6", size = 84313, upload-time = "2025-08-05T16:42:30.949Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ba/bd5d3806641564f2024e97ca98ea8f8811d4e01d9b9f9831474bc9e14f9e/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:4a53aa7c16a60a6857e6b0b165261436396ef7293f8b5c9c828a3a203147ed4a", size = 93044, upload-time = "2025-08-05T16:42:31.959Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/5e/435ce8d5642f1f7679540d1e73c1c42d933331c0976eb397d1717d7f01a3/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:3fc38008969796f0f689f1453722a0f463da1b8a6fbee11987830bfbb664f623", size = 78766, upload-time = "2025-08-05T16:42:33.302Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3b/b909e76b606cbfd53875693ec8c156e93e15a1366a012f0b7e4fb52d3c34/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_s390x.whl", hash = "sha256:15ab25dd3e620790f40e9ead897f91e79c0d3ce65fe193c8ed6c26cffdd24be7", size = 87640, upload-time = "2025-08-05T16:42:34.854Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e7/8f1603b4572d79b775f2140d7952f200f5e6c62904585d08a01f0a70393a/audioop_lts-0.2.2-cp313-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:03f061a1915538fd96272bac9551841859dbb2e3bf73ebe4a23ef043766f5449", size = 86052, upload-time = "2025-08-05T16:42:35.839Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/96/c37846df657ccdda62ba1ae2b6534fa90e2e1b1742ca8dcf8ebd38c53801/audioop_lts-0.2.2-cp313-abi3-win32.whl", hash = "sha256:3bcddaaf6cc5935a300a8387c99f7a7fbbe212a11568ec6cf6e4bc458c048636", size = 26185, upload-time = "2025-08-05T16:42:37.04Z" },
+    { url = "https://files.pythonhosted.org/packages/34/a5/9d78fdb5b844a83da8a71226c7bdae7cc638861085fff7a1d707cb4823fa/audioop_lts-0.2.2-cp313-abi3-win_amd64.whl", hash = "sha256:a2c2a947fae7d1062ef08c4e369e0ba2086049a5e598fda41122535557012e9e", size = 30503, upload-time = "2025-08-05T16:42:38.427Z" },
+    { url = "https://files.pythonhosted.org/packages/34/25/20d8fde083123e90c61b51afb547bb0ea7e77bab50d98c0ab243d02a0e43/audioop_lts-0.2.2-cp313-abi3-win_arm64.whl", hash = "sha256:5f93a5db13927a37d2d09637ccca4b2b6b48c19cd9eda7b17a2e9f77edee6a6f", size = 24173, upload-time = "2025-08-05T16:42:39.704Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/73/413b5a2804091e2c7d5def1d618e4837f1cb82464e230f827226278556b7/audioop_lts-0.2.2-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:f9ee9b52f5f857fbaf9d605a360884f034c92c1c23021fb90b2e39b8e64bede6", size = 47104, upload-time = "2025-08-05T16:42:58.518Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8c/daa3308dc6593944410c2c68306a5e217f5c05b70a12e70228e7dd42dc5c/audioop_lts-0.2.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:49ee1a41738a23e98d98b937a0638357a2477bc99e61b0f768a8f654f45d9b7a", size = 27754, upload-time = "2025-08-05T16:43:00.132Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/86/c2e0f627168fcf61781a8f72cab06b228fe1da4b9fa4ab39cfb791b5836b/audioop_lts-0.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5b00be98ccd0fc123dcfad31d50030d25fcf31488cde9e61692029cd7394733b", size = 27332, upload-time = "2025-08-05T16:43:01.666Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/bd/35dce665255434f54e5307de39e31912a6f902d4572da7c37582809de14f/audioop_lts-0.2.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a6d2e0f9f7a69403e388894d4ca5ada5c47230716a03f2847cfc7bd1ecb589d6", size = 92396, upload-time = "2025-08-05T16:43:02.991Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/d2/deeb9f51def1437b3afa35aeb729d577c04bcd89394cb56f9239a9f50b6f/audioop_lts-0.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f9b0b8a03ef474f56d1a842af1a2e01398b8f7654009823c6d9e0ecff4d5cfbf", size = 91811, upload-time = "2025-08-05T16:43:04.096Z" },
+    { url = "https://files.pythonhosted.org/packages/76/3b/09f8b35b227cee28cc8231e296a82759ed80c1a08e349811d69773c48426/audioop_lts-0.2.2-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2b267b70747d82125f1a021506565bdc5609a2b24bcb4773c16d79d2bb260bbd", size = 100483, upload-time = "2025-08-05T16:43:05.085Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/15/05b48a935cf3b130c248bfdbdea71ce6437f5394ee8533e0edd7cfd93d5e/audioop_lts-0.2.2-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0337d658f9b81f4cd0fdb1f47635070cc084871a3d4646d9de74fdf4e7c3d24a", size = 103885, upload-time = "2025-08-05T16:43:06.197Z" },
+    { url = "https://files.pythonhosted.org/packages/83/80/186b7fce6d35b68d3d739f228dc31d60b3412105854edb975aa155a58339/audioop_lts-0.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:167d3b62586faef8b6b2275c3218796b12621a60e43f7e9d5845d627b9c9b80e", size = 84899, upload-time = "2025-08-05T16:43:07.291Z" },
+    { url = "https://files.pythonhosted.org/packages/49/89/c78cc5ac6cb5828f17514fb12966e299c850bc885e80f8ad94e38d450886/audioop_lts-0.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0d9385e96f9f6da847f4d571ce3cb15b5091140edf3db97276872647ce37efd7", size = 89998, upload-time = "2025-08-05T16:43:08.335Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/4b/6401888d0c010e586c2ca50fce4c903d70a6bb55928b16cfbdfd957a13da/audioop_lts-0.2.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:48159d96962674eccdca9a3df280e864e8ac75e40a577cc97c5c42667ffabfc5", size = 99046, upload-time = "2025-08-05T16:43:09.367Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f8/c874ca9bb447dae0e2ef2e231f6c4c2b0c39e31ae684d2420b0f9e97ee68/audioop_lts-0.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:8fefe5868cd082db1186f2837d64cfbfa78b548ea0d0543e9b28935ccce81ce9", size = 84843, upload-time = "2025-08-05T16:43:10.749Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/c0/0323e66f3daebc13fd46b36b30c3be47e3fc4257eae44f1e77eb828c703f/audioop_lts-0.2.2-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:58cf54380c3884fb49fdd37dfb7a772632b6701d28edd3e2904743c5e1773602", size = 94490, upload-time = "2025-08-05T16:43:12.131Z" },
+    { url = "https://files.pythonhosted.org/packages/98/6b/acc7734ac02d95ab791c10c3f17ffa3584ccb9ac5c18fd771c638ed6d1f5/audioop_lts-0.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:088327f00488cdeed296edd9215ca159f3a5a5034741465789cad403fcf4bec0", size = 92297, upload-time = "2025-08-05T16:43:13.139Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c3/c3dc3f564ce6877ecd2a05f8d751b9b27a8c320c2533a98b0c86349778d0/audioop_lts-0.2.2-cp314-cp314t-win32.whl", hash = "sha256:068aa17a38b4e0e7de771c62c60bbca2455924b67a8814f3b0dee92b5820c0b3", size = 27331, upload-time = "2025-08-05T16:43:14.19Z" },
+    { url = "https://files.pythonhosted.org/packages/72/bb/b4608537e9ffcb86449091939d52d24a055216a36a8bf66b936af8c3e7ac/audioop_lts-0.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:a5bf613e96f49712073de86f20dbdd4014ca18efd4d34ed18c75bd808337851b", size = 31697, upload-time = "2025-08-05T16:43:15.193Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/22/91616fe707a5c5510de2cac9b046a30defe7007ba8a0c04f9c08f27df312/audioop_lts-0.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:b492c3b040153e68b9fdaff5913305aaaba5bb433d8a7f73d5cf6a64ed3cc1dd", size = 25206, upload-time = "2025-08-05T16:43:16.444Z" },
 ]
 
 [[package]]
@@ -433,7 +458,7 @@ dev = [
 [package.metadata.requires-dev]
 dev = [
     { name = "h2", specifier = ">=4,<5" },
-    { name = "homeassistant", specifier = ">=2026.4" },
+    { name = "homeassistant", specifier = ">=2026.5.0" },
     { name = "interrogate" },
     { name = "packaging" },
     { name = "prek" },
@@ -521,30 +546,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.43.4"
+version = "1.43.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/17/04/f391b6e5b607bc00b633e3f18932bf1ef7b92e9a03f8fcc5bb09a561234b/boto3-1.43.4.tar.gz", hash = "sha256:00f40e9ca704c0f860b70ef47b042813c8d9a66b3d5e7bf81d578f79ae17dcd3", size = 113174, upload-time = "2026-05-05T19:34:37.859Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/b0/90ba01763dd483bb040d0815dc0ba893421e3f5926672ceab9acbb73b23f/boto3-1.43.5.tar.gz", hash = "sha256:414be7868f25c3b6a0232301c8ab40347911b6b191926b61f00a63f89b97b2bc", size = 113150, upload-time = "2026-05-06T19:56:49.629Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/85/b25499be693449df63c2c91e4e966ee81e46eb86071747e699f458583ebc/boto3-1.43.4-py3-none-any.whl", hash = "sha256:c4910b54c1f2401ab55d9fbca3d92df0a68e4ac64a69f2bab47a079e384a9d4f", size = 140502, upload-time = "2026-05-05T19:34:36.356Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bb/347307758c2003783df1d9a9b07596928d05a6ca0e17790cea3b18105244/boto3-1.43.5-py3-none-any.whl", hash = "sha256:aa8a296c8db55d812767b282cfe4c7977f0b0eeaa709abdaeb368b9c738e901f", size = 140502, upload-time = "2026-05-06T19:56:46.626Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.43.4"
+version = "1.43.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/45/f73f2a126752ed4c762a46210315c80cb7e67a96887aaa2f9c32d41631c6/botocore-1.43.4.tar.gz", hash = "sha256:1a95c90fa9ca6ee85c1a02b04c8e05e948661d201b85b443000d676857905019", size = 15317239, upload-time = "2026-05-05T19:34:27.317Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/a2/1285a22bf157f9e97a8fd236daea95d9b14cc8425ae5f8a616badf948408/botocore-1.43.5.tar.gz", hash = "sha256:5c7207816ab5e48382adcb2a64db388fa4abe9ee1d23f72c82ae62c51a0bc84e", size = 15321290, upload-time = "2026-05-06T19:56:35.658Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/53/8dfb1f8f0be68cce735181d876d8f7c537c5c44656b3b9ab4b3b9e973320/botocore-1.43.4-py3-none-any.whl", hash = "sha256:f1897d3254965cacac7514cfed1b6ff016166b165ee2e06232b4a3954cf9d713", size = 14999193, upload-time = "2026-05-05T19:34:23.893Z" },
+    { url = "https://files.pythonhosted.org/packages/82/d2/99f1741b12e3cdba2e5370f6dafaab743a373c6f83592601ec75ff2cc47f/botocore-1.43.5-py3-none-any.whl", hash = "sha256:a1df6e0c6346735936f42e6b99f3b28f1e9397731c0bc2563c617df7965a0dc0", size = 15002116, upload-time = "2026-05-06T19:56:29.993Z" },
 ]
 
 [[package]]
@@ -678,33 +703,41 @@ wheels = [
 
 [[package]]
 name = "coverage"
-version = "7.10.6"
+version = "7.13.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/14/70/025b179c993f019105b79575ac6edb5e084fb0f0e63f15cdebef4e454fb5/coverage-7.10.6.tar.gz", hash = "sha256:f644a3ae5933a552a29dbb9aa2f90c677a875f80ebea028e5a52a4f429044b90", size = 823736, upload-time = "2025-08-29T15:35:16.668Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e0/70553e3000e345daff267cec284ce4cbf3fc141b6da229ac52775b5428f1/coverage-7.13.5.tar.gz", hash = "sha256:c81f6515c4c40141f83f502b07bbfa5c240ba25bbe73da7b33f1e5b6120ff179", size = 915967, upload-time = "2026-03-17T10:33:18.341Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/aa/76cf0b5ec00619ef208da4689281d48b57f2c7fde883d14bf9441b74d59f/coverage-7.10.6-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:6008a021907be8c4c02f37cdc3ffb258493bdebfeaf9a839f9e71dfdc47b018e", size = 217331, upload-time = "2025-08-29T15:34:20.846Z" },
-    { url = "https://files.pythonhosted.org/packages/65/91/8e41b8c7c505d398d7730206f3cbb4a875a35ca1041efc518051bfce0f6b/coverage-7.10.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5e75e37f23eb144e78940b40395b42f2321951206a4f50e23cfd6e8a198d3ceb", size = 217607, upload-time = "2025-08-29T15:34:22.433Z" },
-    { url = "https://files.pythonhosted.org/packages/87/7f/f718e732a423d442e6616580a951b8d1ec3575ea48bcd0e2228386805e79/coverage-7.10.6-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:0f7cb359a448e043c576f0da00aa8bfd796a01b06aa610ca453d4dde09cc1034", size = 248663, upload-time = "2025-08-29T15:34:24.425Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/52/c1106120e6d801ac03e12b5285e971e758e925b6f82ee9b86db3aa10045d/coverage-7.10.6-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c68018e4fc4e14b5668f1353b41ccf4bc83ba355f0e1b3836861c6f042d89ac1", size = 251197, upload-time = "2025-08-29T15:34:25.906Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/ec/3a8645b1bb40e36acde9c0609f08942852a4af91a937fe2c129a38f2d3f5/coverage-7.10.6-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cd4b2b0707fc55afa160cd5fc33b27ccbf75ca11d81f4ec9863d5793fc6df56a", size = 252551, upload-time = "2025-08-29T15:34:27.337Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/70/09ecb68eeb1155b28a1d16525fd3a9b65fbe75337311a99830df935d62b6/coverage-7.10.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4cec13817a651f8804a86e4f79d815b3b28472c910e099e4d5a0e8a3b6a1d4cb", size = 250553, upload-time = "2025-08-29T15:34:29.065Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/80/47df374b893fa812e953b5bc93dcb1427a7b3d7a1a7d2db33043d17f74b9/coverage-7.10.6-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:f2a6a8e06bbda06f78739f40bfb56c45d14eb8249d0f0ea6d4b3d48e1f7c695d", size = 248486, upload-time = "2025-08-29T15:34:30.897Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/65/9f98640979ecee1b0d1a7164b589de720ddf8100d1747d9bbdb84be0c0fb/coverage-7.10.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:081b98395ced0d9bcf60ada7661a0b75f36b78b9d7e39ea0790bb4ed8da14747", size = 249981, upload-time = "2025-08-29T15:34:32.365Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/55/eeb6603371e6629037f47bd25bef300387257ed53a3c5fdb159b7ac8c651/coverage-7.10.6-cp314-cp314-win32.whl", hash = "sha256:6937347c5d7d069ee776b2bf4e1212f912a9f1f141a429c475e6089462fcecc5", size = 220054, upload-time = "2025-08-29T15:34:34.124Z" },
-    { url = "https://files.pythonhosted.org/packages/15/d1/a0912b7611bc35412e919a2cd59ae98e7ea3b475e562668040a43fb27897/coverage-7.10.6-cp314-cp314-win_amd64.whl", hash = "sha256:adec1d980fa07e60b6ef865f9e5410ba760e4e1d26f60f7e5772c73b9a5b0713", size = 220851, upload-time = "2025-08-29T15:34:35.651Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/2d/11880bb8ef80a45338e0b3e0725e4c2d73ffbb4822c29d987078224fd6a5/coverage-7.10.6-cp314-cp314-win_arm64.whl", hash = "sha256:a80f7aef9535442bdcf562e5a0d5a5538ce8abe6bb209cfbf170c462ac2c2a32", size = 219429, upload-time = "2025-08-29T15:34:37.16Z" },
-    { url = "https://files.pythonhosted.org/packages/83/c0/1f00caad775c03a700146f55536ecd097a881ff08d310a58b353a1421be0/coverage-7.10.6-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:0de434f4fbbe5af4fa7989521c655c8c779afb61c53ab561b64dcee6149e4c65", size = 218080, upload-time = "2025-08-29T15:34:38.919Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/c4/b1c5d2bd7cc412cbeb035e257fd06ed4e3e139ac871d16a07434e145d18d/coverage-7.10.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6e31b8155150c57e5ac43ccd289d079eb3f825187d7c66e755a055d2c85794c6", size = 218293, upload-time = "2025-08-29T15:34:40.425Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/07/4468d37c94724bf6ec354e4ec2f205fda194343e3e85fd2e59cec57e6a54/coverage-7.10.6-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:98cede73eb83c31e2118ae8d379c12e3e42736903a8afcca92a7218e1f2903b0", size = 259800, upload-time = "2025-08-29T15:34:41.996Z" },
-    { url = "https://files.pythonhosted.org/packages/82/d8/f8fb351be5fee31690cd8da768fd62f1cfab33c31d9f7baba6cd8960f6b8/coverage-7.10.6-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f863c08f4ff6b64fa8045b1e3da480f5374779ef187f07b82e0538c68cb4ff8e", size = 261965, upload-time = "2025-08-29T15:34:43.61Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/70/65d4d7cfc75c5c6eb2fed3ee5cdf420fd8ae09c4808723a89a81d5b1b9c3/coverage-7.10.6-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b38261034fda87be356f2c3f42221fdb4171c3ce7658066ae449241485390d5", size = 264220, upload-time = "2025-08-29T15:34:45.387Z" },
-    { url = "https://files.pythonhosted.org/packages/98/3c/069df106d19024324cde10e4ec379fe2fb978017d25e97ebee23002fbadf/coverage-7.10.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0e93b1476b79eae849dc3872faeb0bf7948fd9ea34869590bc16a2a00b9c82a7", size = 261660, upload-time = "2025-08-29T15:34:47.288Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/8a/2974d53904080c5dc91af798b3a54a4ccb99a45595cc0dcec6eb9616a57d/coverage-7.10.6-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:ff8a991f70f4c0cf53088abf1e3886edcc87d53004c7bb94e78650b4d3dac3b5", size = 259417, upload-time = "2025-08-29T15:34:48.779Z" },
-    { url = "https://files.pythonhosted.org/packages/30/38/9616a6b49c686394b318974d7f6e08f38b8af2270ce7488e879888d1e5db/coverage-7.10.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ac765b026c9f33044419cbba1da913cfb82cca1b60598ac1c7a5ed6aac4621a0", size = 260567, upload-time = "2025-08-29T15:34:50.718Z" },
-    { url = "https://files.pythonhosted.org/packages/76/16/3ed2d6312b371a8cf804abf4e14895b70e4c3491c6e53536d63fd0958a8d/coverage-7.10.6-cp314-cp314t-win32.whl", hash = "sha256:441c357d55f4936875636ef2cfb3bee36e466dcf50df9afbd398ce79dba1ebb7", size = 220831, upload-time = "2025-08-29T15:34:52.653Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/e5/d38d0cb830abede2adb8b147770d2a3d0e7fecc7228245b9b1ae6c24930a/coverage-7.10.6-cp314-cp314t-win_amd64.whl", hash = "sha256:073711de3181b2e204e4870ac83a7c4853115b42e9cd4d145f2231e12d670930", size = 221950, upload-time = "2025-08-29T15:34:54.212Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/51/e48e550f6279349895b0ffcd6d2a690e3131ba3a7f4eafccc141966d4dea/coverage-7.10.6-cp314-cp314t-win_arm64.whl", hash = "sha256:137921f2bac5559334ba66122b753db6dc5d1cf01eb7b64eb412bb0d064ef35b", size = 219969, upload-time = "2025-08-29T15:34:55.83Z" },
-    { url = "https://files.pythonhosted.org/packages/44/0c/50db5379b615854b5cf89146f8f5bd1d5a9693d7f3a987e269693521c404/coverage-7.10.6-py3-none-any.whl", hash = "sha256:92c4ecf6bf11b2e85fd4d8204814dc26e6a19f0c9d938c207c5cb0eadfcabbe3", size = 208986, upload-time = "2025-08-29T15:35:14.506Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/77/39703f0d1d4b478bfd30191d3c14f53caf596fac00efb3f8f6ee23646439/coverage-7.13.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fbabfaceaeb587e16f7008f7795cd80d20ec548dc7f94fbb0d4ec2e038ce563f", size = 219621, upload-time = "2026-03-17T10:32:08.589Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/3e/51dff36d99ae14639a133d9b164d63e628532e2974d8b1edb99dd1ebc733/coverage-7.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9bb2a28101a443669a423b665939381084412b81c3f8c0fcfbac57f4e30b5b8e", size = 219953, upload-time = "2026-03-17T10:32:10.507Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6c/1f1917b01eb647c2f2adc9962bd66c79eb978951cab61bdc1acab3290c07/coverage-7.13.5-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bd3a2fbc1c6cccb3c5106140d87cc6a8715110373ef42b63cf5aea29df8c217a", size = 250992, upload-time = "2026-03-17T10:32:12.41Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e5/06b1f88f42a5a99df42ce61208bdec3bddb3d261412874280a19796fc09c/coverage-7.13.5-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6c36ddb64ed9d7e496028d1d00dfec3e428e0aabf4006583bb1839958d280510", size = 253503, upload-time = "2026-03-17T10:32:14.449Z" },
+    { url = "https://files.pythonhosted.org/packages/80/28/2a148a51e5907e504fa7b85490277734e6771d8844ebcc48764a15e28155/coverage-7.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:380e8e9084d8eb38db3a9176a1a4f3c0082c3806fa0dc882d1d87abc3c789247", size = 254852, upload-time = "2026-03-17T10:32:16.56Z" },
+    { url = "https://files.pythonhosted.org/packages/61/77/50e8d3d85cc0b7ebe09f30f151d670e302c7ff4a1bf6243f71dd8b0981fa/coverage-7.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e808af52a0513762df4d945ea164a24b37f2f518cbe97e03deaa0ee66139b4d6", size = 257161, upload-time = "2026-03-17T10:32:19.004Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c4/b5fd1d4b7bf8d0e75d997afd3925c59ba629fc8616f1b3aae7605132e256/coverage-7.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e301d30dd7e95ae068671d746ba8c34e945a82682e62918e41b2679acd2051a0", size = 251021, upload-time = "2026-03-17T10:32:21.344Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/66/6ea21f910e92d69ef0b1c3346ea5922a51bad4446c9126db2ae96ee24c4c/coverage-7.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:800bc829053c80d240a687ceeb927a94fd108bbdc68dfbe505d0d75ab578a882", size = 252858, upload-time = "2026-03-17T10:32:23.506Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ea/879c83cb5d61aa2a35fb80e72715e92672daef8191b84911a643f533840c/coverage-7.13.5-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:0b67af5492adb31940ee418a5a655c28e48165da5afab8c7fa6fd72a142f8740", size = 250823, upload-time = "2026-03-17T10:32:25.516Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/fb/616d95d3adb88b9803b275580bdeee8bd1b69a886d057652521f83d7322f/coverage-7.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c9136ff29c3a91e25b1d1552b5308e53a1e0653a23e53b6366d7c2dcbbaf8a16", size = 255099, upload-time = "2026-03-17T10:32:27.944Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/93/25e6917c90ec1c9a56b0b26f6cad6408e5f13bb6b35d484a0d75c9cf000d/coverage-7.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:cff784eef7f0b8f6cb28804fbddcfa99f89efe4cc35fb5627e3ac58f91ed3ac0", size = 250638, upload-time = "2026-03-17T10:32:29.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7b/dc1776b0464145a929deed214aef9fb1493f159b59ff3c7eeeedf91eddd0/coverage-7.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:68a4953be99b17ac3c23b6efbc8a38330d99680c9458927491d18700ef23ded0", size = 252295, upload-time = "2026-03-17T10:32:31.981Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/fb/99cbbc56a26e07762a2740713f3c8f9f3f3106e3a3dd8cc4474954bccd34/coverage-7.13.5-cp314-cp314-win32.whl", hash = "sha256:35a31f2b1578185fbe6aa2e74cea1b1d0bbf4c552774247d9160d29b80ed56cc", size = 222360, upload-time = "2026-03-17T10:32:34.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b7/4758d4f73fb536347cc5e4ad63662f9d60ba9118cb6785e9616b2ce5d7fa/coverage-7.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:2aa055ae1857258f9e0045be26a6d62bdb47a72448b62d7b55f4820f361a2633", size = 223174, upload-time = "2026-03-17T10:32:36.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f2/24d84e1dfe70f8ac9fdf30d338239860d0d1d5da0bda528959d0ebc9da28/coverage-7.13.5-cp314-cp314-win_arm64.whl", hash = "sha256:1b11eef33edeae9d142f9b4358edb76273b3bfd30bc3df9a4f95d0e49caf94e8", size = 221739, upload-time = "2026-03-17T10:32:38.736Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5b/4a168591057b3668c2428bff25dd3ebc21b629d666d90bcdfa0217940e84/coverage-7.13.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:10a0c37f0b646eaff7cce1874c31d1f1ccb297688d4c747291f4f4c70741cc8b", size = 220351, upload-time = "2026-03-17T10:32:41.196Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/21/1fd5c4dbfe4a58b6b99649125635df46decdfd4a784c3cd6d410d303e370/coverage-7.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b5db73ba3c41c7008037fa731ad5459fc3944cb7452fc0aa9f822ad3533c583c", size = 220612, upload-time = "2026-03-17T10:32:43.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fe/2a924b3055a5e7e4512655a9d4609781b0d62334fa0140c3e742926834e2/coverage-7.13.5-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:750db93a81e3e5a9831b534be7b1229df848b2e125a604fe6651e48aa070e5f9", size = 261985, upload-time = "2026-03-17T10:32:45.514Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/c8928f2bd518c45990fe1a2ab8db42e914ef9b726c975facc4282578c3eb/coverage-7.13.5-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9ddb4f4a5479f2539644be484da179b653273bca1a323947d48ab107b3ed1f29", size = 264107, upload-time = "2026-03-17T10:32:47.971Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/ae/4ae35bbd9a0af9d820362751f0766582833c211224b38665c0f8de3d487f/coverage-7.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8a7a2049c14f413163e2bdabd37e41179b1d1ccb10ffc6ccc4b7a718429c607", size = 266513, upload-time = "2026-03-17T10:32:50.1Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/d326174c55af36f74eac6ae781612d9492f060ce8244b570bb9d50d9d609/coverage-7.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1c85e0b6c05c592ea6d8768a66a254bfb3874b53774b12d4c89c481eb78cb90", size = 267650, upload-time = "2026-03-17T10:32:52.391Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/5e/31484d62cbd0eabd3412e30d74386ece4a0837d4f6c3040a653878bfc019/coverage-7.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:777c4d1eff1b67876139d24288aaf1817f6c03d6bae9c5cc8d27b83bcfe38fe3", size = 261089, upload-time = "2026-03-17T10:32:54.544Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d8/49a72d6de146eebb0b7e48cc0f4bc2c0dd858e3d4790ab2b39a2872b62bd/coverage-7.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6697e29b93707167687543480a40f0db8f356e86d9f67ddf2e37e2dfd91a9dab", size = 263982, upload-time = "2026-03-17T10:32:56.803Z" },
+    { url = "https://files.pythonhosted.org/packages/06/3b/0351f1bd566e6e4dd39e978efe7958bde1d32f879e85589de147654f57bb/coverage-7.13.5-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:8fdf453a942c3e4d99bd80088141c4c6960bb232c409d9c3558e2dbaa3998562", size = 261579, upload-time = "2026-03-17T10:32:59.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ce/796a2a2f4017f554d7810f5c573449b35b1e46788424a548d4d19201b222/coverage-7.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:32ca0c0114c9834a43f045a87dcebd69d108d8ffb666957ea65aa132f50332e2", size = 265316, upload-time = "2026-03-17T10:33:01.847Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/16/d5ae91455541d1a78bc90abf495be600588aff8f6db5c8b0dae739fa39c9/coverage-7.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:8769751c10f339021e2638cd354e13adeac54004d1941119b2c96fe5276d45ea", size = 260427, upload-time = "2026-03-17T10:33:03.945Z" },
+    { url = "https://files.pythonhosted.org/packages/48/11/07f413dba62db21fb3fad5d0de013a50e073cc4e2dc4306e770360f6dfc8/coverage-7.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cec2d83125531bd153175354055cdb7a09987af08a9430bd173c937c6d0fba2a", size = 262745, upload-time = "2026-03-17T10:33:06.285Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/d792371332eb4663115becf4bad47e047d16234b1aff687b1b18c58d60ae/coverage-7.13.5-cp314-cp314t-win32.whl", hash = "sha256:0cd9ed7a8b181775459296e402ca4fb27db1279740a24e93b3b41942ebe4b215", size = 223146, upload-time = "2026-03-17T10:33:08.756Z" },
+    { url = "https://files.pythonhosted.org/packages/db/51/37221f59a111dca5e85be7dbf09696323b5b9f13ff65e0641d535ed06ea8/coverage-7.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:301e3b7dfefecaca37c9f1aa6f0049b7d4ab8dd933742b607765d757aca77d43", size = 224254, upload-time = "2026-03-17T10:33:11.174Z" },
+    { url = "https://files.pythonhosted.org/packages/54/83/6acacc889de8987441aa7d5adfbdbf33d288dad28704a67e574f1df9bcbb/coverage-7.13.5-cp314-cp314t-win_arm64.whl", hash = "sha256:9dacc2ad679b292709e0f5fc1ac74a6d4d5562e424058962c7bb0c658ad25e45", size = 222276, upload-time = "2026-03-17T10:33:13.466Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346, upload-time = "2026-03-17T10:33:15.691Z" },
 ]
 
 [[package]]
@@ -717,55 +750,55 @@ wheels = [
 
 [[package]]
 name = "cryptography"
-version = "46.0.7"
+version = "47.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5", size = 750652, upload-time = "2026-04-08T01:57:54.692Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/b2/7ffa7fe8207a8c42147ffe70c3e360b228160c1d85dc3faff16aaa3244c0/cryptography-47.0.0.tar.gz", hash = "sha256:9f8e55fe4e63613a5e1cc5819030f27b97742d720203a087802ce4ce9ceb52bb", size = 830863, upload-time = "2026-04-24T19:54:57.056Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/5d/4a8f770695d73be252331e60e526291e3df0c9b27556a90a6b47bccca4c2/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4", size = 7179869, upload-time = "2026-04-08T01:56:17.157Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325", size = 4275492, upload-time = "2026-04-08T01:56:19.36Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308", size = 4426670, upload-time = "2026-04-08T01:56:21.415Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77", size = 4280275, upload-time = "2026-04-08T01:56:23.539Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/54/6bbbfc5efe86f9d71041827b793c24811a017c6ac0fd12883e4caa86b8ed/cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1", size = 4928402, upload-time = "2026-04-08T01:56:25.624Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef", size = 4459985, upload-time = "2026-04-08T01:56:27.309Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/46/4e4e9c6040fb01c7467d47217d2f882daddeb8828f7df800cb806d8a2288/cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de", size = 3990652, upload-time = "2026-04-08T01:56:29.095Z" },
-    { url = "https://files.pythonhosted.org/packages/36/5f/313586c3be5a2fbe87e4c9a254207b860155a8e1f3cca99f9910008e7d08/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83", size = 4279805, upload-time = "2026-04-08T01:56:30.928Z" },
-    { url = "https://files.pythonhosted.org/packages/69/33/60dfc4595f334a2082749673386a4d05e4f0cf4df8248e63b2c3437585f2/cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb", size = 4892883, upload-time = "2026-04-08T01:56:32.614Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b", size = 4459756, upload-time = "2026-04-08T01:56:34.306Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/14/633913398b43b75f1234834170947957c6b623d1701ffc7a9600da907e89/cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85", size = 4410244, upload-time = "2026-04-08T01:56:35.977Z" },
-    { url = "https://files.pythonhosted.org/packages/10/f2/19ceb3b3dc14009373432af0c13f46aa08e3ce334ec6eff13492e1812ccd/cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e", size = 4674868, upload-time = "2026-04-08T01:56:38.034Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/bb/a5c213c19ee94b15dfccc48f363738633a493812687f5567addbcbba9f6f/cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457", size = 3026504, upload-time = "2026-04-08T01:56:39.666Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/02/7788f9fefa1d060ca68717c3901ae7fffa21ee087a90b7f23c7a603c32ae/cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b", size = 3488363, upload-time = "2026-04-08T01:56:41.893Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/56/15619b210e689c5403bb0540e4cb7dbf11a6bf42e483b7644e471a2812b3/cryptography-46.0.7-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842", size = 7119671, upload-time = "2026-04-08T01:56:44Z" },
-    { url = "https://files.pythonhosted.org/packages/74/66/e3ce040721b0b5599e175ba91ab08884c75928fbeb74597dd10ef13505d2/cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c", size = 4268551, upload-time = "2026-04-08T01:56:46.071Z" },
-    { url = "https://files.pythonhosted.org/packages/03/11/5e395f961d6868269835dee1bafec6a1ac176505a167f68b7d8818431068/cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902", size = 4408887, upload-time = "2026-04-08T01:56:47.718Z" },
-    { url = "https://files.pythonhosted.org/packages/40/53/8ed1cf4c3b9c8e611e7122fb56f1c32d09e1fff0f1d77e78d9ff7c82653e/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d", size = 4271354, upload-time = "2026-04-08T01:56:49.312Z" },
-    { url = "https://files.pythonhosted.org/packages/50/46/cf71e26025c2e767c5609162c866a78e8a2915bbcfa408b7ca495c6140c4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022", size = 4905845, upload-time = "2026-04-08T01:56:50.916Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/ea/01276740375bac6249d0a971ebdf6b4dc9ead0ee0a34ef3b5a88c1a9b0d4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce", size = 4444641, upload-time = "2026-04-08T01:56:52.882Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/4c/7d258f169ae71230f25d9f3d06caabcff8c3baf0978e2b7d65e0acac3827/cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f", size = 3967749, upload-time = "2026-04-08T01:56:54.597Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/2a/2ea0767cad19e71b3530e4cad9605d0b5e338b6a1e72c37c9c1ceb86c333/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99", size = 4270942, upload-time = "2026-04-08T01:56:56.416Z" },
-    { url = "https://files.pythonhosted.org/packages/41/3d/fe14df95a83319af25717677e956567a105bb6ab25641acaa093db79975d/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1", size = 4871079, upload-time = "2026-04-08T01:56:58.31Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/59/4a479e0f36f8f378d397f4eab4c850b4ffb79a2f0d58704b8fa0703ddc11/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2", size = 4443999, upload-time = "2026-04-08T01:57:00.508Z" },
-    { url = "https://files.pythonhosted.org/packages/28/17/b59a741645822ec6d04732b43c5d35e4ef58be7bfa84a81e5ae6f05a1d33/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e", size = 4399191, upload-time = "2026-04-08T01:57:02.654Z" },
-    { url = "https://files.pythonhosted.org/packages/59/6a/bb2e166d6d0e0955f1e9ff70f10ec4b2824c9cfcdb4da772c7dd69cc7d80/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee", size = 4655782, upload-time = "2026-04-08T01:57:04.592Z" },
-    { url = "https://files.pythonhosted.org/packages/95/b6/3da51d48415bcb63b00dc17c2eff3a651b7c4fed484308d0f19b30e8cb2c/cryptography-46.0.7-cp314-cp314t-win32.whl", hash = "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298", size = 3002227, upload-time = "2026-04-08T01:57:06.91Z" },
-    { url = "https://files.pythonhosted.org/packages/32/a8/9f0e4ed57ec9cebe506e58db11ae472972ecb0c659e4d52bbaee80ca340a/cryptography-46.0.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb", size = 3475332, upload-time = "2026-04-08T01:57:08.807Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/7f/cd42fc3614386bc0c12f0cb3c4ae1fc2bbca5c9662dfed031514911d513d/cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4", size = 7165618, upload-time = "2026-04-08T01:57:10.645Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/d0/36a49f0262d2319139d2829f773f1b97ef8aef7f97e6e5bd21455e5a8fb5/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7", size = 4270628, upload-time = "2026-04-08T01:57:12.885Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/6c/1a42450f464dda6ffbe578a911f773e54dd48c10f9895a23a7e88b3e7db5/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832", size = 4415405, upload-time = "2026-04-08T01:57:14.923Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/92/4ed714dbe93a066dc1f4b4581a464d2d7dbec9046f7c8b7016f5286329e2/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163", size = 4272715, upload-time = "2026-04-08T01:57:16.638Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/e6/a26b84096eddd51494bba19111f8fffe976f6a09f132706f8f1bf03f51f7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2", size = 4918400, upload-time = "2026-04-08T01:57:19.021Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/08/ffd537b605568a148543ac3c2b239708ae0bd635064bab41359252ef88ed/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067", size = 4450634, upload-time = "2026-04-08T01:57:21.185Z" },
-    { url = "https://files.pythonhosted.org/packages/16/01/0cd51dd86ab5b9befe0d031e276510491976c3a80e9f6e31810cce46c4ad/cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0", size = 3985233, upload-time = "2026-04-08T01:57:22.862Z" },
-    { url = "https://files.pythonhosted.org/packages/92/49/819d6ed3a7d9349c2939f81b500a738cb733ab62fbecdbc1e38e83d45e12/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba", size = 4271955, upload-time = "2026-04-08T01:57:24.814Z" },
-    { url = "https://files.pythonhosted.org/packages/80/07/ad9b3c56ebb95ed2473d46df0847357e01583f4c52a85754d1a55e29e4d0/cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006", size = 4879888, upload-time = "2026-04-08T01:57:26.88Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/c7/201d3d58f30c4c2bdbe9b03844c291feb77c20511cc3586daf7edc12a47b/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0", size = 4449961, upload-time = "2026-04-08T01:57:29.068Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/ef/649750cbf96f3033c3c976e112265c33906f8e462291a33d77f90356548c/cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85", size = 4401696, upload-time = "2026-04-08T01:57:31.029Z" },
-    { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256, upload-time = "2026-04-08T01:57:33.144Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/fa/f0ab06238e899cc3fb332623f337a7364f36f4bb3f2534c2bb95a35b132c/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246", size = 3013001, upload-time = "2026-04-08T01:57:34.933Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3", size = 3472985, upload-time = "2026-04-08T01:57:36.714Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/98/40dfe932134bdcae4f6ab5927c87488754bf9eb79297d7e0070b78dd58e9/cryptography-47.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:160ad728f128972d362e714054f6ba0067cab7fb350c5202a9ae8ae4ce3ef1a0", size = 7912214, upload-time = "2026-04-24T19:53:03.864Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c6/2733531243fba725f58611b918056b277692f1033373dcc8bd01af1c05d4/cryptography-47.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b9a8943e359b7615db1a3ba587994618e094ff3d6fa5a390c73d079ce18b3973", size = 4644617, upload-time = "2026-04-24T19:53:06.909Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e3/b27be1a670a9b87f855d211cf0e1174a5d721216b7616bd52d8581d912ed/cryptography-47.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f5c15764f261394b22aef6b00252f5195f46f2ca300bec57149474e2538b31f8", size = 4668186, upload-time = "2026-04-24T19:53:09.053Z" },
+    { url = "https://files.pythonhosted.org/packages/81/b9/8443cfe5d17d482d348cee7048acf502bb89a51b6382f06240fd290d4ca3/cryptography-47.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9c59ab0e0fa3a180a5a9c59f3a5abe3ef90d474bc56d7fadfbe80359491b615b", size = 4651244, upload-time = "2026-04-24T19:53:11.217Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/5e/13ed0cdd0eb88ba159d6dd5ebfece8cb901dbcf1ae5ac4072e28b55d3153/cryptography-47.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:34b4358b925a5ea3e14384ca781a2c0ef7ac219b57bb9eacc4457078e2b19f92", size = 5252906, upload-time = "2026-04-24T19:53:13.532Z" },
+    { url = "https://files.pythonhosted.org/packages/64/16/ed058e1df0f33d440217cd120d41d5dda9dd215a80b8187f68483185af82/cryptography-47.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0024b87d47ae2399165a6bfb20d24888881eeab83ae2566d62467c5ff0030ce7", size = 4701842, upload-time = "2026-04-24T19:53:15.618Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3d30986b30fdbd9e969abbdf8ba00ed0618615144341faeb57f395a084fe/cryptography-47.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:1e47422b5557bb82d3fff997e8d92cff4e28b9789576984f08c248d2b3535d93", size = 4289313, upload-time = "2026-04-24T19:53:17.755Z" },
+    { url = "https://files.pythonhosted.org/packages/df/fd/32db38e3ad0cb331f0691cb4c7a8a6f176f679124dee746b3af6633db4d9/cryptography-47.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:6f29f36582e6151d9686235e586dd35bb67491f024767d10b842e520dc6a07ac", size = 4650964, upload-time = "2026-04-24T19:53:20.062Z" },
+    { url = "https://files.pythonhosted.org/packages/86/53/5395d944dfd48cb1f67917f533c609c34347185ef15eb4308024c876f274/cryptography-47.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a9b761f012a943b7de0e828843c5688d0de94a0578d44d6c85a1bae32f87791f", size = 5207817, upload-time = "2026-04-24T19:53:22.498Z" },
+    { url = "https://files.pythonhosted.org/packages/34/4f/e5711b28e1901f7d480a2b1b688b645aa4c77c73f10731ed17e7f7db3f0d/cryptography-47.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4e1de79e047e25d6e9f8cea71c86b4a53aced64134f0f003bbcbf3655fd172c8", size = 4701544, upload-time = "2026-04-24T19:53:24.356Z" },
+    { url = "https://files.pythonhosted.org/packages/22/22/c8ddc25de3010fc8da447648f5a092c40e7a8fadf01dd6d255d9c0b9373d/cryptography-47.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ef6b3634087f18d2155b1e8ce264e5345a753da2c5fa9815e7d41315c90f8318", size = 4783536, upload-time = "2026-04-24T19:53:26.665Z" },
+    { url = "https://files.pythonhosted.org/packages/66/b6/d4a68f4ea999c6d89e8498579cba1c5fcba4276284de7773b17e4fa69293/cryptography-47.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:11dbb9f50a0f1bb9757b3d8c27c1101780efb8f0bdecfb12439c22a74d64c001", size = 4926106, upload-time = "2026-04-24T19:53:28.686Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ed/5f524db1fade9c013aa618e1c99c6ed05e8ffc9ceee6cda22fed22dda3f4/cryptography-47.0.0-cp311-abi3-win32.whl", hash = "sha256:7fda2f02c9015db3f42bb8a22324a454516ed10a8c29ca6ece6cdbb5efe2a203", size = 3258581, upload-time = "2026-04-24T19:53:31.058Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/dc/1b901990b174786569029f67542b3edf72ac068b6c3c8683c17e6a2f5363/cryptography-47.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:f5c3296dab66202f1b18a91fa266be93d6aa0c2806ea3d67762c69f60adc71aa", size = 3775309, upload-time = "2026-04-24T19:53:33.054Z" },
+    { url = "https://files.pythonhosted.org/packages/14/88/7aa18ad9c11bc87689affa5ce4368d884b517502d75739d475fc6f4a03c7/cryptography-47.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:be12cb6a204f77ed968bcefe68086eb061695b540a3dd05edac507a3111b25f0", size = 7904299, upload-time = "2026-04-24T19:53:35.003Z" },
+    { url = "https://files.pythonhosted.org/packages/07/55/c18f75724544872f234678fdedc871391722cb34a2aee19faa9f63100bb2/cryptography-47.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2ebd84adf0728c039a3be2700289378e1c164afc6748df1a5ed456767bef9ba7", size = 4631180, upload-time = "2026-04-24T19:53:37.517Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/65/31a5cc0eaca99cec5bafffe155d407115d96136bb161e8b49e0ef73f09a7/cryptography-47.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f68d6fbc7fbbcfb0939fea72c3b96a9f9a6edfc0e1b1d29778a2066030418b1", size = 4653529, upload-time = "2026-04-24T19:53:39.775Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/bc/641c0519a495f3bfd0421b48d7cd325c4336578523ccd76ea322b6c29c7a/cryptography-47.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:6651d32eff255423503aa276739da98c30f26c40cbeffcc6048e0d54ef704c0c", size = 4638570, upload-time = "2026-04-24T19:53:42.129Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f2/300327b0a47f6dc94dd8b71b57052aefe178bb51745073d73d80604f11ab/cryptography-47.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:3fb8fa48075fad7193f2e5496135c6a76ac4b2aa5a38433df0a539296b377829", size = 5238019, upload-time = "2026-04-24T19:53:44.577Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5a/5b5cf994391d4bf9d9c7efd4c66aabe4d95227256627f8fea6cff7dfadbd/cryptography-47.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:11438c7518132d95f354fa01a4aa2f806d172a061a7bed18cf18cbdacdb204d7", size = 4686832, upload-time = "2026-04-24T19:53:47.015Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/2c/ae950e28fd6475c852fc21a44db3e6b5bcc1261d1e370f2b6e42fa800fef/cryptography-47.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:8c1a736bbb3288005796c3f7ccb9453360d7fed483b13b9f468aea5171432923", size = 4269301, upload-time = "2026-04-24T19:53:48.97Z" },
+    { url = "https://files.pythonhosted.org/packages/67/fb/6a39782e150ffe5cc1b0018cb6ddc48bf7ca62b498d7539ffc8a758e977d/cryptography-47.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:f1557695e5c2b86e204f6ce9470497848634100787935ab7adc5397c54abd7ab", size = 4638110, upload-time = "2026-04-24T19:53:51.011Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/d7/0b3c71090a76e5c203164a47688b697635ece006dcd2499ab3a4dbd3f0bd/cryptography-47.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:f9a034b642b960767fb343766ae5ba6ad653f2e890ddd82955aef288ffea8736", size = 5194988, upload-time = "2026-04-24T19:53:52.962Z" },
+    { url = "https://files.pythonhosted.org/packages/63/33/63a961498a9df51721ab578c5a2622661411fc520e00bd83b0cc64eb20c4/cryptography-47.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:b1c76fca783aa7698eb21eb14f9c4aa09452248ee54a627d125025a43f83e7a7", size = 4686563, upload-time = "2026-04-24T19:53:55.274Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/5ee5b145248f92250de86145d1c1d6edebbd57a7fe7caa4dedb5d4cf06a1/cryptography-47.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4f7722c97826770bab8ae92959a2e7b20a5e9e9bf4deae68fd86c3ca457bab52", size = 4770094, upload-time = "2026-04-24T19:53:57.753Z" },
+    { url = "https://files.pythonhosted.org/packages/92/43/21d220b2da5d517773894dacdcdb5c682c28d3fffce65548cb06e87d5501/cryptography-47.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:09f6d7bf6724f8db8b32f11eccf23efc8e759924bc5603800335cf8859a3ddbd", size = 4913811, upload-time = "2026-04-24T19:54:00.236Z" },
+    { url = "https://files.pythonhosted.org/packages/31/98/dc4ad376ac5f1a1a7d4a83f7b0c6f2bcad36b5d2d8f30aeb482d3a7d9582/cryptography-47.0.0-cp314-cp314t-win32.whl", hash = "sha256:6eebcaf0df1d21ce1f90605c9b432dd2c4f4ab665ac29a40d5e3fc68f51b5e63", size = 3237158, upload-time = "2026-04-24T19:54:02.606Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/da/97f62d18306b5133468bc3f8cc73a3111e8cdc8cf8d3e69474d6e5fd2d1b/cryptography-47.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:51c9313e90bd1690ec5a75ed047c27c0b8e6c570029712943d6116ef9a90620b", size = 3758706, upload-time = "2026-04-24T19:54:04.433Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/34/a4fae8ae7c3bc227460c9ae43f56abf1b911da0ec29e0ebac53bb0a4b6b7/cryptography-47.0.0-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:14432c8a9bcb37009784f9594a62fae211a2ae9543e96c92b2a8e4c3cd5cd0c4", size = 7904072, upload-time = "2026-04-24T19:54:06.411Z" },
+    { url = "https://files.pythonhosted.org/packages/01/64/d7b1e54fdb69f22d24a64bb3e88dc718b31c7fb10ef0b9691a3cf7eeea6e/cryptography-47.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:07efe86201817e7d3c18781ca9770bc0db04e1e48c994be384e4602bc38f8f27", size = 4635767, upload-time = "2026-04-24T19:54:08.519Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/7b/cca826391fb2a94efdcdfe4631eb69306ee1cff0b22f664a412c90713877/cryptography-47.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b45761c6ec22b7c726d6a829558777e32d0f1c8be7c3f3480f9c912d5ee8a10", size = 4654350, upload-time = "2026-04-24T19:54:10.795Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/65/4b57bcc823f42a991627c51c2f68c9fd6eb1393c1756aac876cba2accae2/cryptography-47.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:edd4da498015da5b9f26d38d3bfc2e90257bfa9cbed1f6767c282a0025ae649b", size = 4643394, upload-time = "2026-04-24T19:54:13.275Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/2c5fbeea70adbbca2bbae865e1d605d6a4a7f8dbd9d33eaf69645087f06c/cryptography-47.0.0-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9af828c0d5a65c70ec729cd7495a4bf1a67ecb66417b8f02ff125ab8a6326a74", size = 5225777, upload-time = "2026-04-24T19:54:15.18Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/b8/ac57107ef32749d2b244e36069bb688792a363aaaa3acc9e3cf84c130315/cryptography-47.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:256d07c78a04d6b276f5df935a9923275f53bd1522f214447fdf365494e2d515", size = 4688771, upload-time = "2026-04-24T19:54:17.835Z" },
+    { url = "https://files.pythonhosted.org/packages/56/fc/9f1de22ff8be99d991f240a46863c52d475404c408886c5a38d2b5c3bb26/cryptography-47.0.0-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:5d0e362ff51041b0c0d219cc7d6924d7b8996f57ce5712bdcef71eb3c65a59cc", size = 4270753, upload-time = "2026-04-24T19:54:19.963Z" },
+    { url = "https://files.pythonhosted.org/packages/00/68/d70c852797aa68e8e48d12e5a87170c43f67bb4a59403627259dd57d15de/cryptography-47.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:1581aef4219f7ca2849d0250edaa3866212fb74bf5667284f46aa92f9e65c1ca", size = 4642911, upload-time = "2026-04-24T19:54:21.818Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/51/661cbee74f594c5d97ff82d34f10d5551c085ca4668645f4606ebd22bd5d/cryptography-47.0.0-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a49a3eb5341b9503fa3000a9a0db033161db90d47285291f53c2a9d2cd1b7f76", size = 5181411, upload-time = "2026-04-24T19:54:24.376Z" },
+    { url = "https://files.pythonhosted.org/packages/94/87/f2b6c374a82cf076cfa1416992ac8e8ec94d79facc37aec87c1a5cb72352/cryptography-47.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2207a498b03275d0051589e326b79d4cf59985c99031b05bb292ac52631c37fe", size = 4688262, upload-time = "2026-04-24T19:54:26.946Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e2/8b7462f4acf21ec509616f0245018bb197194ab0b65c2ea21a0bdd53c0eb/cryptography-47.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7a02675e2fabd0c0fc04c868b8781863cbf1967691543c22f5470500ff840b31", size = 4775506, upload-time = "2026-04-24T19:54:28.926Z" },
+    { url = "https://files.pythonhosted.org/packages/70/75/158e494e4c08dc05e039da5bb48553826bd26c23930cf8d3cd5f21fa8921/cryptography-47.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80887c5cbd1774683cb126f0ab4184567f080071d5acf62205acb354b4b753b7", size = 4912060, upload-time = "2026-04-24T19:54:30.869Z" },
+    { url = "https://files.pythonhosted.org/packages/06/bd/0a9d3edbf5eadbac926d7b9b3cd0c4be584eeeae4a003d24d9eda4affbbd/cryptography-47.0.0-cp38-abi3-win32.whl", hash = "sha256:ed67ea4e0cfb5faa5bc7ecb6e2b8838f3807a03758eec239d6c21c8769355310", size = 3248487, upload-time = "2026-04-24T19:54:33.494Z" },
+    { url = "https://files.pythonhosted.org/packages/60/80/5681af756d0da3a599b7bdb586fac5a1540f1bcefd2717a20e611ddade45/cryptography-47.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:835d2d7f47cdc53b3224e90810fb1d36ca94ea29cc1801fb4c1bc43876735769", size = 3755737, upload-time = "2026-04-24T19:54:35.408Z" },
 ]
 
 [[package]]
@@ -783,6 +816,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3d/a033cc655a3a32ee145f575cd05066cf5bed71e24238947d77fb9597c905/dbus_fast-4.0.4-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5843c3e543ac1d48cafff67394ada9e568f20d122b44408e378ae43402b785ca", size = 1610602, upload-time = "2026-04-02T04:50:32.146Z" },
     { url = "https://files.pythonhosted.org/packages/4a/46/2834b825da3f6ef206f5bc55363bc8751addcfc03fa34c639f72006f6a3e/dbus_fast-4.0.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7ebb845f2e15ef19f4a99cb879dfbcb1c7028a97d5aaba93b36f65cfd938a022", size = 1550136, upload-time = "2026-04-02T04:50:34.311Z" },
     { url = "https://files.pythonhosted.org/packages/9e/01/894b2f6954d12c5c527232906d67272b59f0f12f386cd2d394d5e5eac7fc/dbus_fast-4.0.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:698fe83128150dd49aaa7deb5493523309f0a9749c3c075730a6981851607455", size = 1627660, upload-time = "2026-04-02T04:50:36.5Z" },
+]
+
+[[package]]
+name = "dill"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
 ]
 
 [[package]]
@@ -805,14 +847,28 @@ wheels = [
 
 [[package]]
 name = "fnv-hash-fast"
-version = "2.0.0"
+version = "2.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fnvhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8d/d3/a7af16d8e1d43d3c1d1cbde7901229773b62696e377f89c6834183680ede/fnv_hash_fast-2.0.0.tar.gz", hash = "sha256:e830b6316be36b2aa629f8a2c6b83833f1f3cc8ecf1da93c7e9e934844826646", size = 5718, upload-time = "2026-03-15T00:17:39.143Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/52/68d217fe739dea6712719effa8e1287a270d924e22d0ad31886cf1af04b1/fnv_hash_fast-2.0.2.tar.gz", hash = "sha256:8d5f6ac760a7ca091ef9d085b22b12c76caa8fa2897de81cee58f50269c0eb65", size = 5720, upload-time = "2026-03-15T09:33:58.352Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/6e/03f61d06f3ed61b10d0a07ac921d077045052db6fdd6847107e4c3405727/fnv_hash_fast-2.0.0-cp314-cp314-manylinux_2_41_x86_64.whl", hash = "sha256:ddf25f8f8b5cf54f068eaf5e3700c96f6c8da679e6efaf2084e57bdbad9d92ee", size = 7756, upload-time = "2026-03-15T00:17:37.392Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/3f/d7a250972ca3528b10cf83b09ffe93bc057f4a6f100c62a222586fc6bf7c/fnv_hash_fast-2.0.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e7e046e021bf3ade896999f1e4308611102c98a9e930729dae80008bfe096ad0", size = 7464, upload-time = "2026-03-15T09:42:16.696Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/48/c5f2fc199efce58fb512902f91ad549ca25a96b89a444c1dfad0e602816e/fnv_hash_fast-2.0.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14ff86c79ec7f44fcb15488d44362e1f576a363c9c8db5b97bd52eb7017eebf6", size = 8379, upload-time = "2026-03-15T09:42:17.569Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/23/9f95735e80411024200ce0f4a638b818fe42d0701448a6244f74ccecc2ff/fnv_hash_fast-2.0.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97ef72953a74e9bc918ccb7e7d6229e533054226fdd4ee933997e8dcd11f6108", size = 9216, upload-time = "2026-03-15T09:42:18.721Z" },
+    { url = "https://files.pythonhosted.org/packages/36/0f/b9ae42639b7529438d8a329fb25a17c3f05905fbdd5829cfa5e6a7f550d9/fnv_hash_fast-2.0.2-cp314-cp314-manylinux_2_41_x86_64.whl", hash = "sha256:f2c938907c2140b86e778e571ebefcc15377996c0e1c85d8a60ef6cdc5b0fd9c", size = 7755, upload-time = "2026-03-15T09:33:57.092Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/6c/31db3cd922c34cbcc47265e15ae110bee131d61b9e6857c370c0a3314935/fnv_hash_fast-2.0.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:faf4d478f2b68afacfcf12b2737c834a63cc0d48f0c8ff3a5b39487de78bc312", size = 9125, upload-time = "2026-03-15T09:42:19.589Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/88/4bac5c92f2bf8f3c9f06b1fd9d3c1becc23a34c2c5c2e3e67eb264b10b58/fnv_hash_fast-2.0.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2ad9c8008158e8b4acd19e9d61805bff58b6bc86fd459f030053a0e4aa6a2c1d", size = 8618, upload-time = "2026-03-15T09:42:20.782Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/71fe6bbd8907dd07aad205e40dbe8d0c5927d949c765c438ae31b550773b/fnv_hash_fast-2.0.2-cp314-cp314-win32.whl", hash = "sha256:fecd6c9026ff8177a813daf680ef7849ec3463ece8456c15809fd1a8c5aa72f0", size = 10371, upload-time = "2026-03-15T09:42:21.716Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/d9/afe630f1441e8bad36d0d0e8e5605ee27b1547bc0f8fa64e588702268024/fnv_hash_fast-2.0.2-cp314-cp314-win_amd64.whl", hash = "sha256:7cdf55ed4a002e99f0c14ef009114e85a73221bb6267f589e43a36b6422908df", size = 10766, upload-time = "2026-03-15T09:42:22.574Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/7c/1dad8f50f07b255fdee9c9af64b90c06d9c32c112469ee85beb956a77954/fnv_hash_fast-2.0.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:83273853e040343e018f82fd9fcfa5a2fd18ec840f8abdd29240702fad5904bc", size = 9095, upload-time = "2026-03-15T09:42:23.79Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0e/472e5f55beca0b3498a6a58b4b9ca367b97fac94ca88af0808cdbc3d9b23/fnv_hash_fast-2.0.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:415f66d4e5d47f6d018e15d95851c700bef4dcb26f85d8a1238d0150ea62a763", size = 10909, upload-time = "2026-03-15T09:42:24.728Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/77/fd93ba63b953a8c8b8116966e513adab789303ca0e172d926fde05980c24/fnv_hash_fast-2.0.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:270c64fc8f02179f7aff5f921c08115357bc038b5057da237e5b290c38de2a13", size = 12586, upload-time = "2026-03-15T09:42:25.702Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/67/413d3ac61194702c4b20785831c27e6968824183fe168e343579b4b92e0b/fnv_hash_fast-2.0.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c421c4519694c9f54d4110e7ffc31e6cc4def2c09e1d6009bfbc14d980a978b4", size = 12414, upload-time = "2026-03-15T09:42:26.594Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7f/84e5652a554b61b77d30799e23d445cfc70673d60dd1de86b86b11056b4e/fnv_hash_fast-2.0.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:620095dd5ca6d89f4394280b71a9d6f29c0ffbba85612ef5ae96e43eb27da707", size = 11390, upload-time = "2026-03-15T09:42:27.798Z" },
+    { url = "https://files.pythonhosted.org/packages/00/04/570904efb0586f94c66b4592047d2867ad7eb668c4d0709e97320004db05/fnv_hash_fast-2.0.2-cp314-cp314t-win32.whl", hash = "sha256:2c3d4d3a3d6d06ece900663806b3a3ff4649e3ac7fb5e258634e6ccca50a139c", size = 15286, upload-time = "2026-03-15T09:42:28.992Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/17/1f64a2cea0775c4ca606eaa3e6e9e878f6329b5039d3e9d0e8573758cca6/fnv_hash_fast-2.0.2-cp314-cp314t-win_amd64.whl", hash = "sha256:20f621be9b22763feebd2d9a898a8256220a4aca654092b41372b7036e1f6d6f", size = 16062, upload-time = "2026-03-15T09:42:29.91Z" },
 ]
 
 [[package]]
@@ -826,14 +882,14 @@ wheels = [
 
 [[package]]
 name = "freezegun"
-version = "1.5.2"
+version = "1.5.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "python-dateutil" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/75/0455fa5029507a2150da59db4f165fbc458ff8bb1c4f4d7e8037a14ad421/freezegun-1.5.2.tar.gz", hash = "sha256:a54ae1d2f9c02dbf42e02c18a3ab95ab4295818b549a34dac55592d72a905181", size = 34855, upload-time = "2025-05-24T12:38:47.051Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/dd/23e2f4e357f8fd3bdff613c1fe4466d21bfb00a6177f238079b17f7b1c84/freezegun-1.5.5.tar.gz", hash = "sha256:ac7742a6cc6c25a2c35e9292dfd554b897b517d2dec26891a2e8debf205cb94a", size = 35914, upload-time = "2025-08-09T10:39:08.338Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/b2/68d4c9b6431121b6b6aa5e04a153cac41dcacc79600ed6e2e7c3382156f5/freezegun-1.5.2-py3-none-any.whl", hash = "sha256:5aaf3ba229cda57afab5bd311f0108d86b6fb119ae89d2cd9c43ec8c1733c85b", size = 18715, upload-time = "2025-05-24T12:38:45.274Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/2e/b41d8a1a917d6581fc27a35d05561037b048e47df50f27f8ac9c7e27a710/freezegun-1.5.5-py3-none-any.whl", hash = "sha256:cd557f4a75cf074e84bc374249b9dd491eaeacd61376b9eb3c423282211619d2", size = 19266, upload-time = "2025-08-09T10:39:06.636Z" },
 ]
 
 [[package]]
@@ -875,6 +931,29 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/89/76/c615883b7b521ead2944bb3480398cbb07e12b7b4e4d073d3752eb721558/frozenlist-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:06be8f67f39c8b1dc671f5d83aaefd3358ae5cdcf8314552c57e7ed3e6475bdd", size = 49451, upload-time = "2025-10-06T05:37:53.425Z" },
     { url = "https://files.pythonhosted.org/packages/e0/a3/5982da14e113d07b325230f95060e2169f5311b1017ea8af2a29b374c289/frozenlist-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:102e6314ca4da683dca92e3b1355490fed5f313b768500084fbe6371fddfdb79", size = 42507, upload-time = "2025-10-06T05:37:54.513Z" },
     { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/3f/dbf99fb14bfeb88c28f16729215478c0e265cacd6dc22270c8f31bb6892f/greenlet-3.5.0.tar.gz", hash = "sha256:d419647372241bc68e957bf38d5c1f98852155e4146bd1e4121adea81f4f01e4", size = 196995, upload-time = "2026-04-27T13:37:15.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/5e/a70f31e3e8d961c4ce589c15b28e4225d63704e431a23932a3808cbcc867/greenlet-3.5.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:f35807464c4c58c55f0d31dfa83c541a5615d825c2fe3d2b95360cf7c4e3c0a8", size = 285564, upload-time = "2026-04-27T12:23:08.555Z" },
+    { url = "https://files.pythonhosted.org/packages/af/a6/046c0a28e21833e4086918218cfb3d8bed51c075a1b700f20b9d7861c0f4/greenlet-3.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55fa7ea52771be44af0de27d8b80c02cd18c2c3cddde6c847ecebdf72418b6a1", size = 651166, upload-time = "2026-04-27T12:52:43.644Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f8/4af27f71c5ff32a7fbc516adb46370d9c4ae2bc7bd3dc7d066ac542b4b15/greenlet-3.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a97e4821aa710603f94de0da25f25096454d78ffdace5dc77f3a006bc01abba3", size = 663792, upload-time = "2026-04-27T12:59:44.93Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/59/1bd6d7428d6ed9106efbb8c52310c60fd04f6672490f452aeaa3829aa436/greenlet-3.5.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f52a464e4ed91780bdfbbdd2b97197f3accaa629b98c200f4dffada759f3ae7", size = 660933, upload-time = "2026-04-27T12:25:33.276Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e4/b903e5a5fae1e8a28cdd32a0cfbfd560b668c25b692f67768822ddc5f40f/greenlet-3.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:762612baf1161ccb8437c0161c668a688223cba28e1bf038f4eb47b13e39ccdf", size = 1618401, upload-time = "2026-04-27T12:53:31.062Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/e3/5ec408a329acb854fb607a122e1ee5fb3ff649f9a97952948a90803c0d8e/greenlet-3.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:57a43c6079a89713522bc4bcb9f75070ecf5d3dbad7792bfe42239362cbf2a16", size = 1682038, upload-time = "2026-04-27T12:25:31.838Z" },
+    { url = "https://files.pythonhosted.org/packages/91/20/6b165108058767ee643c55c5c4904d591a830ee2b3c7dbd359828fbc829f/greenlet-3.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:3bc59be3945ae9750b9e7d45067d01ae3fe90ea5f9ade99239dabdd6e28a5033", size = 239835, upload-time = "2026-04-27T12:24:54.136Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/62/1c498375cee177b55d980c1db319f26470e5309e54698c8f8fc06c0fd539/greenlet-3.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:a96fcee45e03fe30a62669fd16ab5c9d3c172660d3085605cb1e2d1280d3c988", size = 236862, upload-time = "2026-04-27T12:23:24.957Z" },
+    { url = "https://files.pythonhosted.org/packages/78/a8/4522939255bb5409af4e87132f915446bf3622c2c292d14d3c38d128ae82/greenlet-3.5.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a10a732421ab4fec934783ce3e54763470d0181db6e3468f9103a275c3ed1853", size = 293614, upload-time = "2026-04-27T12:24:12.874Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5e/8744c52e2c027b5a8772a01561934c8835f869733e101f62075c60430340/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fc391b1566f2907d17aaebe78f8855dc45675159a775fcf9e61f8ee0078e87f", size = 650723, upload-time = "2026-04-27T12:52:45.412Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ef/7b4c39c03cf46ceca512c5d3f914afd85aa30b2cc9a93015b0dd73e4be6c/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:680bd0e7ad5e8daa8a4aa89f68fd6adc834b8a8036dc256533f7e08f4a4b01f7", size = 656529, upload-time = "2026-04-27T12:59:46.295Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/c7768f352f5c010f92064d0063f987e7dc0cd290a6d92a34109015ce4aa1/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddb36c7d6c9c0a65f18c7258634e0c416c6ab59caac8c987b96f80c2ebda0112", size = 654364, upload-time = "2026-04-27T12:25:35.64Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/d0/079ebe12e4b1fc758857ce5be1a5e73f06870f2101e52611d1e71925ce54/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e5ddf316ced87539144621453c3aef229575825fe60c604e62bedc4003f372b2", size = 1614204, upload-time = "2026-04-27T12:53:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/89/6c2fb63df3596552d20e58fb4d96669243388cf680cff222758812c7bfaa/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4a448128607be0de65342dc9b31be7f948ef4cc0bc8832069350abefd310a8f2", size = 1675480, upload-time = "2026-04-27T12:25:34.168Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/77ee8a6c1564fc345a491a4e85b3bf360e4cf26eac98c4532d2fdb96e01f/greenlet-3.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d60097128cb0a1cab9ea541186ea13cd7b847b8449a7787c2e2350da0cb82d86", size = 245324, upload-time = "2026-04-27T12:24:40.295Z" },
 ]
 
 [[package]]
@@ -987,19 +1066,19 @@ wheels = [
 
 [[package]]
 name = "home-assistant-bluetooth"
-version = "1.13.1"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "habluetooth" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b4/0e/c05ee603cab1adb847a305bc8f1034cbdbc0a5d15169fcf68c0d6d21e33f/home_assistant_bluetooth-1.13.1.tar.gz", hash = "sha256:0ae0e2a8491cc762ee9e694b8bc7665f1e2b4618926f63969a23a2e3a48ce55e", size = 7607, upload-time = "2025-02-04T16:11:15.259Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/6f/914fd8086f502748907751766e26e3f7fe5204347a679703ee9954e55e4d/home_assistant_bluetooth-2.0.0.tar.gz", hash = "sha256:3febd16b194812b156024d9bc8ce8ec7622cdd8d159047cac504cc77ca034ea1", size = 7604, upload-time = "2025-07-09T18:01:47.541Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/9b/9904cec885cc32c45e8c22cd7e19d9c342e30074fdb7c58f3d5b33ea1adb/home_assistant_bluetooth-1.13.1-py3-none-any.whl", hash = "sha256:cdf13b5b45f7744165677831e309ee78fbaf0c2866c6b5931e14d1e4e7dae5d7", size = 7915, upload-time = "2025-02-04T16:11:13.163Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3e/2ed9e59da8fc26c43cbd9d6abbd27217138a31c608b1d334cc5e680e4069/home_assistant_bluetooth-2.0.0-py3-none-any.whl", hash = "sha256:8d7c2ac48c303adacad73cb6cdfe7710f2fccd2a367d4c3106acf301b0d22b91", size = 7907, upload-time = "2025-07-09T18:01:46.506Z" },
 ]
 
 [[package]]
 name = "homeassistant"
-version = "2026.4.4"
+version = "2026.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiodns" },
@@ -1053,9 +1132,9 @@ dependencies = [
     { name = "yarl" },
     { name = "zeroconf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/3d/041a66485642537286c4b1a3ee66ace7ce43cfb61737e224cf01e6b59c97/homeassistant-2026.4.4.tar.gz", hash = "sha256:10f997fb7c00b2f8abbe30f343469428665b68d5a1e665feee2b827d9d815212", size = 32333699, upload-time = "2026-04-24T18:58:32.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/af/a01defe35f6c2505c1f479094ba457dfd5f76370c2f79d516a4c39dc4ffd/homeassistant-2026.5.0.tar.gz", hash = "sha256:497b09a981131e9f76642fc8da34b66657ab515553ba015d6ce84b0b1a0b27d2", size = 33108205, upload-time = "2026-05-06T15:53:15.187Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/cb/120eb528c6eb5a21bc726aff1bc47898e5353a677ec18d33d65b11b8f3f8/homeassistant-2026.4.4-py3-none-any.whl", hash = "sha256:cd83240d320e9842822810b4c4aa13a132dbf7954d10576f406e66fca645467f", size = 53499095, upload-time = "2026-04-24T18:58:24.834Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/ca/3eabc5e91b7831b995a4d2a1d87c1860c9544b72fe91d78cc3404598e68e/homeassistant-2026.5.0-py3-none-any.whl", hash = "sha256:f84f3a8225a70dae338f7067d24f648f8e740e2d75e5c69560b92ce9c1bb70d8", size = 54595344, upload-time = "2026-05-06T15:53:08.389Z" },
 ]
 
 [[package]]
@@ -1157,6 +1236,15 @@ wheels = [
 ]
 
 [[package]]
+name = "isort"
+version = "8.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592, upload-time = "2026-02-28T10:08:20.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733, upload-time = "2026-02-28T10:08:19.466Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1203,9 +1291,36 @@ wheels = [
 
 [[package]]
 name = "lru-dict"
-version = "1.3.0"
+version = "1.4.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/96/e3/42c87871920602a3c8300915bd0292f76eccc66c38f782397acbf8a62088/lru-dict-1.3.0.tar.gz", hash = "sha256:54fd1966d6bd1fcde781596cb86068214edeebff1db13a2cea11079e3fd07b6b", size = 13123, upload-time = "2023-11-06T01:40:12.951Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/0a/dec86efe38b350314c49a8d39ef01ba7cf8bbbef1d177646320eedea7159/lru_dict-1.4.1.tar.gz", hash = "sha256:cc518ff2d38cc7a8ab56f9a6ae557f91e2e1524b57ed8e598e97f45a2bd708fc", size = 13439, upload-time = "2025-11-02T10:02:13.548Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/02/8e04a8d744b466d4153502e2d92b453c2e5a549d49bf7fabfdca1621828a/lru_dict-1.4.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:7b770c7db258625e57b6ea8e2e0503ba0fbbdcde374baacf9adb256eb9c5adfa", size = 11119, upload-time = "2025-11-02T10:01:36.239Z" },
+    { url = "https://files.pythonhosted.org/packages/50/f8/ee96f30127ff47c29966603f040e0485700fe0ca0e7d7b1ecbc9bf999eea/lru_dict-1.4.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:45d4dc338237cedcbacedab1afd9707b8f9867d8b601ec04e0395ec73f57405c", size = 11435, upload-time = "2025-11-02T10:01:36.857Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/5a/897b33ba1974b6487848cafa5de7e93a7c4f5d9d3f43319ee010f6882830/lru_dict-1.4.1-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:5b31e9b6636f8945ad69c630c1891d810d62a91d99e792ef0b9ca865b6c26745", size = 10988, upload-time = "2025-11-02T10:01:37.531Z" },
+    { url = "https://files.pythonhosted.org/packages/19/8e/b87d0f2bfcad0169afc00e23e014bad9af252206ec2cbc6079f12bece58e/lru_dict-1.4.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:f9335d46c83882a1b5deffed8098a2dd9ad66d2bd6263f416fc4c73f63e26904", size = 16733, upload-time = "2025-11-02T10:01:38.194Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/19/d2384266864b1e5b1cc20527ae468550d3b23a71636371b40e4663276294/lru_dict-1.4.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:17844b4f8dd996144d53380395d73832e2508159ad49ed4fbcb62f1787a5feaf", size = 11222, upload-time = "2025-11-02T10:01:39.093Z" },
+    { url = "https://files.pythonhosted.org/packages/66/8a/94dec42ae6b5c8bdc53a86867924fa22634516434f129dca187ccc0853b8/lru_dict-1.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2b569c7813adb753b7b631097c34e6dbc194cb1814f22299c2d2a94894779877", size = 11733, upload-time = "2025-11-02T10:01:39.739Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/19/0b6de1db804cf094e201c5541d58e6a96359eb5beed048fa64d0589b6520/lru_dict-1.4.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:33cf1eb368d3989b8f00945937cfbfc2095d8ad2b1d2274ce1bde0af6f6d1e66", size = 32251, upload-time = "2025-11-02T10:01:40.421Z" },
+    { url = "https://files.pythonhosted.org/packages/97/38/89d9425dde436b9bd894234171988289b259aeeab5965bd2c21d5104cb41/lru_dict-1.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:22d5879ec5d5955f9dde105997bdf7ec9e0522bf99612a80b55b09f356a08368", size = 33405, upload-time = "2025-11-02T10:01:41.917Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/24/f1a189399ee107a64f955c9d6c84d3b0aee9b64b31fc5684b1eaeb3a6fc0/lru_dict-1.4.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2084363e4488aa5b4f8b26bd3cc148d70a15be92e3d347621a5b830b2b1e0a82", size = 35135, upload-time = "2025-11-02T10:01:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/57/58e9dcf0853d639e2995e5d9f84649ff8d6792a04a418628672a130137f4/lru_dict-1.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8198ab8ad7cc81b86340243ddd5cca882ead87daed0c9fa6cce377a10a7f2e47", size = 32620, upload-time = "2025-11-02T10:01:43.627Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/bb/664922f0cf076b1e3c2e43e8258582d507b07c19bd441a72dd5547a483e9/lru_dict-1.4.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f1f4ae6967d5873e684ce8b986e2e43985d0a1be735b09584737ad5634ff48f3", size = 34077, upload-time = "2025-11-02T10:01:44.694Z" },
+    { url = "https://files.pythonhosted.org/packages/58/38/b7a6fa85b150232cada26a50c89dc4bcf9acd6ada00e987b074c3b4e57f2/lru_dict-1.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a9bb130b5eaddd6453ca3dc38ce4a75f743512ad135b6f3994999dde0680bd79", size = 31905, upload-time = "2025-11-02T10:01:45.668Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7d/9c86393946d621f4aec852d543df4023241d85106e9e1e2a0e4057861f71/lru_dict-1.4.1-cp314-cp314-win32.whl", hash = "sha256:5534c69a52add5757714456d08ce3831d36b86c98972394ba900493bb0bd97f8", size = 13435, upload-time = "2025-11-02T10:01:46.397Z" },
+    { url = "https://files.pythonhosted.org/packages/20/3f/b017cbeea55a8a1d18037840a8a9c9cdae29554e9985b55d4e8694305035/lru_dict-1.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:96fd677b6d912229f2d02ba61a5a1210176963c4770c1bb765b8da937cec3834", size = 14423, upload-time = "2025-11-02T10:01:47.473Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/73/13132af7a5155edde66979b53eb509465304e6e5a2b00769246448479c73/lru_dict-1.4.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:6699bfebbf11dd9ff1387be7996fac6d1009fe6a6f48091ef6e069e6f19c7bce", size = 17184, upload-time = "2025-11-02T10:01:48.161Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/82/094985beb3e49461bf65a3c40df8de2018b8484e4ef129295090460ca5d9/lru_dict-1.4.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:a276f8f6f43861c3f05986824741d00e3133a973c3396598375310129535382d", size = 11459, upload-time = "2025-11-02T10:01:48.823Z" },
+    { url = "https://files.pythonhosted.org/packages/14/29/836abc49f8c2b6c2efccd2ac2b2c0ad3e55b7d75a05a20cc061f17871e39/lru_dict-1.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:090c7b6a3d54fa7f3d69ba4802abe2f33c9583b16b33f52bcb521c701f7ea46c", size = 11938, upload-time = "2025-11-02T10:01:49.448Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/83/1bb4e8fbc0b753fea825564d9d96180813a71715d46a9b6bb30a6dea4ce0/lru_dict-1.4.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b21d06dec64fb1952385262d9fcefaec147921dc0b55210007091a79da440d93", size = 36389, upload-time = "2025-11-02T10:01:50.49Z" },
+    { url = "https://files.pythonhosted.org/packages/54/f2/7df3b6d0dbc66f3be9aa6261750967cdc5619c89a563420c52200d2dd547/lru_dict-1.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b9613908a38cf8aa47f6c138ba031a8ac4ed38460299e84a2b07dba7b3b45aae", size = 38706, upload-time = "2025-11-02T10:01:51.197Z" },
+    { url = "https://files.pythonhosted.org/packages/97/5f/e3ba3eeb9b864a09b92e24fbf179aef4ef48588e763a9d8d2bc10bd2c6f8/lru_dict-1.4.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7558302ce8bbfcd29f08e695e07bf7a0d799c2979636d6a6a0b4e207f840969f", size = 38892, upload-time = "2025-11-02T10:01:51.899Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e3/12e0888aab0bf3ab9ce35e9849f239994a0feff6fe49380859bf57124a17/lru_dict-1.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3910396142322fb2718546115bb2a56f50ebc9144b5140327053cca084e0d375", size = 37254, upload-time = "2025-11-02T10:01:52.587Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/dc/06cd981718d039eb07a9c03263094aca6269721c470f765a292b24381a20/lru_dict-1.4.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:f3f4fad5c4a9458954b275de6a6e31c67a26fbef7037c6a7354e22523a77db26", size = 37422, upload-time = "2025-11-02T10:01:53.271Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/82/ea88e618f39d78ff3c15b71f01a0b1a6c6ac2034ce5c6428ae41b1c30ea5/lru_dict-1.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:85fc29363e2d3ba0a5f87b5e17f54b1078aea6d24c6dfc792725854b9d0f8d17", size = 35909, upload-time = "2025-11-02T10:01:54.356Z" },
+    { url = "https://files.pythonhosted.org/packages/89/36/1dd91c602f623839cec24d6c77fa3fd1a8878bf2d716871197cd3bf084dc/lru_dict-1.4.1-cp314-cp314t-win32.whl", hash = "sha256:b3853518dfa50f28af0d6e2dcf8bb8b0a1687c5f4eb913c0b35b0da5c6d276ce", size = 13816, upload-time = "2025-11-02T10:01:55.417Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a3/113410f7b2e61e9d6f13f1f17c584dbd08b5796e65d772ecd5b063fab3af/lru_dict-1.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:ff3af42922205620fdc920dcdf580c4c16b32c84a537a03b04b523e5c641a8a9", size = 15204, upload-time = "2025-11-02T10:01:56.06Z" },
+]
 
 [[package]]
 name = "markupsafe"
@@ -1247,6 +1362,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/64/3d/0f1bf475109a816c2a31a8b424750911343f0bce304827a5255df167547e/mashumaro-3.20.tar.gz", hash = "sha256:af4573f14ae61be3fbc3a473158ddfc1420f345410385809fd782e0d79e9215c", size = 191643, upload-time = "2026-02-09T21:53:55.24Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/96/5a/4fed77781061647d3be98e2f235ef1869289dd839ca0451a8d50a30fcd5c/mashumaro-3.20-py3-none-any.whl", hash = "sha256:648bc326f64c55447988eab67d6bfe3b7958c0961c83590709b1f950f88f4a3c", size = 94942, upload-time = "2026-02-09T21:53:53.343Z" },
+]
+
+[[package]]
+name = "mccabe"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
 ]
 
 [[package]]
@@ -1341,25 +1465,25 @@ wheels = [
 
 [[package]]
 name = "orjson"
-version = "3.11.7"
+version = "3.11.8"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/53/45/b268004f745ede84e5798b48ee12b05129d19235d0e15267aa57dcdb400b/orjson-3.11.7.tar.gz", hash = "sha256:9b1a67243945819ce55d24a30b59d6a168e86220452d2c96f4d1f093e71c0c49", size = 6144992, upload-time = "2026-02-02T15:38:49.29Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/1b/2024d06792d0779f9dbc51531b61c24f76c75b9f4ce05e6f3377a1814cea/orjson-3.11.8.tar.gz", hash = "sha256:96163d9cdc5a202703e9ad1b9ae757d5f0ca62f4fa0cc93d1f27b0e180cc404e", size = 5603832, upload-time = "2026-03-31T16:16:27.878Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/1e/745565dca749813db9a093c5ebc4bac1a9475c64d54b95654336ac3ed961/orjson-3.11.7-cp314-cp314-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:de0a37f21d0d364954ad5de1970491d7fbd0fb1ef7417d4d56a36dc01ba0c0a0", size = 228391, upload-time = "2026-02-02T15:38:27.757Z" },
-    { url = "https://files.pythonhosted.org/packages/46/19/e40f6225da4d3aa0c8dc6e5219c5e87c2063a560fe0d72a88deb59776794/orjson-3.11.7-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:c2428d358d85e8da9d37cba18b8c4047c55222007a84f97156a5b22028dfbfc0", size = 125188, upload-time = "2026-02-02T15:38:29.241Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/7e/c4de2babef2c0817fd1f048fd176aa48c37bec8aef53d2fa932983032cce/orjson-3.11.7-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3c4bc6c6ac52cdaa267552544c73e486fecbd710b7ac09bc024d5a78555a22f6", size = 128097, upload-time = "2026-02-02T15:38:30.618Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/74/233d360632bafd2197f217eee7fb9c9d0229eac0c18128aee5b35b0014fe/orjson-3.11.7-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bd0d68edd7dfca1b2eca9361a44ac9f24b078de3481003159929a0573f21a6bf", size = 123364, upload-time = "2026-02-02T15:38:32.363Z" },
-    { url = "https://files.pythonhosted.org/packages/79/51/af79504981dd31efe20a9e360eb49c15f06df2b40e7f25a0a52d9ae888e8/orjson-3.11.7-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:623ad1b9548ef63886319c16fa317848e465a21513b31a6ad7b57443c3e0dcf5", size = 129076, upload-time = "2026-02-02T15:38:33.68Z" },
-    { url = "https://files.pythonhosted.org/packages/67/e2/da898eb68b72304f8de05ca6715870d09d603ee98d30a27e8a9629abc64b/orjson-3.11.7-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6e776b998ac37c0396093d10290e60283f59cfe0fc3fccbd0ccc4bd04dd19892", size = 141705, upload-time = "2026-02-02T15:38:34.989Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/89/15364d92acb3d903b029e28d834edb8780c2b97404cbf7929aa6b9abdb24/orjson-3.11.7-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:652c6c3af76716f4a9c290371ba2e390ede06f6603edb277b481daf37f6f464e", size = 130855, upload-time = "2026-02-02T15:38:36.379Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/8b/ecdad52d0b38d4b8f514be603e69ccd5eacf4e7241f972e37e79792212ec/orjson-3.11.7-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a56df3239294ea5964adf074c54bcc4f0ccd21636049a2cf3ca9cf03b5d03cf1", size = 133386, upload-time = "2026-02-02T15:38:37.704Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/0e/45e1dcf10e17d0924b7c9162f87ec7b4ca79e28a0548acf6a71788d3e108/orjson-3.11.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bda117c4148e81f746655d5a3239ae9bd00cb7bc3ca178b5fc5a5997e9744183", size = 138295, upload-time = "2026-02-02T15:38:39.096Z" },
-    { url = "https://files.pythonhosted.org/packages/63/d7/4d2e8b03561257af0450f2845b91fbd111d7e526ccdf737267108075e0ba/orjson-3.11.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:23d6c20517a97a9daf1d48b580fcdc6f0516c6f4b5038823426033690b4d2650", size = 408720, upload-time = "2026-02-02T15:38:40.634Z" },
-    { url = "https://files.pythonhosted.org/packages/78/cf/d45343518282108b29c12a65892445fc51f9319dc3c552ceb51bb5905ed2/orjson-3.11.7-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:8ff206156006da5b847c9304b6308a01e8cdbc8cce824e2779a5ba71c3def141", size = 144152, upload-time = "2026-02-02T15:38:42.262Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/3a/d6001f51a7275aacd342e77b735c71fa04125a3f93c36fee4526bc8c654e/orjson-3.11.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:962d046ee1765f74a1da723f4b33e3b228fe3a48bd307acce5021dfefe0e29b2", size = 134814, upload-time = "2026-02-02T15:38:43.627Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/d3/f19b47ce16820cc2c480f7f1723e17f6d411b3a295c60c8ad3aa9ff1c96a/orjson-3.11.7-cp314-cp314-win32.whl", hash = "sha256:89e13dd3f89f1c38a9c9eba5fbf7cdc2d1feca82f5f290864b4b7a6aac704576", size = 127997, upload-time = "2026-02-02T15:38:45.06Z" },
-    { url = "https://files.pythonhosted.org/packages/12/df/172771902943af54bf661a8d102bdf2e7f932127968080632bda6054b62c/orjson-3.11.7-cp314-cp314-win_amd64.whl", hash = "sha256:845c3e0d8ded9c9271cd79596b9b552448b885b97110f628fb687aee2eed11c1", size = 124985, upload-time = "2026-02-02T15:38:46.388Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/1c/f2a8d8a1b17514660a614ce5f7aac74b934e69f5abc2700cc7ced882a009/orjson-3.11.7-cp314-cp314-win_arm64.whl", hash = "sha256:4a2e9c5be347b937a2e0203866f12bba36082e89b402ddb9e927d5822e43088d", size = 126038, upload-time = "2026-02-02T15:38:47.703Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/35/b01910c3d6b85dc882442afe5060cbf719c7d1fc85749294beda23d17873/orjson-3.11.8-cp314-cp314-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:ec795530a73c269a55130498842aaa762e4a939f6ce481a7e986eeaa790e9da4", size = 229171, upload-time = "2026-03-31T16:16:00.651Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/56/c9ec97bd11240abef39b9e5d99a15462809c45f677420fd148a6c5e6295e/orjson-3.11.8-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:c492a0e011c0f9066e9ceaa896fbc5b068c54d365fea5f3444b697ee01bc8625", size = 128746, upload-time = "2026-03-31T16:16:02.673Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/e4/66d4f30a90de45e2f0cbd9623588e8ae71eef7679dbe2ae954ed6d66a41f/orjson-3.11.8-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:883206d55b1bd5f5679ad5e6ddd3d1a5e3cac5190482927fdb8c78fb699193b5", size = 131867, upload-time = "2026-03-31T16:16:04.342Z" },
+    { url = "https://files.pythonhosted.org/packages/19/30/2a645fc9286b928675e43fa2a3a16fb7b6764aa78cc719dc82141e00f30b/orjson-3.11.8-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5774c1fdcc98b2259800b683b19599c133baeb11d60033e2095fd9d4667b82db", size = 124664, upload-time = "2026-03-31T16:16:05.837Z" },
+    { url = "https://files.pythonhosted.org/packages/db/44/77b9a86d84a28d52ba3316d77737f6514e17118119ade3f91b639e859029/orjson-3.11.8-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ac7381c83dd3d4a6347e6635950aa448f54e7b8406a27c7ecb4a37e9f1ae08b", size = 129701, upload-time = "2026-03-31T16:16:07.407Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/ea/eff3d9bfe47e9bc6969c9181c58d9f71237f923f9c86a2d2f490cd898c82/orjson-3.11.8-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:14439063aebcb92401c11afc68ee4e407258d2752e62d748b6942dad20d2a70d", size = 141202, upload-time = "2026-03-31T16:16:09.48Z" },
+    { url = "https://files.pythonhosted.org/packages/52/c8/90d4b4c60c84d62068d0cf9e4d8f0a4e05e76971d133ac0c60d818d4db20/orjson-3.11.8-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fa72e71977bff96567b0f500fc5bfd2fdf915f34052c782a4c6ebbdaa97aa858", size = 127194, upload-time = "2026-03-31T16:16:11.02Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/c7/ea9e08d1f0ba981adffb629811148b44774d935171e7b3d780ae43c4c254/orjson-3.11.8-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7679bc2f01bb0d219758f1a5f87bb7c8a81c0a186824a393b366876b4948e14f", size = 133639, upload-time = "2026-03-31T16:16:13.434Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/8c/ddbbfd6ba59453c8fc7fe1d0e5983895864e264c37481b2a791db635f046/orjson-3.11.8-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:14f7b8fcb35ef403b42fa5ecfa4ed032332a91f3dc7368fbce4184d59e1eae0d", size = 141914, upload-time = "2026-03-31T16:16:14.955Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/31/dbfbefec9df060d34ef4962cd0afcb6fa7a9ec65884cb78f04a7859526c3/orjson-3.11.8-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:c2bdf7b2facc80b5e34f48a2d557727d5c5c57a8a450de122ae81fa26a81c1bc", size = 423800, upload-time = "2026-03-31T16:16:16.594Z" },
+    { url = "https://files.pythonhosted.org/packages/87/cf/f74e9ae9803d4ab46b163494adba636c6d7ea955af5cc23b8aaa94cfd528/orjson-3.11.8-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ccd7ba1b0605813a0715171d39ec4c314cb97a9c85893c2c5c0c3a3729df38bf", size = 147837, upload-time = "2026-03-31T16:16:18.585Z" },
+    { url = "https://files.pythonhosted.org/packages/64/e6/9214f017b5db85e84e68602792f742e5dc5249e963503d1b356bee611e01/orjson-3.11.8-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cdbc8c9c02463fef4d3c53a9ba3336d05496ec8e1f1c53326a1e4acc11f5c600", size = 136441, upload-time = "2026-03-31T16:16:20.151Z" },
+    { url = "https://files.pythonhosted.org/packages/24/dd/3590348818f58f837a75fb969b04cdf187ae197e14d60b5e5a794a38b79d/orjson-3.11.8-cp314-cp314-win32.whl", hash = "sha256:0b57f67710a8cd459e4e54eb96d5f77f3624eba0c661ba19a525807e42eccade", size = 131983, upload-time = "2026-03-31T16:16:21.823Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/0f/b6cb692116e05d058f31ceee819c70f097fa9167c82f67fabe7516289abc/orjson-3.11.8-cp314-cp314-win_amd64.whl", hash = "sha256:735e2262363dcbe05c35e3a8869898022af78f89dde9e256924dc02e99fe69ca", size = 127396, upload-time = "2026-03-31T16:16:23.685Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d1/facb5b5051fabb0ef9d26c6544d87ef19a939a9a001198655d0d891062dd/orjson-3.11.8-cp314-cp314-win_arm64.whl", hash = "sha256:6ccdea2c213cf9f3d9490cbd5d427693c870753df41e6cb375bd79bcbafc8817", size = 127330, upload-time = "2026-03-31T16:16:25.496Z" },
 ]
 
 [[package]]
@@ -1433,6 +1557,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/74/ef/9158ee3b28274667986d39191760c988a2de22c6321be1262e21c8a19ccf/pipdeptree-2.26.1.tar.gz", hash = "sha256:92a8f37ab79235dacb46af107e691a1309ca4a429315ba2a1df97d1cd56e27ac", size = 41024, upload-time = "2025-04-20T03:27:42.489Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b9/a5/f9f143b420e53a296869636d1c3bdc144be498ca3136a113f52b53ea2b02/pipdeptree-2.26.1-py3-none-any.whl", hash = "sha256:3849d62a2ed641256afac3058c4f9b85ac4a47e9d8c991ee17a8f3d230c5cffb", size = 32802, upload-time = "2025-04-20T03:27:40.413Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
 ]
 
 [[package]]
@@ -1611,7 +1744,7 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.12.2"
+version = "2.13.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -1619,39 +1752,50 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8d/35/d319ed522433215526689bad428a94058b6dd12190ce7ddd78618ac14b28/pydantic-2.12.2.tar.gz", hash = "sha256:7b8fa15b831a4bbde9d5b84028641ac3080a4ca2cbd4a621a661687e741624fd", size = 816358, upload-time = "2025-10-14T15:02:21.842Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/e5/06d23afac9973109d1e3c8ad38e1547a12e860610e327c05ee686827dc37/pydantic-2.13.2.tar.gz", hash = "sha256:b418196607e61081c3226dcd4f0672f2a194828abb9109e9cfb84026564df2d1", size = 843836, upload-time = "2026-04-17T09:31:59.636Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/98/468cb649f208a6f1279448e6e5247b37ae79cf5e4041186f1e2ef3d16345/pydantic-2.12.2-py3-none-any.whl", hash = "sha256:25ff718ee909acd82f1ff9b1a4acfd781bb23ab3739adaa7144f19a6a4e231ae", size = 460628, upload-time = "2025-10-14T15:02:19.623Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ca/b45c378e6e8d0b90577288b533e04e95b7afd61bb1d51b6c263176435489/pydantic-2.13.2-py3-none-any.whl", hash = "sha256:a525087f4c03d7e7456a3de89b64cd693d2229933bb1068b9af6befd5563694e", size = 471947, upload-time = "2026-04-17T09:31:57.541Z" },
 ]
 
 [[package]]
 name = "pydantic-core"
-version = "2.41.4"
+version = "2.46.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/18/d0944e8eaaa3efd0a91b0f1fc537d3be55ad35091b6a87638211ba691964/pydantic_core-2.41.4.tar.gz", hash = "sha256:70e47929a9d4a1905a67e4b687d5946026390568a8e952b92824118063cee4d5", size = 457557, upload-time = "2025-10-14T10:23:47.909Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/bb/4742f05b739b2478459bb16fa8470549518c802e06ddcf3f106c5081315e/pydantic_core-2.46.2.tar.gz", hash = "sha256:37bb079f9ee3f1a519392b73fda2a96379b31f2013c6b467fe693e7f2987f596", size = 471269, upload-time = "2026-04-17T09:10:07.017Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/28/d3325da57d413b9819365546eb9a6e8b7cbd9373d9380efd5f74326143e6/pydantic_core-2.41.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:e9205d97ed08a82ebb9a307e92914bb30e18cdf6f6b12ca4bedadb1588a0bfe1", size = 2102022, upload-time = "2025-10-14T10:21:32.809Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/24/b58a1bc0d834bf1acc4361e61233ee217169a42efbdc15a60296e13ce438/pydantic_core-2.41.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:82df1f432b37d832709fbcc0e24394bba04a01b6ecf1ee87578145c19cde12ac", size = 1905495, upload-time = "2025-10-14T10:21:34.812Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/a4/71f759cc41b7043e8ecdaab81b985a9b6cad7cec077e0b92cff8b71ecf6b/pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fc3b4cc4539e055cfa39a3763c939f9d409eb40e85813257dcd761985a108554", size = 1956131, upload-time = "2025-10-14T10:21:36.924Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/64/1e79ac7aa51f1eec7c4cda8cbe456d5d09f05fdd68b32776d72168d54275/pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b1eb1754fce47c63d2ff57fdb88c351a6c0150995890088b33767a10218eaa4e", size = 2052236, upload-time = "2025-10-14T10:21:38.927Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/e3/a3ffc363bd4287b80f1d43dc1c28ba64831f8dfc237d6fec8f2661138d48/pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e6ab5ab30ef325b443f379ddb575a34969c333004fca5a1daa0133a6ffaad616", size = 2223573, upload-time = "2025-10-14T10:21:41.574Z" },
-    { url = "https://files.pythonhosted.org/packages/28/27/78814089b4d2e684a9088ede3790763c64693c3d1408ddc0a248bc789126/pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:31a41030b1d9ca497634092b46481b937ff9397a86f9f51bd41c4767b6fc04af", size = 2342467, upload-time = "2025-10-14T10:21:44.018Z" },
-    { url = "https://files.pythonhosted.org/packages/92/97/4de0e2a1159cb85ad737e03306717637842c88c7fd6d97973172fb183149/pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a44ac1738591472c3d020f61c6df1e4015180d6262ebd39bf2aeb52571b60f12", size = 2063754, upload-time = "2025-10-14T10:21:46.466Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/50/8cb90ce4b9efcf7ae78130afeb99fd1c86125ccdf9906ef64b9d42f37c25/pydantic_core-2.41.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d72f2b5e6e82ab8f94ea7d0d42f83c487dc159c5240d8f83beae684472864e2d", size = 2196754, upload-time = "2025-10-14T10:21:48.486Z" },
-    { url = "https://files.pythonhosted.org/packages/34/3b/ccdc77af9cd5082723574a1cc1bcae7a6acacc829d7c0a06201f7886a109/pydantic_core-2.41.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:c4d1e854aaf044487d31143f541f7aafe7b482ae72a022c664b2de2e466ed0ad", size = 2137115, upload-time = "2025-10-14T10:21:50.63Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/ba/e7c7a02651a8f7c52dc2cff2b64a30c313e3b57c7d93703cecea76c09b71/pydantic_core-2.41.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b568af94267729d76e6ee5ececda4e283d07bbb28e8148bb17adad93d025d25a", size = 2317400, upload-time = "2025-10-14T10:21:52.959Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/ba/6c533a4ee8aec6b812c643c49bb3bd88d3f01e3cebe451bb85512d37f00f/pydantic_core-2.41.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:6d55fb8b1e8929b341cc313a81a26e0d48aa3b519c1dbaadec3a6a2b4fcad025", size = 2312070, upload-time = "2025-10-14T10:21:55.419Z" },
-    { url = "https://files.pythonhosted.org/packages/22/ae/f10524fcc0ab8d7f96cf9a74c880243576fd3e72bd8ce4f81e43d22bcab7/pydantic_core-2.41.4-cp314-cp314-win32.whl", hash = "sha256:5b66584e549e2e32a1398df11da2e0a7eff45d5c2d9db9d5667c5e6ac764d77e", size = 1982277, upload-time = "2025-10-14T10:21:57.474Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/dc/e5aa27aea1ad4638f0c3fb41132f7eb583bd7420ee63204e2d4333a3bbf9/pydantic_core-2.41.4-cp314-cp314-win_amd64.whl", hash = "sha256:557a0aab88664cc552285316809cab897716a372afaf8efdbef756f8b890e894", size = 2024608, upload-time = "2025-10-14T10:21:59.557Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/61/51d89cc2612bd147198e120a13f150afbf0bcb4615cddb049ab10b81b79e/pydantic_core-2.41.4-cp314-cp314-win_arm64.whl", hash = "sha256:3f1ea6f48a045745d0d9f325989d8abd3f1eaf47dd00485912d1a3a63c623a8d", size = 1967614, upload-time = "2025-10-14T10:22:01.847Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/c2/472f2e31b95eff099961fa050c376ab7156a81da194f9edb9f710f68787b/pydantic_core-2.41.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6c1fe4c5404c448b13188dd8bd2ebc2bdd7e6727fa61ff481bcc2cca894018da", size = 1876904, upload-time = "2025-10-14T10:22:04.062Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/07/ea8eeb91173807ecdae4f4a5f4b150a520085b35454350fc219ba79e66a3/pydantic_core-2.41.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:523e7da4d43b113bf8e7b49fa4ec0c35bf4fe66b2230bfc5c13cc498f12c6c3e", size = 1882538, upload-time = "2025-10-14T10:22:06.39Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/29/b53a9ca6cd366bfc928823679c6a76c7a4c69f8201c0ba7903ad18ebae2f/pydantic_core-2.41.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5729225de81fb65b70fdb1907fcf08c75d498f4a6f15af005aabb1fdadc19dfa", size = 2041183, upload-time = "2025-10-14T10:22:08.812Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/3d/f8c1a371ceebcaf94d6dd2d77c6cf4b1c078e13a5837aee83f760b4f7cfd/pydantic_core-2.41.4-cp314-cp314t-win_amd64.whl", hash = "sha256:de2cfbb09e88f0f795fd90cf955858fc2c691df65b1f21f0aa00b99f3fbc661d", size = 1993542, upload-time = "2025-10-14T10:22:11.332Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/ac/9fc61b4f9d079482a290afe8d206b8f490e9fd32d4fc03ed4fc698214e01/pydantic_core-2.41.4-cp314-cp314t-win_arm64.whl", hash = "sha256:d34f950ae05a83e0ede899c595f312ca976023ea1db100cd5aa188f7005e3ab0", size = 1973897, upload-time = "2025-10-14T10:22:13.444Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/96/a50ccb6b539ae780f73cea74905468777680e30c6c3bdf714b9d4c116ea0/pydantic_core-2.46.2-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:4f59b45f3ef8650c0c736a57f59031d47ed9df4c0a64e83796849d7d14863a2d", size = 2097111, upload-time = "2026-04-17T09:10:49.617Z" },
+    { url = "https://files.pythonhosted.org/packages/34/5f/fdead7b3afa822ab6e5a18ee0ecffd54937de1877c01ed13a342e0fb3f07/pydantic_core-2.46.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3a075a29ebef752784a91532a1a85be6b234ccffec0a9d7978a92696387c3da6", size = 1951904, upload-time = "2026-04-17T09:12:32.062Z" },
+    { url = "https://files.pythonhosted.org/packages/95/e0/1c5d547e550cdab1bec737492aa08865337af6fe7fc9b96f7f45f17d9519/pydantic_core-2.46.2-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d12d786e30c04a9d307c5d7080bf720d9bac7f1668191d8e37633a9562749e2", size = 1978667, upload-time = "2026-04-17T09:11:35.589Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/cb/665ce629e218c8228302cb94beff4f6531082a2c87d3ecc3d5e63a26f392/pydantic_core-2.46.2-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0d5e6d6343b0b5dcacb3503b5de90022968da8ed0ab9ab39d3eda71c20cbf84e", size = 2046721, upload-time = "2026-04-17T09:11:47.725Z" },
+    { url = "https://files.pythonhosted.org/packages/77/e9/6cb2cf60f54c1472bbdfce19d957553b43dbba79d1d7b2930a195c594785/pydantic_core-2.46.2-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:233eebac0999b6b9ba76eb56f3ec8fce13164aa16b6d2225a36a79e0f95b5973", size = 2228483, upload-time = "2026-04-17T09:12:08.837Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/2a/93e018dd5571f781ebaeda8c0cf65398489d5bee9b1f484df0b6149b43b9/pydantic_core-2.46.2-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9cc0eee720dd2f14f3b7c349469402b99ad81a174ab49d3533974529e9d93992", size = 2294663, upload-time = "2026-04-17T09:12:52.053Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/4f/49e57ca55c770c93d9bb046666a54949b42e3c9099a0c5fe94557873fe30/pydantic_core-2.46.2-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83ee76bf2c9910513dbc19e7d82367131fa7508dedd6186a462393071cc11059", size = 2098742, upload-time = "2026-04-17T09:13:45.472Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/b0/6e46b5cd3332af665f794b8cdeea206618a8630bd9e7bcc36864518fce81/pydantic_core-2.46.2-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:d61db38eb4ee5192f0c261b7f2d38e420b554df8912245e3546aee5c45e2fd78", size = 2125922, upload-time = "2026-04-17T09:12:54.304Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d1/40850c81585be443a2abfdf7f795f8fae831baf8e2f9b2133c8246ac671c/pydantic_core-2.46.2-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8f09a713d17bcd55da8ab02ebd9110c5246a49c44182af213b5212800af8bc83", size = 2183000, upload-time = "2026-04-17T09:10:59.027Z" },
+    { url = "https://files.pythonhosted.org/packages/04/af/8493d7dfa03ebb7866909e577c6aa65ea0de7377b86023cc51d0c8e11db3/pydantic_core-2.46.2-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:30cacc5fb696e64b8ef6fd31d9549d394dd7d52760db072eecb98e37e3af1677", size = 2180335, upload-time = "2026-04-17T09:12:57.01Z" },
+    { url = "https://files.pythonhosted.org/packages/72/5b/1f6a344c4ffdf284da41c6067b82d5ebcbd11ce1b515ae4b662d4adb6f61/pydantic_core-2.46.2-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:7ccfb105fcfe91a22bbb5563ad3dc124bc1aa75bfd2e53a780ab05f78cdf6108", size = 2330002, upload-time = "2026-04-17T09:12:02.958Z" },
+    { url = "https://files.pythonhosted.org/packages/25/ff/9a694126c12d6d2f48a0cafa6f8eef88ef0d8825600e18d03ff2e896c3b2/pydantic_core-2.46.2-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:13ffef637dc8370c249e5b26bd18e9a80a4fca3d809618c44e18ec834a7ca7a8", size = 2359920, upload-time = "2026-04-17T09:10:27.764Z" },
+    { url = "https://files.pythonhosted.org/packages/51/c8/3a35c763d68a9cb2675eb10ef242cf66c5d4701b28ae12e688d67d2c180e/pydantic_core-2.46.2-cp314-cp314-win32.whl", hash = "sha256:1b0ab6d756ca2704a938e6c31b53f290c2f9c10d3914235410302a149de1a83e", size = 1953701, upload-time = "2026-04-17T09:13:30.021Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/6a/f2726a780365f7dfd89d62036f984f7acb99978c60c5e1fa7c0cb898ed11/pydantic_core-2.46.2-cp314-cp314-win_amd64.whl", hash = "sha256:99ebade8c9ada4df975372d8dd25883daa0e379a05f1cd0c99aa0c04368d01a6", size = 2071867, upload-time = "2026-04-17T09:10:39.205Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/79/76baacb9feba3d7c399b245ca1a29c74ea0db04ea693811374827eec2290/pydantic_core-2.46.2-cp314-cp314-win_arm64.whl", hash = "sha256:de87422197cf7f83db91d89c86a21660d749b3cd76cd8a45d115b8e675670f02", size = 2017252, upload-time = "2026-04-17T09:10:26.175Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/3b/77c26938f817668d9ad9bab1a905cb23f11d9a3d4bf724d429b3e55a8eaf/pydantic_core-2.46.2-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:236f22b4a206b5b61db955396b7cf9e2e1ff77f372efe9570128ccfcd6a525eb", size = 2094545, upload-time = "2026-04-17T09:12:19.339Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/de/42c13f590e3c260966aa49bcdb1674774f975467c49abd51191e502bea28/pydantic_core-2.46.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c2012f64d2cd7cca50f49f22445aa5a88691ac2b4498ee0a9a977f8ca4f7289f", size = 1933953, upload-time = "2026-04-17T09:09:55.889Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/84/ebe3ebb3e2d8db656937cfa6f97f544cb7132f2307a4a7dfdcd0ea102a12/pydantic_core-2.46.2-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d07d6c63106d3a9c9a333e2636f9c82c703b1a9e3b079299e58747964e4fdb72", size = 1974435, upload-time = "2026-04-17T09:10:12.371Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/15/0bf51ca6709477cd4ef86148b6d7844f3308f029eac361dd0383f1e17b1a/pydantic_core-2.46.2-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c326a2b4b85e959d9a1fc3a11f32f84611b6ec07c053e1828a860edf8d068208", size = 2031113, upload-time = "2026-04-17T09:10:00.752Z" },
+    { url = "https://files.pythonhosted.org/packages/02/ae/b7b5af9b79db036d9e61a44c481c17a213dc8fc4b8b71fe6875a72fc778b/pydantic_core-2.46.2-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ac8a65e798f2462552c00d2e013d532c94d646729dda98458beaf51f9ec7b120", size = 2236325, upload-time = "2026-04-17T09:10:33.227Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/ae/ecef7477b5a03d4a499708f7e75d2836452ebb70b776c2d64612b334f57a/pydantic_core-2.46.2-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5a3c2bc1cc8164bedbc160b7bb1e8cc1e8b9c27f69ae4f9ae2b976cdae02b2dd", size = 2278135, upload-time = "2026-04-17T09:10:23.287Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e4/2f9d82faa47af6c39fc3f120145fd915971e1e0cb6b55b494fad9fdf8275/pydantic_core-2.46.2-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e69aa5e10b7e8b1bb4a6888650fd12fcbf11d396ca11d4a44de1450875702830", size = 2109071, upload-time = "2026-04-17T09:11:06.149Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/9c/677cf10873fbd0b116575ab7b97c90482b21564f8a8040beb18edef7a577/pydantic_core-2.46.2-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:4e6df5c3301e65fb42bc5338bf9a1027a02b0a31dc7f54c33775229af474daf0", size = 2106028, upload-time = "2026-04-17T09:10:51.525Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/53/6a06183544daba51c059123a2064a99039df25f115a06bdb26f2ea177038/pydantic_core-2.46.2-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2c2f6e32548ac8d559b47944effcf8ae4d81c161f6b6c885edc53bc08b8f192d", size = 2164816, upload-time = "2026-04-17T09:11:56.187Z" },
+    { url = "https://files.pythonhosted.org/packages/57/6f/10fcdd9e3eca66fc828eef0f6f5850f2dd3bca2c59e6e041fb8bc3da39be/pydantic_core-2.46.2-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:b089a81c58e6ea0485562bbbbbca4f65c0549521606d5ef27fba217aac9b665a", size = 2166130, upload-time = "2026-04-17T09:10:03.804Z" },
+    { url = "https://files.pythonhosted.org/packages/29/83/92d3fd0e0156cad2e3cb5c26de73794af78ac9fa0c22ab666e566dd67061/pydantic_core-2.46.2-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:7f700a6d6f64112ae9193709b84303bbab84424ad4b47d0253301aabce9dfc70", size = 2316605, upload-time = "2026-04-17T09:12:45.249Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f1/facffdb970981068219582e499b8d0871ed163ffcc6b347de5c412669e4c/pydantic_core-2.46.2-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:67db6814beaa5fefe91101ec7eb9efda613795767be96f7cf58b1ca8c9ca9972", size = 2358385, upload-time = "2026-04-17T09:09:54.657Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/a1/b8160b2f22b2199467bc68581a4ed380643c16b348a27d6165c6c242d694/pydantic_core-2.46.2-cp314-cp314t-win32.whl", hash = "sha256:32fbc7447be8e3be99bf7869f7066308f16be55b61f9882c2cefc7931f5c7664", size = 1942373, upload-time = "2026-04-17T09:12:59.594Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/90/db89acabe5b150e11d1b59fe3d947dda2ef6abbfef5c82f056ff63802f5d/pydantic_core-2.46.2-cp314-cp314t-win_amd64.whl", hash = "sha256:b317a2b97019c0b95ce99f4f901ae383f40132da6706cdf1731066a73394c25c", size = 2052078, upload-time = "2026-04-17T09:10:19.96Z" },
+    { url = "https://files.pythonhosted.org/packages/97/32/e19b83ceb07a3f1bb21798407790bbc9a31740158fd132b94139cb84e16c/pydantic_core-2.46.2-cp314-cp314t-win_arm64.whl", hash = "sha256:7dcb9d40930dfad7ab6b20bcc6ca9d2b030b0f347a0cd9909b54bd53ead521b1", size = 2016941, upload-time = "2026-04-17T09:12:34.447Z" },
 ]
 
 [[package]]
@@ -1665,11 +1809,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.10.1"
+version = "2.12.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/46/bd74733ff231675599650d3e47f361794b22ef3e3770998dda30d3b63726/pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953", size = 87785, upload-time = "2024-11-28T03:43:29.933Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb", size = 22997, upload-time = "2024-11-28T03:43:27.893Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
 ]
 
 [package.optional-dependencies]
@@ -1678,12 +1822,33 @@ crypto = [
 ]
 
 [[package]]
-name = "pylint-per-file-ignores"
-version = "1.4.0"
+name = "pylint"
+version = "4.0.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a5/3d/21bec2f2f432519616c34a64ba0766ef972fdfb6234a86bb1b8baf4b0c7c/pylint_per_file_ignores-1.4.0.tar.gz", hash = "sha256:c0de7b3d0169571aefaa1ac3a82a265641b8825b54a0b6f5ef27c3b76b988609", size = 4419, upload-time = "2025-01-17T21:35:02.383Z" }
+dependencies = [
+    { name = "astroid" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "dill" },
+    { name = "isort" },
+    { name = "mccabe" },
+    { name = "platformdirs" },
+    { name = "tomlkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/b6/74d9a8a68b8067efce8d07707fe6a236324ee1e7808d2eb3646ec8517c7d/pylint-4.0.5.tar.gz", hash = "sha256:8cd6a618df75deb013bd7eb98327a95f02a6fb839205a6bbf5456ef96afb317c", size = 1572474, upload-time = "2026-02-20T09:07:33.621Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/0e/bf3473d86648a17e6dd6ee9e6abce526b077169031177f4f2031368f864a/pylint_per_file_ignores-1.4.0-py3-none-any.whl", hash = "sha256:0cd82d22551738b4e63a0aa1dab2a1fc4016e8f27f1429159616483711e122fd", size = 4888, upload-time = "2025-01-17T21:35:00.371Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/6f/9ac2548e290764781f9e7e2aaf0685b086379dabfb29ca38536985471eaf/pylint-4.0.5-py3-none-any.whl", hash = "sha256:00f51c9b14a3b3ae08cff6b2cdd43f28165c78b165b628692e428fb1f8dc2cf2", size = 536694, upload-time = "2026-02-20T09:07:31.028Z" },
+]
+
+[[package]]
+name = "pylint-per-file-ignores"
+version = "3.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pylint" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/bc/6d40a3596f91ef23fca7b89983b78bf4b3686323fd98e44e53ae365b1880/pylint_per_file_ignores-3.2.1.tar.gz", hash = "sha256:0a89f3cdc6fa09244a3f5624ad977ac9b026f0b25b2adb48c97c080da8d858f9", size = 81844, upload-time = "2026-04-03T19:35:37.697Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/68/2b0cc27b549fd788caae254752910fe7222ac47c71627c60926895fe8960/pylint_per_file_ignores-3.2.1-py3-none-any.whl", hash = "sha256:aaac8b118791e742ccf7baaf42346978f6cd0440a9090d4087fc8ff26e4a31f2", size = 5699, upload-time = "2026-04-03T19:35:36.524Z" },
 ]
 
 [[package]]
@@ -1774,14 +1939,14 @@ wheels = [
 
 [[package]]
 name = "pyopenssl"
-version = "26.0.0"
+version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/11/a62e1d33b373da2b2c2cd9eb508147871c80f12b1cacde3c5d314922afdd/pyopenssl-26.0.0.tar.gz", hash = "sha256:f293934e52936f2e3413b89c6ce36df66a0b34ae1ea3a053b8c5020ff2f513fc", size = 185534, upload-time = "2026-03-15T14:28:26.353Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/a8/26d36401e3ab8eed9030ad33f381da7856fcfad5691780fccd1b019718fc/pyopenssl-26.1.0.tar.gz", hash = "sha256:737f0a2275c5bc54f3b02137687e1a765931fb3949b9a92a825e4d33b9eec08b", size = 186181, upload-time = "2026-04-24T20:23:48.115Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/7d/d4f7d908fa8415571771b30669251d57c3cf313b36a856e6d7548ae01619/pyopenssl-26.0.0-py3-none-any.whl", hash = "sha256:df94d28498848b98cc1c0ffb8ef1e71e40210d3b0a8064c9d29571ed2904bf81", size = 57969, upload-time = "2026-03-15T14:28:24.864Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/41/52f3a3e812b816a91e89aa504199d8bf989a1f873192b10762be66cf2009/pyopenssl-26.1.0-py3-none-any.whl", hash = "sha256:115563879b2c8ccb207975705d3e491434d8c9d7c79667c902ecbf5f3bbd2ece", size = 58109, upload-time = "2026-04-24T20:23:46.273Z" },
 ]
 
 [[package]]
@@ -1814,7 +1979,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.0"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1823,9 +1988,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/da/1d/eb34f286b164c5e431a810a38697409cca1112cee04b287bb56ac486730b/pytest-9.0.0.tar.gz", hash = "sha256:8f44522eafe4137b0f35c9ce3072931a788a21ee40a2ed279e817d3cc16ed21e", size = 1562764, upload-time = "2025-11-08T17:25:33.34Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/99/cafef234114a3b6d9f3aaed0723b437c40c57bdb7b3e4c3a575bc4890052/pytest-9.0.0-py3-none-any.whl", hash = "sha256:e5ccdf10b0bac554970ee88fc1a4ad0ee5d221f8ef22321f9b7e4584e19d7f96", size = 373364, upload-time = "2025-11-08T17:25:31.811Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -1856,16 +2021,16 @@ wheels = [
 
 [[package]]
 name = "pytest-cov"
-version = "7.0.0"
+version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "coverage" },
     { name = "pluggy" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
 ]
 
 [[package]]
@@ -1883,19 +2048,19 @@ wheels = [
 
 [[package]]
 name = "pytest-github-actions-annotate-failures"
-version = "0.3.0"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/39/d4/c54ee6a871eee4a7468e3a8c0dead28e634c0bc2110c694309dcb7563a66/pytest_github_actions_annotate_failures-0.3.0.tar.gz", hash = "sha256:d4c3177c98046c3900a7f8ddebb22ea54b9f6822201b5d3ab8fcdea51e010db7", size = 11248, upload-time = "2025-01-17T22:39:32.722Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/e1/8f2c242e6d75a26a8e5ddcc23f652a411e4aac3eedc4b923808ac0582685/pytest_github_actions_annotate_failures-0.4.0.tar.gz", hash = "sha256:77d6baa29c8c61c2dacc494fa76eb95a185f0ee61666714ac43fb12ea672d217", size = 10857, upload-time = "2026-03-02T18:57:40.919Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/73/7b0b15cb8605ee967b34aa1d949737ab664f94e6b0f1534e8339d9e64ab2/pytest_github_actions_annotate_failures-0.3.0-py3-none-any.whl", hash = "sha256:41ea558ba10c332c0bfc053daeee0c85187507b2034e990f21e4f7e5fef044cf", size = 6030, upload-time = "2025-01-17T22:39:31.701Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/bd/11809f5c78d5d8da2d0e004845d2382768bc20798b3e0988bca61efd349f/pytest_github_actions_annotate_failures-0.4.0-py3-none-any.whl", hash = "sha256:285fed86e16b0b7a8eac6acdcde31913798fb739b15ef5b86895b4f5e32bf237", size = 6039, upload-time = "2026-03-02T18:57:39.991Z" },
 ]
 
 [[package]]
 name = "pytest-homeassistant-custom-component"
-version = "0.13.325"
+version = "0.13.329"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohasupervisor" },
@@ -1926,9 +2091,9 @@ dependencies = [
     { name = "syrupy" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f2/40/e14846938decc2073b78d2c88a08444973aae82b7fb263ba0073aca89793/pytest_homeassistant_custom_component-0.13.325.tar.gz", hash = "sha256:12924ad407b6601748d3a3c7883423fd0d34b1f782f14b615d1b61d994f371fc", size = 69950, upload-time = "2026-04-25T05:37:23.337Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/29/8f17e1c0dbfc45e65a8f4468ab3c7f03377ce82d7c3b99e7699351ea8366/pytest_homeassistant_custom_component-0.13.329.tar.gz", hash = "sha256:9355a7ab10cad2e871f5141cdff4c56286687dd8f6f4443c807b14b484fc2ec8", size = 77808, upload-time = "2026-05-07T06:03:59.017Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/c7/51cac710f1b6679550d04e162899dbdf4e7289ba715e5c4a9bff6bec7cfa/pytest_homeassistant_custom_component-0.13.325-py3-none-any.whl", hash = "sha256:9b758a092f74722e060d252ac80d71b6ae1ec2a712d55d0c9d378266e74e2c05", size = 75792, upload-time = "2026-04-25T05:37:21.529Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f4/4051455a0920f1586d2bcadf541fb52d6bc1ca3d23de53ca5103b10f42f7/pytest_homeassistant_custom_component-0.13.329-py3-none-any.whl", hash = "sha256:4e709447d6dfd07619072ddb9b32fcb33e533819c4a4bb6c4001a21025ead9bb", size = 83744, upload-time = "2026-05-07T06:03:57.958Z" },
 ]
 
 [[package]]
@@ -2120,14 +2285,14 @@ wheels = [
 
 [[package]]
 name = "respx"
-version = "0.22.0"
+version = "0.23.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/7c/96bd0bc759cf009675ad1ee1f96535edcb11e9666b985717eb8c87192a95/respx-0.22.0.tar.gz", hash = "sha256:3c8924caa2a50bd71aefc07aa812f2466ff489f1848c96e954a5362d17095d91", size = 28439, upload-time = "2024-12-19T22:33:59.374Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243, upload-time = "2026-04-08T14:37:16.008Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/67/afbb0978d5399bc9ea200f1d4489a23c9a1dad4eee6376242b8182389c79/respx-0.22.0-py2.py3-none-any.whl", hash = "sha256:631128d4c9aba15e56903fb5f66fb1eff412ce28dd387ca3a81339e52dbd3ad0", size = 25127, upload-time = "2024-12-19T22:33:57.837Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557, upload-time = "2026-04-08T14:37:14.613Z" },
 ]
 
 [[package]]
@@ -2169,15 +2334,15 @@ wheels = [
 
 [[package]]
 name = "securetar"
-version = "2026.4.0"
+version = "2026.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "pynacl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cb/25/138e19209d8f04765e6e51f94997d7e1141448103bae8ba30af98a755595/securetar-2026.4.0.tar.gz", hash = "sha256:d6e8d8c747655ac4564543f35f7fc70a2ebc7426f23c77f16238e7cb763691e8", size = 28254, upload-time = "2026-04-07T13:25:20.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/54/c7084733ce23f33c5f863734d6fd0c1789ba9ec771257cc54529c7a999ac/securetar-2026.4.1.tar.gz", hash = "sha256:536108c7cec0bdd6fb51abd8d293deba02930124d76ec5dd4599ae5e0c755638", size = 28289, upload-time = "2026-04-07T17:02:07.231Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/16/47a417d1264ad238191185ddd1a1d6585c6f33462e60408be09aee74147b/securetar-2026.4.0-py3-none-any.whl", hash = "sha256:72e09a864282ec96b05b5a61cc4febca7a1a7978b4083687369b6eb4835abe27", size = 19176, upload-time = "2026-04-07T13:25:19.803Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/56/4ef84868d1ff2f77ac080929117283ac9d18f7d018ae64fa1e7f957a8d20/securetar-2026.4.1-py3-none-any.whl", hash = "sha256:7cf66c204d678b9d1e2d17814c83048a6468e928ea00edb7e6c1efe72aab0540", size = 19339, upload-time = "2026-04-07T17:02:05.635Z" },
 ]
 
 [[package]]
@@ -2216,14 +2381,28 @@ wheels = [
 
 [[package]]
 name = "sqlalchemy"
-version = "2.0.41"
+version = "2.0.49"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/63/66/45b165c595ec89aa7dcc2c1cd222ab269bc753f1fc7a1e68f8481bd957bf/sqlalchemy-2.0.41.tar.gz", hash = "sha256:edba70118c4be3c2b1f90754d308d0b79c6fe2c0fdc52d8ddf603916f83f4db9", size = 9689424, upload-time = "2025-05-14T17:10:32.339Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/45/461788f35e0364a8da7bda51a1fe1b09762d0c32f12f63727998d85a873b/sqlalchemy-2.0.49.tar.gz", hash = "sha256:d15950a57a210e36dd4cec1aac22787e2a4d57ba9318233e2ef8b2daf9ff2d5f", size = 9898221, upload-time = "2026-04-03T16:38:11.704Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/fc/9ba22f01b5cdacc8f5ed0d22304718d2c758fce3fd49a5372b886a86f37c/sqlalchemy-2.0.41-py3-none-any.whl", hash = "sha256:57df5dc6fdb5ed1a88a1ed2195fd31927e705cad62dedd86b46972752a80f576", size = 1911224, upload-time = "2025-05-14T17:39:42.154Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/bf28f618c0a9597d14e0b9ee7d1e0622faff738d44fe986ee287cdf1b8d0/sqlalchemy-2.0.49-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:233088b4b99ebcbc5258c755a097aa52fbf90727a03a5a80781c4b9c54347a2e", size = 2156356, upload-time = "2026-04-03T16:53:09.914Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a7/5f476227576cb8644650eff68cc35fa837d3802b997465c96b8340ced1e2/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:57ca426a48eb2c682dae8204cd89ea8ab7031e2675120a47924fabc7caacbc2a", size = 3276486, upload-time = "2026-04-03T17:07:46.9Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/84/efc7c0bf3a1c5eef81d397f6fddac855becdbb11cb38ff957888603014a7/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:685e93e9c8f399b0c96a624799820176312f5ceef958c0f88215af4013d29066", size = 3281479, upload-time = "2026-04-03T17:12:32.226Z" },
+    { url = "https://files.pythonhosted.org/packages/91/68/bb406fa4257099c67bd75f3f2261b129c63204b9155de0d450b37f004698/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9e0400fa22f79acc334d9a6b185dc00a44a8e6578aa7e12d0ddcd8434152b187", size = 3226269, upload-time = "2026-04-03T17:07:48.678Z" },
+    { url = "https://files.pythonhosted.org/packages/67/84/acb56c00cca9f251f437cb49e718e14f7687505749ea9255d7bd8158a6df/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a05977bffe9bffd2229f477fa75eabe3192b1b05f408961d1bebff8d1cd4d401", size = 3248260, upload-time = "2026-04-03T17:12:34.381Z" },
+    { url = "https://files.pythonhosted.org/packages/56/19/6a20ea25606d1efd7bd1862149bb2a22d1451c3f851d23d887969201633f/sqlalchemy-2.0.49-cp314-cp314-win32.whl", hash = "sha256:0f2fa354ba106eafff2c14b0cc51f22801d1e8b2e4149342023bd6f0955de5f5", size = 2118463, upload-time = "2026-04-03T17:05:47.093Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4f/8297e4ed88e80baa1f5aa3c484a0ee29ef3c69c7582f206c916973b75057/sqlalchemy-2.0.49-cp314-cp314-win_amd64.whl", hash = "sha256:77641d299179c37b89cf2343ca9972c88bb6eef0d5fc504a2f86afd15cd5adf5", size = 2144204, upload-time = "2026-04-03T17:05:48.694Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/33/95e7216df810c706e0cd3655a778604bbd319ed4f43333127d465a46862d/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c1dc3368794d522f43914e03312202523cc89692f5389c32bea0233924f8d977", size = 3565474, upload-time = "2026-04-03T16:58:35.128Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/a4/ed7b18d8ccf7f954a83af6bb73866f5bc6f5636f44c7731fbb741f72cc4f/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c821c47ecfe05cc32140dcf8dc6fd5d21971c86dbd56eabfe5ba07a64910c01", size = 3530567, upload-time = "2026-04-03T17:06:04.587Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a3/20faa869c7e21a827c4a2a42b41353a54b0f9f5e96df5087629c306df71e/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9c04bff9a5335eb95c6ecf1c117576a0aa560def274876fd156cfe5510fccc61", size = 3474282, upload-time = "2026-04-03T16:58:37.131Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/50/276b9a007aa0764304ad467eceb70b04822dc32092492ee5f322d559a4dc/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7f605a456948c35260e7b2a39f8952a26f077fd25653c37740ed186b90aaa68a", size = 3480406, upload-time = "2026-04-03T17:06:07.176Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/c3/c80fcdb41905a2df650c2a3e0337198b6848876e63d66fe9188ef9003d24/sqlalchemy-2.0.49-cp314-cp314t-win32.whl", hash = "sha256:6270d717b11c5476b0cbb21eedc8d4dbb7d1a956fd6c15a23e96f197a6193158", size = 2149151, upload-time = "2026-04-03T17:02:07.281Z" },
+    { url = "https://files.pythonhosted.org/packages/05/52/9f1a62feab6ed368aff068524ff414f26a6daebc7361861035ae00b05530/sqlalchemy-2.0.49-cp314-cp314t-win_amd64.whl", hash = "sha256:275424295f4256fd301744b8f335cff367825d270f155d522b30c7bf49903ee7", size = 2184178, upload-time = "2026-04-03T17:02:08.623Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/30/8519fdde58a7bdf155b714359791ad1dc018b47d60269d5d160d311fdc36/sqlalchemy-2.0.49-py3-none-any.whl", hash = "sha256:ec44cfa7ef1a728e88ad41674de50f6db8cfdb3e2af84af86e0041aaf02d43d0", size = 1942158, upload-time = "2026-04-03T16:53:44.135Z" },
 ]
 
 [[package]]
@@ -2259,14 +2438,14 @@ wheels = [
 
 [[package]]
 name = "syrupy"
-version = "5.0.0"
+version = "5.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/90/1a442d21527009d4b40f37fe50b606ebb68a6407142c2b5cc508c34b696b/syrupy-5.0.0.tar.gz", hash = "sha256:3282fe963fa5d4d3e47231b16d1d4d0f4523705e8199eeb99a22a1bc9f5942f2", size = 48881, upload-time = "2025-09-28T21:15:12.783Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/b0/24bca682d6a6337854be37f242d116cceeda9942571d5804c44bc1bdd427/syrupy-5.1.0.tar.gz", hash = "sha256:df543c7aa50d3cf1246e83d58fe490afe5f7dab7b41e74ecc0d8d23ae19bd4b8", size = 50495, upload-time = "2026-01-25T14:53:06.2Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/9a/6c68aad2ccfce6e2eeebbf5bb709d0240592eb51ff142ec4c8fbf3c2460a/syrupy-5.0.0-py3-none-any.whl", hash = "sha256:c848e1a980ca52a28715cd2d2b4d434db424699c05653bd1158fb31cf56e9546", size = 49087, upload-time = "2025-09-28T21:15:11.639Z" },
+    { url = "https://files.pythonhosted.org/packages/de/70/cf880c3b95a6034ef673e74b369941b42315c01f1554a5637a4f8b911009/syrupy-5.1.0-py3-none-any.whl", hash = "sha256:95162d2b05e61ed3e13f117b88dfab7c58bd6f90e66ebbf918e8a77114ad51c5", size = 51658, upload-time = "2026-01-25T14:53:05.105Z" },
 ]
 
 [[package]]
@@ -2418,28 +2597,28 @@ wheels = [
 
 [[package]]
 name = "uv"
-version = "0.11.6"
+version = "0.11.8"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/dd/f3/8aceeab67ea69805293ab290e7ca8cc1b61a064d28b8a35c76d8eba063dd/uv-0.11.6.tar.gz", hash = "sha256:e3b21b7e80024c95ff339fcd147ac6fc3dd98d3613c9d45d3a1f4fd1057f127b", size = 4073298, upload-time = "2026-04-09T12:09:01.738Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c1/cd/4393fecb083897e956f016d4e66d0b8a496a08fe2e03cbda32a1e91da7ee/uv-0.11.8.tar.gz", hash = "sha256:bb2cf302b8503629aab6f0090a05551e6f8cfc2d687ca059cad7ec9e11214335", size = 4098020, upload-time = "2026-04-27T13:15:31.625Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/fe/4b61a3d5ad9d02e8a4405026ccd43593d7044598e0fa47d892d4dafe44c9/uv-0.11.6-py3-none-linux_armv6l.whl", hash = "sha256:ada04dcf89ddea5b69d27ac9cdc5ef575a82f90a209a1392e930de504b2321d6", size = 23780079, upload-time = "2026-04-09T12:08:56.609Z" },
-    { url = "https://files.pythonhosted.org/packages/52/db/d27519a9e1a5ffee9d71af1a811ad0e19ce7ab9ae815453bef39dd479389/uv-0.11.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:5be013888420f96879c6e0d3081e7bcf51b539b034a01777041934457dfbedf3", size = 23214721, upload-time = "2026-04-09T12:09:32.228Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/8f/4399fa8b882bd7e0efffc829f73ab24d117d490a93e6bc7104a50282b854/uv-0.11.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:ffa5dc1cbb52bdce3b8447e83d1601a57ad4da6b523d77d4b47366db8b1ceb18", size = 21750109, upload-time = "2026-04-09T12:09:24.357Z" },
-    { url = "https://files.pythonhosted.org/packages/32/07/5a12944c31c3dda253632da7a363edddb869ed47839d4d92a2dc5f546c93/uv-0.11.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:bfb107b4dade1d2c9e572992b06992d51dd5f2136eb8ceee9e62dd124289e825", size = 23551146, upload-time = "2026-04-09T12:09:10.439Z" },
-    { url = "https://files.pythonhosted.org/packages/79/5b/2ec8b0af80acd1016ed596baf205ddc77b19ece288473b01926c4a9cf6db/uv-0.11.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:9e2fe7ce12161d8016b7deb1eaad7905a76ff7afec13383333ca75e0c4b5425d", size = 23331192, upload-time = "2026-04-09T12:09:34.792Z" },
-    { url = "https://files.pythonhosted.org/packages/62/7d/eea35935f2112b21c296a3e42645f3e4b1aa8bcd34dcf13345fbd55134b7/uv-0.11.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7ed9c6f70c25e8dfeedddf4eddaf14d353f5e6b0eb43da9a14d3a1033d51d915", size = 23337686, upload-time = "2026-04-09T12:09:18.522Z" },
-    { url = "https://files.pythonhosted.org/packages/21/47/2584f5ab618f6ebe9bdefb2f765f2ca8540e9d739667606a916b35449eec/uv-0.11.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d68a013e609cebf82077cbeeb0809ed5e205257814273bfd31e02fc0353bbfc2", size = 25008139, upload-time = "2026-04-09T12:09:03.983Z" },
-    { url = "https://files.pythonhosted.org/packages/95/81/497ae5c1d36355b56b97dc59f550c7e89d0291c163a3f203c6f341dff195/uv-0.11.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:93f736dddca03dae732c6fdea177328d3bc4bf137c75248f3d433c57416a4311", size = 25712458, upload-time = "2026-04-09T12:09:07.598Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/1c/74083238e4fab2672b63575b9008f1ea418b02a714bcfcf017f4f6a309b6/uv-0.11.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e96a66abe53fced0e3389008b8d2eff8278cfa8bb545d75631ae8ceb9c929aba", size = 24915507, upload-time = "2026-04-09T12:08:50.892Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/ee/e14fe10ba455a823ed18233f12de6699a601890905420b5c504abf115116/uv-0.11.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b096311b2743b228df911a19532b3f18fa420bf9530547aecd6a8e04bbfaccd", size = 24971011, upload-time = "2026-04-09T12:08:54.016Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/a1/7b9c83eaadf98e343317ff6384a7227a4855afd02cdaf9696bcc71ee6155/uv-0.11.6-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:904d537b4a6e798015b4a64ff5622023bd4601b43b6cd1e5f423d63471f5e948", size = 23640234, upload-time = "2026-04-09T12:09:15.735Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/51/75ccdd23e76ff1703b70eb82881cd5b4d2a954c9679f8ef7e0136ef2cfab/uv-0.11.6-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:4ed8150c26b5e319381d75ae2ce6aba1e9c65888f4850f4e3b3fa839953c90a5", size = 24452664, upload-time = "2026-04-09T12:09:26.875Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/86/ace80fe47d8d48b5e3b5aee0b6eb1a49deaacc2313782870250b3faa36f5/uv-0.11.6-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:1c9218c8d4ac35ca6e617fb0951cc0ab2d907c91a6aea2617de0a5494cf162c0", size = 24494599, upload-time = "2026-04-09T12:09:37.368Z" },
-    { url = "https://files.pythonhosted.org/packages/05/2d/4b642669b56648194f026de79bc992cbfc3ac2318b0a8d435f3c284934e8/uv-0.11.6-py3-none-musllinux_1_1_i686.whl", hash = "sha256:9e211c83cc890c569b86a4183fcf5f8b6f0c7adc33a839b699a98d30f1310d3a", size = 24159150, upload-time = "2026-04-09T12:09:13.17Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/24/7eecd76fe983a74fed1fc700a14882e70c4e857f1d562a9f2303d4286c12/uv-0.11.6-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:d2a1d2089afdf117ad19a4c1dd36b8189c00ae1ad4135d3bfbfced82342595cf", size = 25164324, upload-time = "2026-04-09T12:08:59.56Z" },
-    { url = "https://files.pythonhosted.org/packages/27/e0/bbd4ba7c2e5067bbba617d87d306ec146889edaeeaa2081d3e122178ca08/uv-0.11.6-py3-none-win32.whl", hash = "sha256:6e8344f38fa29f85dcfd3e62dc35a700d2448f8e90381077ef393438dcd5012e", size = 22865693, upload-time = "2026-04-09T12:09:21.415Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/33/1983ce113c538a856f2d620d16e39691962ecceef091a84086c5785e32e5/uv-0.11.6-py3-none-win_amd64.whl", hash = "sha256:a28bea69c1186303d1200f155c7a28c449f8a4431e458fcf89360cc7ef546e40", size = 25371258, upload-time = "2026-04-09T12:09:40.52Z" },
-    { url = "https://files.pythonhosted.org/packages/35/01/be0873f44b9c9bc250fcbf263367fcfc1f59feab996355bcb6b52fff080d/uv-0.11.6-py3-none-win_arm64.whl", hash = "sha256:a78f6d64b9950e24061bc7ec7f15ff8089ad7f5a976e7b65fcadce58fe02f613", size = 23869585, upload-time = "2026-04-09T12:09:29.425Z" },
+    { url = "https://files.pythonhosted.org/packages/99/84/dcb676a3e36a3a2b44dc2e4dfea471b8cd709025e27cce3e588b176fd899/uv-0.11.8-py3-none-linux_armv6l.whl", hash = "sha256:a53e704a780a9e78a50f5a880e99a690f84e6fb9e82610903ce26f47c271d74c", size = 23664296, upload-time = "2026-04-27T13:15:15.644Z" },
+    { url = "https://files.pythonhosted.org/packages/86/05/557aa070fda7b8460bbbe1e867e8e5b80602c5b30ed77d1d94fc5acae518/uv-0.11.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:d414fc3795b6f56fb6b1fa359537930924fdfe857750a144d2aedf3077be3f1d", size = 23087321, upload-time = "2026-04-27T13:15:36.193Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/62/82953018801a250e16b091ef4b5e95e939b2f01224363d6fc80f600b7eff/uv-0.11.8-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f0d402e182ab581e934c159cc9edf25ec6e08d32f29aa797980e949afefc87cd", size = 21747142, upload-time = "2026-04-27T13:15:20.4Z" },
+    { url = "https://files.pythonhosted.org/packages/af/4c/477f2abe16f9a3d3c73077f15615878a303eef3760115ec946be58ecb9b2/uv-0.11.8-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:877c9af3b3955a35ef739e5b2ba79c56dae5c4d50420a7ed908c0901e1c8c807", size = 23425861, upload-time = "2026-04-27T13:15:10.374Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/63/19f46193e49f0c9bf33346a4d726313871864db16e7cdd1c0a63bc112000/uv-0.11.8-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:8278144df8d80a83f770c264a5e79ea50791316d2a0dda869e53b3c1174142a8", size = 23215551, upload-time = "2026-04-27T13:15:38.706Z" },
+    { url = "https://files.pythonhosted.org/packages/72/3e/5595b265df848a33cd060b10e8f763a46d67521ac9f6c314e8a4ad5329d7/uv-0.11.8-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b3494ad32465f4e02259cfb104d24efe5bb8f7a782351f0354de9385415fb310", size = 23224170, upload-time = "2026-04-27T13:15:18.083Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/b3/6ca95e690b52542caa1dae10ede57732f90c629946ab5f027ff746f87deb/uv-0.11.8-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a4421e27e81f85bce3bdb75986c38b5f9bfab9cdccaf3d977cf124b3f0f0b989", size = 24730048, upload-time = "2026-04-27T13:15:13.254Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/49/71b7322067c85a3736a22a300072b0566991fe3f95b81bed793508ff5315/uv-0.11.8-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:91943e77fc962752d4f64ad5739219858395981078051c740b28b52963b366aa", size = 25585906, upload-time = "2026-04-27T13:15:41.455Z" },
+    { url = "https://files.pythonhosted.org/packages/37/16/4e84cd5131327fe86d4784ebfc8a983149f4e6b811476ef271fc548b29e6/uv-0.11.8-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:41fbba287efcc9bc9505a60549b3a223220da720eacd03be8c23d9daaafa44f4", size = 24795740, upload-time = "2026-04-27T13:15:49.842Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/01/df175979018743cc5ba6e2fb9dcec916868271e8d88cf0b9df8fd805a0df/uv-0.11.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d97bb2920d6cddc07faa475013461294cc09b77ec8139278416c6e54b938d037", size = 24824980, upload-time = "2026-04-27T13:15:53.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/95/93c7f595f7136fb32807442860c55d0faed2cd3d7da4b7105ed3c2535d5f/uv-0.11.8-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:fb6a755305eb1e081dfe6a8bc007dbae2d26fe75e551656ca7c9cd08fba21d26", size = 23526790, upload-time = "2026-04-27T13:15:04.955Z" },
+    { url = "https://files.pythonhosted.org/packages/04/02/77430b89e172c20cc549b07a5b1dfda0c882c161b6d82781d3150a7063ac/uv-0.11.8-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:841ecbb38532698f73b14b49dc5f0c5e756194c7fcf6e5c6b7ed3859200fe91b", size = 24280498, upload-time = "2026-04-27T13:15:43.978Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/e3/23e4a2bb91e3880e017e6116886e2d0bde14ba6aa95ddc458160ee630e7c/uv-0.11.8-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:b3ff2b20c1897105ebe7ed7f9b1b331c7171da029bc1e35970ce31dc086141c1", size = 24375233, upload-time = "2026-04-27T13:15:25.753Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/67/fb7dc17cea816a667d1be2632525aa1687566bfafd17bdac561a7a6c9484/uv-0.11.8-py3-none-musllinux_1_1_i686.whl", hash = "sha256:ad381228b0170ef9646902c7e908d4a10a7ecc3da8139450506cf70c7e7f3e80", size = 23904818, upload-time = "2026-04-27T13:15:23.21Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/91/b920e35f54f8c6b51f2c639e8170bb80a47a739a1442fea33a479bc93a3d/uv-0.11.8-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:0172b5215544844cd3db0fa3c73a2eb74999b3f00cd2527dde578725076d7b65", size = 25015448, upload-time = "2026-04-27T13:15:46.666Z" },
+    { url = "https://files.pythonhosted.org/packages/05/e8/3771956dc1c94b8484789bb8070d91872080d0af99332b8bdec7218c2bfd/uv-0.11.8-py3-none-win32.whl", hash = "sha256:e71c1dd23cbb480f3952c3a95b4fd00f96bd618e2a94583fc9388c500af3070d", size = 22823583, upload-time = "2026-04-27T13:15:33.674Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/9b/a91a9c60dcae0e1e3da06377d38f32118a523697d461fe41bc9f117ecf59/uv-0.11.8-py3-none-win_amd64.whl", hash = "sha256:306c624c68d95dd7ea3647675323d72c1abc25f91c3e92ae4cd6f0f11b508726", size = 25407438, upload-time = "2026-04-27T13:15:28.957Z" },
+    { url = "https://files.pythonhosted.org/packages/61/5d/defa29fe617e6f07d4e514089e9d36fd9f44ede869e597e39ff7d69f6917/uv-0.11.8-py3-none-win_arm64.whl", hash = "sha256:a9853456696d579f206135c9dda7227a6ed8311b8a9a0b9b2008c4ae81950efe", size = 23914243, upload-time = "2026-04-27T13:15:07.717Z" },
 ]
 
 [[package]]
@@ -2453,14 +2632,14 @@ wheels = [
 
 [[package]]
 name = "voluptuous-openapi"
-version = "0.2.0"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "voluptuous" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/15/ac7a98afd478e9afc804354fe9d9715e0e560a590fdd425b22b65a152bb3/voluptuous_openapi-0.2.0.tar.gz", hash = "sha256:2366be934c37bb5fd8ed6bd5a2a46b1079b57dfbdf8c6c02e88f4ca13e975073", size = 15789, upload-time = "2025-08-21T04:49:16.755Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/5f/e77f088f4eff2e0f572f651bb9c2259561ec32d0bff20f59dd107e392ad8/voluptuous_openapi-0.3.0.tar.gz", hash = "sha256:1ecd2386e63b59b791e0f64715e317c7018a2e5598333138bd1f28adfd348d5c", size = 17467, upload-time = "2025-12-31T00:40:24.296Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/eb/2ae58431a078318f03267f196137282ea6f01ea7f7e0fcba2b25a30b0bf2/voluptuous_openapi-0.2.0-py3-none-any.whl", hash = "sha256:d51f07be8af44b11570b7366785d90daa716b7fd11ea2845803763ae551f35cf", size = 10180, upload-time = "2025-08-21T04:49:15.885Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/2d/3a8728e638bac8fd5857bb7775e39a9a520ae90b1d6dffd8badfa9852ccc/voluptuous_openapi-0.3.0-py3-none-any.whl", hash = "sha256:db35598e9fc711cbaf7d7732de160de3edf89cc7411b6febe5a132f1f54ea931", size = 10896, upload-time = "2025-12-31T00:40:23.067Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary by Sourcery

Emit a Home Assistant event when blueprints are updated, tighten network and domain safety handling, and improve the validation and testing pipeline.

New Features:
- Fire a standardized EVENT_BLUEPRINTS_UPDATER_UPDATED event with blueprint metadata whenever a blueprint is successfully installed or updated.

Bug Fixes:
- Ensure unsafe hostnames and special-use TLDs such as .local and home.arpa are correctly blocked when fetching blueprint updates.
- Fix domain detection and normalization so script and template blueprints respect their functional domains derived from paths and metadata.

Enhancements:
- Improve blueprint validation to respect expected domains and handle domain mismatches with clearer warnings and safer fallbacks.
- Refine metadata handling during installs to preserve trusted source URLs, derive relative paths reliably, and keep hash and breaking-change state in sync.
- Centralize IP safety checks in a shared utility and extend allowed reload domains usage across the coordinator and UI entities.
- Add deterministic DNS mocking in tests to avoid real network resolution and make hostname safety tests robust across environments.

Build:
- Update development dependency on Home Assistant Core to 2026.5.0 and enhance the validate.py pipeline logging and Prettier invocation flags for CI-friendly output.

CI:
- Tighten pytest configuration with higher strictness, including strict markers and an explicit real_network marker for tests that may touch the network.

Tests:
- Expand and adjust coordinator, entity, UI, and integration tests to cover event emission, domain resolution behavior, unsafe URL blocking, blueprint validation across domains, and DNS mocking logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Update events now include richer metadata (identity, previous/new hashes, breaking-risk, source URL and auto-update flag); validation and reloads are domain-aware and handle diverse blueprint layouts.
* **Bug Fixes**
  * Tighter blocking and clearer logging for unsafe remote blueprint updates from special-use hostnames/TLDs and unsafe IPs.
* **Tests**
  * Added/expanded tests for events, domain/reload behavior, installer flows, and deterministic DNS/network mocking.
* **Chores**
  * Reduced Prettier pre-commit verbosity; bumped a development dependency minimum and unified validation output formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->