### PR TITLE
Add comprehensive test coverage for blueprint coordinator

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,7 +102,7 @@ jobs:
           uv --no-config venv --no-project --python ${{ matrix.python_version }}
           HA_SPEC="homeassistant==${{ matrix.ha_real_version }}"
           echo "homeassistant == ${{ matrix.ha_real_version }}" > overrides.txt
-          uv --no-config pip install --overrides overrides.txt --python .venv/bin/python "$HA_SPEC" h2 pytest pytest-homeassistant-custom-component
+          uv --no-config pip install --overrides overrides.txt --python .venv/bin/python "$HA_SPEC" httpx[http2] pytest pytest-homeassistant-custom-component
 
       - name: Run Tests
         run: uv run --no-project --python .venv/bin/python pytest --quiet --no-cov

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,7 +102,7 @@ jobs:
           uv --no-config venv --no-project --python ${{ matrix.python_version }}
           HA_SPEC="homeassistant==${{ matrix.ha_real_version }}"
           echo "homeassistant == ${{ matrix.ha_real_version }}" > overrides.txt
-          uv --no-config pip install --overrides overrides.txt --python .venv/bin/python "$HA_SPEC" httpx[http2] pytest pytest-homeassistant-custom-component
+          uv --no-config pip install --overrides overrides.txt --python .venv/bin/python "$HA_SPEC" "httpx[http2]" pytest pytest-homeassistant-custom-component
 
       - name: Run Tests
         run: uv run --no-project --python .venv/bin/python pytest --quiet --no-cov

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,7 +102,7 @@ jobs:
           uv --no-config venv --no-project --python ${{ matrix.python_version }}
           HA_SPEC="homeassistant==${{ matrix.ha_real_version }}"
           echo "homeassistant == ${{ matrix.ha_real_version }}" > overrides.txt
-          uv --no-config pip install --overrides overrides.txt --python .venv/bin/python "$HA_SPEC" "httpx[http2]" pytest pytest-homeassistant-custom-component
+          uv --no-config pip install --overrides overrides.txt --python .venv/bin/python "$HA_SPEC" 'httpx[http2]' pytest pytest-homeassistant-custom-component
 
       - name: Run Tests
         run: uv run --no-project --python .venv/bin/python pytest --quiet --no-cov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ filterwarnings = ["ignore::DeprecationWarning"]
 addopts = [
   "--cov=custom_components",
   "--cov-fail-under=90",
+  "--cov-branch",
   "--timeout=60",
   "--strict-markers",
 ]

--- a/tests/coordinator/test_import_blueprint_failures.py
+++ b/tests/coordinator/test_import_blueprint_failures.py
@@ -9,9 +9,14 @@ from homeassistant.exceptions import ServiceValidationError
 from custom_components.blueprints_updater.const import BLUEPRINTS_DATA_DIR, SourceProviderType
 
 PROVIDER_LOOKUP = "custom_components.blueprints_updater.coordinator.registry.get_provider"
+IMPORT_URL = "https://example.com/bp.yaml"
+CONFLICTING_SOURCE_URL = "https://other.example/bp.yaml"
+IMPORTED_BLUEPRINT = "blueprint:\n  name: Imported\n  domain: automation\n"
+EXISTING_BLUEPRINT = "blueprint:\n  name: Existing\n  domain: automation\n"
+EXISTING_IMPORT_PATH = "/config/blueprints/automation/author/name.yaml"
 
 
-def _provider(canonical_url: str = "https://example.com/bp.yaml") -> MagicMock:
+def _provider(canonical_url: str = IMPORT_URL) -> MagicMock:
     """Build a provider mock that owns a canonical blueprint URL."""
     provider = MagicMock()
     provider.provider_type = SourceProviderType.GITHUB
@@ -25,11 +30,11 @@ def _patched_provider(provider):
     return patch(PROVIDER_LOOKUP, return_value=provider)
 
 
-def _response(url: str = "https://example.com/bp.yaml") -> httpx.Response:
+def _response(url: str = IMPORT_URL) -> httpx.Response:
     """Build a successful YAML response for import tests."""
     return httpx.Response(
         200,
-        content=b"blueprint:\n  name: Imported\n  domain: automation\n",
+        content=IMPORTED_BLUEPRINT.encode("utf-8"),
         headers={"Content-Type": "text/yaml"},
         request=httpx.Request("GET", url),
     )
@@ -57,7 +62,7 @@ async def test_async_import_blueprint_rejects_unsafe_canonical_url(coordinator):
         patch.object(coordinator, "_is_safe_url", AsyncMock(side_effect=[True, False])),
         pytest.raises(ServiceValidationError) as err,
     ):
-        await coordinator.async_import_blueprint("https://example.com/bp.yaml", confirm=True)
+        await coordinator.async_import_blueprint(IMPORT_URL, confirm=True)
 
     assert err.value.translation_key == "unsafe_url"
 
@@ -75,7 +80,7 @@ async def test_async_import_blueprint_rejects_empty_provider_content(coordinator
         patch.object(coordinator, "_parse_provider_response", AsyncMock(return_value="")),
         pytest.raises(ServiceValidationError) as err,
     ):
-        await coordinator.async_import_blueprint("https://example.com/bp.yaml", confirm=True)
+        await coordinator.async_import_blueprint(IMPORT_URL, confirm=True)
 
     assert err.value.translation_key == "empty_content"
     provider.get_metadata.assert_not_called()
@@ -95,7 +100,7 @@ async def test_async_import_blueprint_wraps_fetch_errors(coordinator):
         ),
         pytest.raises(ServiceValidationError) as err,
     ):
-        await coordinator.async_import_blueprint("https://example.com/bp.yaml", confirm=True)
+        await coordinator.async_import_blueprint(IMPORT_URL, confirm=True)
 
     assert err.value.translation_key == "fetch_error"
     assert err.value.translation_placeholders == {"error": "network down"}
@@ -115,11 +120,11 @@ async def test_async_import_blueprint_rejects_malformed_provider_metadata(coordi
         patch.object(
             coordinator,
             "_parse_provider_response",
-            AsyncMock(return_value="blueprint:\n  name: Imported\n  domain: automation\n"),
+            AsyncMock(return_value=IMPORTED_BLUEPRINT),
         ),
         pytest.raises(ServiceValidationError) as err,
     ):
-        await coordinator.async_import_blueprint("https://example.com/bp.yaml", confirm=True)
+        await coordinator.async_import_blueprint(IMPORT_URL, confirm=True)
 
     assert err.value.translation_key == "fetch_error"
     placeholders = err.value.translation_placeholders
@@ -142,7 +147,7 @@ async def test_async_import_blueprint_rejects_yaml_without_blueprint_block(coord
         ),
         pytest.raises(ServiceValidationError) as err,
     ):
-        await coordinator.async_import_blueprint("https://example.com/bp.yaml", confirm=True)
+        await coordinator.async_import_blueprint(IMPORT_URL, confirm=True)
 
     assert err.value.translation_key == "invalid_yaml"
 
@@ -165,11 +170,11 @@ async def test_async_import_blueprint_rejects_existing_non_string_source_url(coo
         patch.object(
             coordinator,
             "_parse_provider_response",
-            AsyncMock(return_value="blueprint:\n  name: Imported\n  domain: automation\n"),
+            AsyncMock(return_value=IMPORTED_BLUEPRINT),
         ),
         pytest.raises(ServiceValidationError) as err,
     ):
-        await coordinator.async_import_blueprint("https://example.com/bp.yaml", confirm=True)
+        await coordinator.async_import_blueprint(IMPORT_URL, confirm=True)
 
     assert err.value.translation_key == "import_invalid_source_type"
     assert err.value.translation_placeholders == {"type": "int"}
@@ -188,12 +193,12 @@ async def test_async_import_blueprint_rejects_unsafe_destination_path(coordinato
         patch.object(
             coordinator,
             "_parse_provider_response",
-            AsyncMock(return_value="blueprint:\n  name: Imported\n  domain: automation\n"),
+            AsyncMock(return_value=IMPORTED_BLUEPRINT),
         ),
         patch.object(coordinator, "_is_safe_path", return_value=False),
         pytest.raises(ServiceValidationError) as err,
     ):
-        await coordinator.async_import_blueprint("https://example.com/bp.yaml", confirm=True)
+        await coordinator.async_import_blueprint(IMPORT_URL, confirm=True)
 
     assert err.value.translation_key == "unsafe_path"
 
@@ -204,11 +209,9 @@ async def test_async_import_blueprint_rejects_existing_data_with_conflicting_sou
 ):
     """Verify existing coordinator data with a different source_url blocks import."""
     provider = _provider()
-    provider.normalize_url.side_effect = lambda url: (
-        "https://example.com/bp.yaml" if url == "https://example.com/bp.yaml" else url
-    )
+    provider.normalize_url.side_effect = lambda url: IMPORT_URL if url == IMPORT_URL else url
     existing_path = tmp_path / "name.yaml"
-    coordinator.data[str(existing_path)] = {"source_url": "https://other.example/bp.yaml"}
+    coordinator.data[str(existing_path)] = {"source_url": CONFLICTING_SOURCE_URL}
 
     with (
         _patched_provider(provider),
@@ -219,23 +222,23 @@ async def test_async_import_blueprint_rejects_existing_data_with_conflicting_sou
         patch.object(
             coordinator,
             "_parse_provider_response",
-            AsyncMock(return_value="blueprint:\n  name: Imported\n  domain: automation\n"),
+            AsyncMock(return_value=IMPORTED_BLUEPRINT),
         ),
         pytest.raises(ServiceValidationError) as err,
     ):
-        await coordinator.async_import_blueprint("https://example.com/bp.yaml", confirm=True)
+        await coordinator.async_import_blueprint(IMPORT_URL, confirm=True)
 
     assert err.value.translation_key == "import_path_conflict"
     placeholders = err.value.translation_placeholders
     assert placeholders is not None
-    assert placeholders["existing_url"] == "https://other.example/bp.yaml"
+    assert placeholders["existing_url"] == CONFLICTING_SOURCE_URL
 
 
 @pytest.mark.asyncio
 async def test_async_import_blueprint_rejects_existing_file_without_source_url(coordinator):
     """Verify an existing destination without source_url is treated as a conflict."""
     provider = _provider()
-    existing_path = "/config/blueprints/automation/author/name.yaml"
+    existing_path = EXISTING_IMPORT_PATH
 
     with (
         _patched_provider(provider),
@@ -246,16 +249,16 @@ async def test_async_import_blueprint_rejects_existing_file_without_source_url(c
         patch.object(
             coordinator,
             "_parse_provider_response",
-            AsyncMock(return_value="blueprint:\n  name: Imported\n  domain: automation\n"),
+            AsyncMock(return_value=IMPORTED_BLUEPRINT),
         ),
         patch("custom_components.blueprints_updater.coordinator.os.path.exists", return_value=True),
         patch(
             "builtins.open",
-            mock_open(read_data="blueprint:\n  name: Existing\n  domain: automation\n"),
+            mock_open(read_data=EXISTING_BLUEPRINT),
         ),
         pytest.raises(ServiceValidationError) as err,
     ):
-        await coordinator.async_import_blueprint("https://example.com/bp.yaml", confirm=True)
+        await coordinator.async_import_blueprint(IMPORT_URL, confirm=True)
 
     assert err.value.translation_key == "import_path_conflict"
 
@@ -273,14 +276,14 @@ async def test_async_import_blueprint_surfaces_blueprint_validation_error(coordi
         patch.object(
             coordinator,
             "_parse_provider_response",
-            AsyncMock(return_value="blueprint:\n  name: Imported\n  domain: automation\n"),
+            AsyncMock(return_value=IMPORTED_BLUEPRINT),
         ),
         patch.object(
             coordinator, "_validate_blueprint", return_value="validation_error|bad schema"
         ),
         pytest.raises(ServiceValidationError) as err,
     ):
-        await coordinator.async_import_blueprint("https://example.com/bp.yaml", confirm=True)
+        await coordinator.async_import_blueprint(IMPORT_URL, confirm=True)
 
     assert err.value.translation_key == "validation_error"
     assert err.value.translation_placeholders == {"error": "bad schema"}

--- a/tests/coordinator/test_import_blueprint_failures.py
+++ b/tests/coordinator/test_import_blueprint_failures.py
@@ -1,12 +1,14 @@
 """Tests for async_import_blueprint failure handling."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, mock_open, patch
 
 import httpx
 import pytest
 from homeassistant.exceptions import ServiceValidationError
 
 from custom_components.blueprints_updater.const import BLUEPRINTS_DATA_DIR, SourceProviderType
+
+PROVIDER_LOOKUP = "custom_components.blueprints_updater.coordinator.registry.get_provider"
 
 
 def _provider(canonical_url: str = "https://example.com/bp.yaml") -> MagicMock:
@@ -16,6 +18,11 @@ def _provider(canonical_url: str = "https://example.com/bp.yaml") -> MagicMock:
     provider.normalize_url.return_value = canonical_url
     provider.get_metadata.return_value = {"author": "author", "name": "name"}
     return provider
+
+
+def _patched_provider(provider):
+    """Patch provider lookup for an import attempt."""
+    return patch(PROVIDER_LOOKUP, return_value=provider)
 
 
 def _response(url: str = "https://example.com/bp.yaml") -> httpx.Response:
@@ -32,10 +39,7 @@ def _response(url: str = "https://example.com/bp.yaml") -> httpx.Response:
 async def test_async_import_blueprint_rejects_unsupported_provider(coordinator):
     """Verify unsupported import sources fail before fetching."""
     with (
-        patch(
-            "custom_components.blueprints_updater.coordinator.registry.get_provider",
-            return_value=None,
-        ),
+        _patched_provider(None),
         pytest.raises(ServiceValidationError) as err,
     ):
         await coordinator.async_import_blueprint("not-a-url", confirm=True)
@@ -49,10 +53,7 @@ async def test_async_import_blueprint_rejects_unsafe_canonical_url(coordinator):
     provider = _provider("http://unsafe.example/bp.yaml")
 
     with (
-        patch(
-            "custom_components.blueprints_updater.coordinator.registry.get_provider",
-            return_value=provider,
-        ),
+        _patched_provider(provider),
         patch.object(coordinator, "_is_safe_url", AsyncMock(side_effect=[True, False])),
         pytest.raises(ServiceValidationError) as err,
     ):
@@ -67,10 +68,7 @@ async def test_async_import_blueprint_rejects_empty_provider_content(coordinator
     provider = _provider()
 
     with (
-        patch(
-            "custom_components.blueprints_updater.coordinator.registry.get_provider",
-            return_value=provider,
-        ),
+        _patched_provider(provider),
         patch.object(
             coordinator, "_execute_with_redirect_guard", AsyncMock(return_value=_response())
         ),
@@ -89,10 +87,7 @@ async def test_async_import_blueprint_wraps_fetch_errors(coordinator):
     provider = _provider()
 
     with (
-        patch(
-            "custom_components.blueprints_updater.coordinator.registry.get_provider",
-            return_value=provider,
-        ),
+        _patched_provider(provider),
         patch.object(
             coordinator,
             "_execute_with_redirect_guard",
@@ -113,10 +108,7 @@ async def test_async_import_blueprint_rejects_malformed_provider_metadata(coordi
     provider.get_metadata.return_value = {"author": "author"}
 
     with (
-        patch(
-            "custom_components.blueprints_updater.coordinator.registry.get_provider",
-            return_value=provider,
-        ),
+        _patched_provider(provider),
         patch.object(
             coordinator, "_execute_with_redirect_guard", AsyncMock(return_value=_response())
         ),
@@ -141,10 +133,7 @@ async def test_async_import_blueprint_rejects_yaml_without_blueprint_block(coord
     provider = _provider()
 
     with (
-        patch(
-            "custom_components.blueprints_updater.coordinator.registry.get_provider",
-            return_value=provider,
-        ),
+        _patched_provider(provider),
         patch.object(
             coordinator, "_execute_with_redirect_guard", AsyncMock(return_value=_response())
         ),
@@ -169,10 +158,7 @@ async def test_async_import_blueprint_rejects_existing_non_string_source_url(coo
     coordinator.data[full_path] = {"source_url": 123}
 
     with (
-        patch(
-            "custom_components.blueprints_updater.coordinator.registry.get_provider",
-            return_value=provider,
-        ),
+        _patched_provider(provider),
         patch.object(
             coordinator, "_execute_with_redirect_guard", AsyncMock(return_value=_response())
         ),
@@ -187,3 +173,114 @@ async def test_async_import_blueprint_rejects_existing_non_string_source_url(coo
 
     assert err.value.translation_key == "import_invalid_source_type"
     assert err.value.translation_placeholders == {"type": "int"}
+
+
+@pytest.mark.asyncio
+async def test_async_import_blueprint_rejects_unsafe_destination_path(coordinator):
+    """Verify imported metadata cannot write outside the safe blueprint root."""
+    provider = _provider()
+
+    with (
+        _patched_provider(provider),
+        patch.object(
+            coordinator, "_execute_with_redirect_guard", AsyncMock(return_value=_response())
+        ),
+        patch.object(
+            coordinator,
+            "_parse_provider_response",
+            AsyncMock(return_value="blueprint:\n  name: Imported\n  domain: automation\n"),
+        ),
+        patch.object(coordinator, "_is_safe_path", return_value=False),
+        pytest.raises(ServiceValidationError) as err,
+    ):
+        await coordinator.async_import_blueprint("https://example.com/bp.yaml", confirm=True)
+
+    assert err.value.translation_key == "unsafe_path"
+
+
+@pytest.mark.asyncio
+async def test_async_import_blueprint_rejects_existing_data_with_conflicting_source(
+    coordinator, tmp_path
+):
+    """Verify existing coordinator data with a different source_url blocks import."""
+    provider = _provider()
+    provider.normalize_url.side_effect = lambda url: (
+        "https://example.com/bp.yaml" if url == "https://example.com/bp.yaml" else url
+    )
+    existing_path = tmp_path / "name.yaml"
+    coordinator.data[str(existing_path)] = {"source_url": "https://other.example/bp.yaml"}
+
+    with (
+        _patched_provider(provider),
+        patch.object(coordinator.hass.config, "path", return_value=str(existing_path)),
+        patch.object(
+            coordinator, "_execute_with_redirect_guard", AsyncMock(return_value=_response())
+        ),
+        patch.object(
+            coordinator,
+            "_parse_provider_response",
+            AsyncMock(return_value="blueprint:\n  name: Imported\n  domain: automation\n"),
+        ),
+        pytest.raises(ServiceValidationError) as err,
+    ):
+        await coordinator.async_import_blueprint("https://example.com/bp.yaml", confirm=True)
+
+    assert err.value.translation_key == "import_path_conflict"
+    placeholders = err.value.translation_placeholders
+    assert placeholders is not None
+    assert placeholders["existing_url"] == "https://other.example/bp.yaml"
+
+
+@pytest.mark.asyncio
+async def test_async_import_blueprint_rejects_existing_file_without_source_url(coordinator):
+    """Verify an existing destination without source_url is treated as a conflict."""
+    provider = _provider()
+    existing_path = "/config/blueprints/automation/author/name.yaml"
+
+    with (
+        _patched_provider(provider),
+        patch.object(coordinator.hass.config, "path", return_value=existing_path),
+        patch.object(
+            coordinator, "_execute_with_redirect_guard", AsyncMock(return_value=_response())
+        ),
+        patch.object(
+            coordinator,
+            "_parse_provider_response",
+            AsyncMock(return_value="blueprint:\n  name: Imported\n  domain: automation\n"),
+        ),
+        patch("custom_components.blueprints_updater.coordinator.os.path.exists", return_value=True),
+        patch(
+            "builtins.open",
+            mock_open(read_data="blueprint:\n  name: Existing\n  domain: automation\n"),
+        ),
+        pytest.raises(ServiceValidationError) as err,
+    ):
+        await coordinator.async_import_blueprint("https://example.com/bp.yaml", confirm=True)
+
+    assert err.value.translation_key == "import_path_conflict"
+
+
+@pytest.mark.asyncio
+async def test_async_import_blueprint_surfaces_blueprint_validation_error(coordinator):
+    """Verify schema validation errors keep their translation key and detail."""
+    provider = _provider()
+
+    with (
+        _patched_provider(provider),
+        patch.object(
+            coordinator, "_execute_with_redirect_guard", AsyncMock(return_value=_response())
+        ),
+        patch.object(
+            coordinator,
+            "_parse_provider_response",
+            AsyncMock(return_value="blueprint:\n  name: Imported\n  domain: automation\n"),
+        ),
+        patch.object(
+            coordinator, "_validate_blueprint", return_value="validation_error|bad schema"
+        ),
+        pytest.raises(ServiceValidationError) as err,
+    ):
+        await coordinator.async_import_blueprint("https://example.com/bp.yaml", confirm=True)
+
+    assert err.value.translation_key == "validation_error"
+    assert err.value.translation_placeholders == {"error": "bad schema"}

--- a/tests/coordinator/test_import_blueprint_failures.py
+++ b/tests/coordinator/test_import_blueprint_failures.py
@@ -1,0 +1,189 @@
+"""Tests for async_import_blueprint failure handling."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from homeassistant.exceptions import ServiceValidationError
+
+from custom_components.blueprints_updater.const import BLUEPRINTS_DATA_DIR, SourceProviderType
+
+
+def _provider(canonical_url: str = "https://example.com/bp.yaml") -> MagicMock:
+    """Build a provider mock that owns a canonical blueprint URL."""
+    provider = MagicMock()
+    provider.provider_type = SourceProviderType.GITHUB
+    provider.normalize_url.return_value = canonical_url
+    provider.get_metadata.return_value = {"author": "author", "name": "name"}
+    return provider
+
+
+def _response(url: str = "https://example.com/bp.yaml") -> httpx.Response:
+    """Build a successful YAML response for import tests."""
+    return httpx.Response(
+        200,
+        content=b"blueprint:\n  name: Imported\n  domain: automation\n",
+        headers={"Content-Type": "text/yaml"},
+        request=httpx.Request("GET", url),
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_import_blueprint_rejects_unsupported_provider(coordinator):
+    """Verify unsupported import sources fail before fetching."""
+    with (
+        patch(
+            "custom_components.blueprints_updater.coordinator.registry.get_provider",
+            return_value=None,
+        ),
+        pytest.raises(ServiceValidationError) as err,
+    ):
+        await coordinator.async_import_blueprint("not-a-url", confirm=True)
+
+    assert err.value.translation_key == "unsupported_source"
+
+
+@pytest.mark.asyncio
+async def test_async_import_blueprint_rejects_unsafe_canonical_url(coordinator):
+    """Verify provider normalization is checked with the same URL safety guard."""
+    provider = _provider("http://unsafe.example/bp.yaml")
+
+    with (
+        patch(
+            "custom_components.blueprints_updater.coordinator.registry.get_provider",
+            return_value=provider,
+        ),
+        patch.object(coordinator, "_is_safe_url", AsyncMock(side_effect=[True, False])),
+        pytest.raises(ServiceValidationError) as err,
+    ):
+        await coordinator.async_import_blueprint("https://example.com/bp.yaml", confirm=True)
+
+    assert err.value.translation_key == "unsafe_url"
+
+
+@pytest.mark.asyncio
+async def test_async_import_blueprint_rejects_empty_provider_content(coordinator):
+    """Verify empty parsed provider content is rejected before metadata is used."""
+    provider = _provider()
+
+    with (
+        patch(
+            "custom_components.blueprints_updater.coordinator.registry.get_provider",
+            return_value=provider,
+        ),
+        patch.object(
+            coordinator, "_execute_with_redirect_guard", AsyncMock(return_value=_response())
+        ),
+        patch.object(coordinator, "_parse_provider_response", AsyncMock(return_value="")),
+        pytest.raises(ServiceValidationError) as err,
+    ):
+        await coordinator.async_import_blueprint("https://example.com/bp.yaml", confirm=True)
+
+    assert err.value.translation_key == "empty_content"
+    provider.get_metadata.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_import_blueprint_wraps_fetch_errors(coordinator):
+    """Verify transport errors are exposed as service fetch errors."""
+    provider = _provider()
+
+    with (
+        patch(
+            "custom_components.blueprints_updater.coordinator.registry.get_provider",
+            return_value=provider,
+        ),
+        patch.object(
+            coordinator,
+            "_execute_with_redirect_guard",
+            AsyncMock(side_effect=httpx.HTTPError("network down")),
+        ),
+        pytest.raises(ServiceValidationError) as err,
+    ):
+        await coordinator.async_import_blueprint("https://example.com/bp.yaml", confirm=True)
+
+    assert err.value.translation_key == "fetch_error"
+    assert err.value.translation_placeholders == {"error": "network down"}
+
+
+@pytest.mark.asyncio
+async def test_async_import_blueprint_rejects_malformed_provider_metadata(coordinator):
+    """Verify provider metadata must include author and name."""
+    provider = _provider()
+    provider.get_metadata.return_value = {"author": "author"}
+
+    with (
+        patch(
+            "custom_components.blueprints_updater.coordinator.registry.get_provider",
+            return_value=provider,
+        ),
+        patch.object(
+            coordinator, "_execute_with_redirect_guard", AsyncMock(return_value=_response())
+        ),
+        patch.object(
+            coordinator,
+            "_parse_provider_response",
+            AsyncMock(return_value="blueprint:\n  name: Imported\n  domain: automation\n"),
+        ),
+        pytest.raises(ServiceValidationError) as err,
+    ):
+        await coordinator.async_import_blueprint("https://example.com/bp.yaml", confirm=True)
+
+    assert err.value.translation_key == "fetch_error"
+    placeholders = err.value.translation_placeholders
+    assert placeholders is not None
+    assert "Malformed metadata" in placeholders["error"]
+
+
+@pytest.mark.asyncio
+async def test_async_import_blueprint_rejects_yaml_without_blueprint_block(coordinator):
+    """Verify YAML that is syntactically valid but not a blueprint is rejected."""
+    provider = _provider()
+
+    with (
+        patch(
+            "custom_components.blueprints_updater.coordinator.registry.get_provider",
+            return_value=provider,
+        ),
+        patch.object(
+            coordinator, "_execute_with_redirect_guard", AsyncMock(return_value=_response())
+        ),
+        patch.object(
+            coordinator, "_parse_provider_response", AsyncMock(return_value="not_blueprint: true")
+        ),
+        pytest.raises(ServiceValidationError) as err,
+    ):
+        await coordinator.async_import_blueprint("https://example.com/bp.yaml", confirm=True)
+
+    assert err.value.translation_key == "invalid_yaml"
+
+
+@pytest.mark.asyncio
+async def test_async_import_blueprint_rejects_existing_non_string_source_url(coordinator):
+    """Verify import conflict detection rejects malformed stored source_url values."""
+    provider = _provider()
+    full_path = coordinator.hass.config.path(
+        BLUEPRINTS_DATA_DIR,
+        "automation/author/name.yaml",
+    )
+    coordinator.data[full_path] = {"source_url": 123}
+
+    with (
+        patch(
+            "custom_components.blueprints_updater.coordinator.registry.get_provider",
+            return_value=provider,
+        ),
+        patch.object(
+            coordinator, "_execute_with_redirect_guard", AsyncMock(return_value=_response())
+        ),
+        patch.object(
+            coordinator,
+            "_parse_provider_response",
+            AsyncMock(return_value="blueprint:\n  name: Imported\n  domain: automation\n"),
+        ),
+        pytest.raises(ServiceValidationError) as err,
+    ):
+        await coordinator.async_import_blueprint("https://example.com/bp.yaml", confirm=True)
+
+    assert err.value.translation_key == "import_invalid_source_type"
+    assert err.value.translation_placeholders == {"type": "int"}

--- a/tests/coordinator/test_networking.py
+++ b/tests/coordinator/test_networking.py
@@ -295,35 +295,82 @@ async def test_execute_with_redirect_guard_304_https_enforcement(coordinator):
         )
 
 
-@pytest.mark.asyncio
-async def test_parse_provider_response_rejects_unsupported_unowned_content(coordinator):
-    """Verify unsupported content is rejected when no provider owns the response URL."""
-    response = httpx.Response(
-        200,
-        headers={"Content-Type": "application/json"},
-        content=b"{}",
-        request=httpx.Request("GET", "https://example.com/data"),
-    )
-
-    with (
-        patch(
-            "custom_components.blueprints_updater.coordinator.registry.get_provider",
-            return_value=None,
+@pytest.mark.parametrize(
+    (
+        "provider_available",
+        "content_type",
+        "body",
+        "url",
+        "expected_match",
+        "should_parse",
+        "expected_json",
+    ),
+    [
+        (
+            False,
+            "application/json",
+            b"{}",
+            "https://example.com/data",
+            "Unsupported content type",
+            False,
+            None,
         ),
-        pytest.raises(HomeAssistantError, match="Unsupported content type"),
-    ):
-        await coordinator._parse_provider_response(response, "https://example.com/data")
-
-
+        (
+            True,
+            "application/json",
+            b"{",
+            "https://community.home-assistant.io/t/1.json",
+            "Invalid JSON response",
+            False,
+            None,
+        ),
+        (
+            True,
+            "application/json",
+            b'{"post_stream": {"posts": []}}',
+            "https://community.home-assistant.io/t/1.json",
+            "Failed to extract blueprint content from JSON",
+            True,
+            {"post_stream": {"posts": []}},
+        ),
+        (
+            True,
+            "text/html",
+            b"<html></html>",
+            "https://example.com/page",
+            "Failed to extract blueprint content from response",
+            True,
+            None,
+        ),
+    ],
+    ids=[
+        "unsupported-unowned-content",
+        "invalid-json",
+        "empty-json-provider-content",
+        "empty-non-json-provider-content",
+    ],
+)
 @pytest.mark.asyncio
-async def test_parse_provider_response_rejects_invalid_json_before_provider_parse(coordinator):
-    """Verify provider JSON responses fail before parsing when the body is malformed."""
-    provider = MagicMock()
+async def test_parse_provider_response_rejects_invalid_content(
+    coordinator,
+    provider_available,
+    content_type,
+    body,
+    url,
+    expected_match,
+    should_parse,
+    expected_json,
+):
+    """Verify invalid provider responses raise behavior-specific errors."""
+    provider = MagicMock() if provider_available else None
+    if provider is not None:
+        provider.parse_content.return_value = None
+
     response = httpx.Response(
         200,
-        headers={"Content-Type": "application/json"},
-        content=b"{",
-        request=httpx.Request("GET", "https://community.home-assistant.io/t/1.json"),
+        headers={"Content-Type": content_type},
+        content=body,
+        request=httpx.Request("GET", url),
     )
 
     with (
@@ -331,62 +378,14 @@ async def test_parse_provider_response_rejects_invalid_json_before_provider_pars
             "custom_components.blueprints_updater.coordinator.registry.get_provider",
             return_value=provider,
         ),
-        pytest.raises(HomeAssistantError, match="Invalid JSON response"),
+        pytest.raises(HomeAssistantError, match=expected_match),
     ):
-        await coordinator._parse_provider_response(
-            response, "https://community.home-assistant.io/t/1.json"
-        )
+        await coordinator._parse_provider_response(response, url)
 
-    provider.parse_content.assert_not_called()
+    if provider is None:
+        return
 
-
-@pytest.mark.asyncio
-async def test_parse_provider_response_rejects_empty_json_provider_content(coordinator):
-    """Verify JSON providers must extract blueprint content from valid JSON."""
-    provider = MagicMock()
-    provider.parse_content.return_value = None
-    response = httpx.Response(
-        200,
-        headers={"Content-Type": "application/json"},
-        content=b'{"post_stream": {"posts": []}}',
-        request=httpx.Request("GET", "https://community.home-assistant.io/t/1.json"),
-    )
-
-    with (
-        patch(
-            "custom_components.blueprints_updater.coordinator.registry.get_provider",
-            return_value=provider,
-        ),
-        pytest.raises(HomeAssistantError, match="Failed to extract blueprint content from JSON"),
-    ):
-        await coordinator._parse_provider_response(
-            response, "https://community.home-assistant.io/t/1.json"
-        )
-
-    provider.parse_content.assert_called_once_with(response.text, {"post_stream": {"posts": []}})
-
-
-@pytest.mark.asyncio
-async def test_parse_provider_response_rejects_empty_non_json_provider_content(coordinator):
-    """Verify non-JSON providers must extract blueprint content from the response body."""
-    provider = MagicMock()
-    provider.parse_content.return_value = None
-    response = httpx.Response(
-        200,
-        headers={"Content-Type": "text/html"},
-        content=b"<html></html>",
-        request=httpx.Request("GET", "https://example.com/page"),
-    )
-
-    with (
-        patch(
-            "custom_components.blueprints_updater.coordinator.registry.get_provider",
-            return_value=provider,
-        ),
-        pytest.raises(
-            HomeAssistantError, match="Failed to extract blueprint content from response"
-        ),
-    ):
-        await coordinator._parse_provider_response(response, "https://example.com/page")
-
-    provider.parse_content.assert_called_once_with(response.text, None)
+    if should_parse:
+        provider.parse_content.assert_called_once_with(response.text, expected_json)
+    else:
+        provider.parse_content.assert_not_called()

--- a/tests/coordinator/test_networking.py
+++ b/tests/coordinator/test_networking.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.blueprints_updater.const import (
     MAX_RETRIES,
@@ -292,3 +293,100 @@ async def test_execute_with_redirect_guard_304_https_enforcement(coordinator):
         await coordinator._execute_with_redirect_guard(
             mock_session, "http://unsafe.com/bp.yaml", {}
         )
+
+
+@pytest.mark.asyncio
+async def test_parse_provider_response_rejects_unsupported_unowned_content(coordinator):
+    """Verify unsupported content is rejected when no provider owns the response URL."""
+    response = httpx.Response(
+        200,
+        headers={"Content-Type": "application/json"},
+        content=b"{}",
+        request=httpx.Request("GET", "https://example.com/data"),
+    )
+
+    with (
+        patch(
+            "custom_components.blueprints_updater.coordinator.registry.get_provider",
+            return_value=None,
+        ),
+        pytest.raises(HomeAssistantError, match="Unsupported content type"),
+    ):
+        await coordinator._parse_provider_response(response, "https://example.com/data")
+
+
+@pytest.mark.asyncio
+async def test_parse_provider_response_rejects_invalid_json_before_provider_parse(coordinator):
+    """Verify provider JSON responses fail before parsing when the body is malformed."""
+    provider = MagicMock()
+    response = httpx.Response(
+        200,
+        headers={"Content-Type": "application/json"},
+        content=b"{",
+        request=httpx.Request("GET", "https://community.home-assistant.io/t/1.json"),
+    )
+
+    with (
+        patch(
+            "custom_components.blueprints_updater.coordinator.registry.get_provider",
+            return_value=provider,
+        ),
+        pytest.raises(HomeAssistantError, match="Invalid JSON response"),
+    ):
+        await coordinator._parse_provider_response(
+            response, "https://community.home-assistant.io/t/1.json"
+        )
+
+    provider.parse_content.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_parse_provider_response_rejects_empty_json_provider_content(coordinator):
+    """Verify JSON providers must extract blueprint content from valid JSON."""
+    provider = MagicMock()
+    provider.parse_content.return_value = None
+    response = httpx.Response(
+        200,
+        headers={"Content-Type": "application/json"},
+        content=b'{"post_stream": {"posts": []}}',
+        request=httpx.Request("GET", "https://community.home-assistant.io/t/1.json"),
+    )
+
+    with (
+        patch(
+            "custom_components.blueprints_updater.coordinator.registry.get_provider",
+            return_value=provider,
+        ),
+        pytest.raises(HomeAssistantError, match="Failed to extract blueprint content from JSON"),
+    ):
+        await coordinator._parse_provider_response(
+            response, "https://community.home-assistant.io/t/1.json"
+        )
+
+    provider.parse_content.assert_called_once_with(response.text, {"post_stream": {"posts": []}})
+
+
+@pytest.mark.asyncio
+async def test_parse_provider_response_rejects_empty_non_json_provider_content(coordinator):
+    """Verify non-JSON providers must extract blueprint content from the response body."""
+    provider = MagicMock()
+    provider.parse_content.return_value = None
+    response = httpx.Response(
+        200,
+        headers={"Content-Type": "text/html"},
+        content=b"<html></html>",
+        request=httpx.Request("GET", "https://example.com/page"),
+    )
+
+    with (
+        patch(
+            "custom_components.blueprints_updater.coordinator.registry.get_provider",
+            return_value=provider,
+        ),
+        pytest.raises(
+            HomeAssistantError, match="Failed to extract blueprint content from response"
+        ),
+    ):
+        await coordinator._parse_provider_response(response, "https://example.com/page")
+
+    provider.parse_content.assert_called_once_with(response.text, None)

--- a/tests/coordinator/test_storage.py
+++ b/tests/coordinator/test_storage.py
@@ -499,6 +499,7 @@ async def test_async_check_backup_exists_rejects_invalid_version_and_unsafe_path
     coordinator.config_entry = MagicMock()
     coordinator.config_entry.options = MappingProxyType({"max_backups": 2})
     coordinator.hass.async_add_executor_job = AsyncMock()
+    coordinator._is_safe_path = MagicMock(return_value=True)
 
     assert await coordinator.async_check_backup_exists("/safe.yaml", 0) is False
     assert await coordinator.async_check_backup_exists("/safe.yaml", 3) is False

--- a/tests/coordinator/test_storage.py
+++ b/tests/coordinator/test_storage.py
@@ -491,3 +491,33 @@ async def test_restore_invalid_version_details(coordinator):
     assert result["translation_key"] == "invalid_version"
     assert result["translation_kwargs"]["version"] == "999"
     assert "max_backups" in result["translation_kwargs"]
+
+
+@pytest.mark.asyncio
+async def test_async_check_backup_exists_rejects_invalid_version_and_unsafe_path(coordinator):
+    """Verify backup existence checks reject invalid versions and unsafe paths."""
+    coordinator.config_entry = MagicMock()
+    coordinator.config_entry.options = MappingProxyType({"max_backups": 2})
+    coordinator.hass.async_add_executor_job = AsyncMock()
+
+    assert await coordinator.async_check_backup_exists("/safe.yaml", 0) is False
+    assert await coordinator.async_check_backup_exists("/safe.yaml", 3) is False
+    coordinator.hass.async_add_executor_job.assert_not_called()
+
+    coordinator._is_safe_path = MagicMock(return_value=False)
+    assert await coordinator.async_check_backup_exists("/unsafe.yaml", 1) is False
+    coordinator.hass.async_add_executor_job.assert_not_called()
+
+
+def test_execute_restore_file_returns_system_error_on_oserror(tmp_path):
+    """Verify restore executor reports filesystem failures as system_error."""
+    target = tmp_path / "restore.yaml"
+
+    with patch("builtins.open", side_effect=OSError("disk failure")):
+        success, message, count = BlueprintUpdateCoordinator._execute_restore_file(
+            str(target), 1, 3
+        )
+
+    assert success is False
+    assert message == "system_error"
+    assert count == 0

--- a/tests/coordinator/test_update_cycle.py
+++ b/tests/coordinator/test_update_cycle.py
@@ -26,6 +26,7 @@ from custom_components.blueprints_updater.const import (
     MAX_CONCURRENT_REQUESTS,
     REQUEST_TIMEOUT,
     RISK_TYPE_TRANSLATIONS,
+    BlueprintBlockingReason,
     BlueprintRiskType,
 )
 from custom_components.blueprints_updater.coordinator import (
@@ -1640,3 +1641,178 @@ async def test_async_update_blueprint_blocks_special_use_tld_local(coordinator, 
         mock_logger.warning.assert_called()
         warning_args = mock_logger.warning.call_args.args
         assert any("Blocking update from untrusted URL" in str(arg) for arg in warning_args)
+
+
+@pytest.mark.asyncio
+async def test_async_fetch_blueprint_returns_without_data_or_source_url(coordinator):
+    """Verify fetch exits before networking when path data or source_url is missing."""
+    coord: Any = coordinator
+
+    with patch("custom_components.blueprints_updater.coordinator.get_async_client") as mock_client:
+        await coord.async_fetch_blueprint("/missing.yaml", force=True)
+        mock_client.assert_not_called()
+
+    path = "/config/blueprints/automation/no_source.yaml"
+    coord.data = {path: {"name": "No Source"}}
+
+    with patch("custom_components.blueprints_updater.coordinator.get_async_client") as mock_client:
+        await coord.async_fetch_blueprint(path, force=True)
+        mock_client.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_not_modified_updates_conditionals_and_skips_without_remote_hash(coordinator):
+    """Verify 304 handling updates validators but does not fetch without a remote hash."""
+    coord: Any = coordinator
+    path = "/config/blueprints/automation/not_modified.yaml"
+    coord.data = {
+        path: {
+            "name": "Not Modified",
+            "local_hash": "local",
+            "remote_hash": None,
+            "updatable": True,
+        }
+    }
+
+    result = await coord._handle_not_modified_case(
+        MagicMock(),
+        path,
+        coord.data[path],
+        "https://example.com/not_modified.yaml",
+        new_etag="etag-new",
+        new_last_modified="Wed, 20 May 2026 00:00:00 GMT",
+    )
+
+    assert result == (None, "etag-new", "Wed, 20 May 2026 00:00:00 GMT")
+    assert coord.data[path]["etag"] == "etag-new"
+    assert coord.data[path]["last_modified"] == "Wed, 20 May 2026 00:00:00 GMT"
+    assert coord.data[path]["updatable"] is True
+
+
+@pytest.mark.asyncio
+async def test_handle_not_modified_returns_without_data(coordinator):
+    """Verify 304 handling is inert when coordinator data no longer contains the path."""
+    coord: Any = coordinator
+    coord.data = {}
+
+    result = await coord._handle_not_modified_case(
+        MagicMock(),
+        "/missing.yaml",
+        {"name": "Missing", "local_hash": "local"},
+        "https://example.com/missing.yaml",
+        new_etag="etag",
+        new_last_modified="last-modified",
+    )
+
+    assert result == (None, "etag", "last-modified")
+
+
+@pytest.mark.asyncio
+async def test_async_fetch_diff_content_rejects_invalid_remote_yaml(coordinator):
+    """Verify invalid remote diff content is not cached for installation."""
+    coord: Any = coordinator
+    path = "/config/blueprints/automation/diff.yaml"
+    coord.data = {
+        path: {
+            "name": "Diff",
+            "relative_path": "automation/diff.yaml",
+            "source_url": "https://example.com/diff.yaml",
+            "local_hash": "local",
+            "remote_hash": "remote",
+            "updatable": True,
+        }
+    }
+    coord._async_fetch_with_cdn_fallback = AsyncMock(return_value=("invalid: yaml: [", None, None))
+
+    with (
+        patch(
+            "custom_components.blueprints_updater.coordinator.get_async_client",
+            return_value=MagicMock(),
+        ),
+        patch.object(coord, "_is_safe_url", AsyncMock(return_value=True)),
+    ):
+        result = await coord.async_fetch_diff_content(path)
+
+    assert result is None
+    assert coord.data[path].get("remote_content") is None
+    last_error = coord.data[path]["last_error"]
+    assert isinstance(last_error, str)
+    assert last_error.startswith("yaml_syntax_error|")
+
+
+@pytest.mark.asyncio
+async def test_async_get_git_diff_returns_none_on_diff_io_error(coordinator):
+    """Verify diff generation I/O errors do not surface stale diff data."""
+    coord: Any = coordinator
+    path = "/config/blueprints/automation/diff_io.yaml"
+    coord.data = {
+        path: {
+            "source_url": "https://example.com/diff_io.yaml",
+            "local_hash": "local",
+            "remote_hash": "remote",
+            "remote_content": "blueprint:\n  name: Remote\n  domain: automation\n",
+            "updatable": True,
+        }
+    }
+    coord.hass.async_add_executor_job = AsyncMock(side_effect=OSError("disk unavailable"))
+
+    result = await coord.async_get_git_diff(path)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_handle_auto_update_step_rejects_missing_remote_hash(coordinator):
+    """Verify auto-update refuses to install when remote_hash is unexpectedly missing."""
+    coord: Any = coordinator
+    coord.async_install_blueprint = AsyncMock()
+
+    result = await coord._handle_auto_update_step(
+        "/config/blueprints/automation/auto.yaml",
+        {"name": "Auto", "relative_path": "automation/auto.yaml"},
+        "remote content",
+        [],
+        [],
+        set(),
+        remote_hash=None,
+    )
+
+    assert result is False
+    coord.async_install_blueprint.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_auto_update_step_preserves_failure_state(coordinator):
+    """Verify failed auto-update records blocking state and keeps remote content."""
+    coord: Any = coordinator
+    path = "/config/blueprints/automation/auto_fail.yaml"
+    coord.data = {path: {}}
+    coord.async_install_blueprint = AsyncMock(side_effect=RuntimeError("install exploded"))
+    results_to_notify: list[str] = []
+    updated_domains: set[str] = set()
+
+    result = await coord._handle_auto_update_step(
+        path,
+        {
+            "name": "Auto Fail",
+            "relative_path": "automation/auto_fail.yaml",
+            "domain": DOMAIN_AUTOMATION,
+        },
+        "remote content",
+        [],
+        results_to_notify,
+        updated_domains,
+        remote_hash="remote-hash",
+        new_etag="etag-new",
+        new_last_modified="Wed, 20 May 2026 00:00:00 GMT",
+        source_url="https://example.com/auto_fail.yaml",
+    )
+
+    assert result is False
+    assert results_to_notify == []
+    assert updated_domains == set()
+    assert coord.data[path]["updatable"] is True
+    assert coord.data[path]["remote_hash"] == "remote-hash"
+    assert coord.data[path]["remote_content"] == "remote content"
+    assert coord.data[path]["update_blocking_reason"] == BlueprintBlockingReason.SYSTEM_ERROR
+    assert coord.data[path]["auto_update_last_error"] == "install exploded"

--- a/tests/providers/test_providers_edge_cases.py
+++ b/tests/providers/test_providers_edge_cases.py
@@ -11,6 +11,7 @@ from custom_components.blueprints_updater.providers import (
     GitHubProvider,
     GitLabProvider,
     HAForumProvider,
+    ProviderRegistry,
 )
 
 
@@ -154,3 +155,38 @@ def test_gist_metadata_normalization():
     metadata_raw = provider.get_metadata(normalized_url)
     assert metadata_raw["author"] == "author"
     assert metadata_raw["name"] == "gist_id"
+
+
+def test_gitlab_normalization_keeps_empty_path_unchanged():
+    """Verify GitLab normalization is inert when there is no path to inspect."""
+    assert GitLabProvider().normalize_url("https://gitlab.com") == "https://gitlab.com"
+
+
+def test_provider_registry_returns_original_url_without_matching_provider():
+    """Verify registry normalization returns invalid sources unchanged."""
+    assert ProviderRegistry().normalize_url("not-a-url") == "not-a-url"
+
+
+def test_ha_forum_metadata_prefers_post_containing_blueprint():
+    """Verify forum metadata uses the post that actually contains blueprint YAML."""
+    provider = HAForumProvider()
+    url = "https://community.home-assistant.io/t/topic/123"
+    content = json.dumps(
+        {
+            "slug": "target-blueprint",
+            "post_stream": {
+                "posts": [
+                    None,
+                    {"username": "intro_author", "cooked": "<p>No YAML here</p>"},
+                    {
+                        "username": "blueprint_author",
+                        "cooked": "<pre><code>blueprint:\n  name: Real</code></pre>",
+                    },
+                ]
+            },
+        }
+    )
+
+    metadata = provider.get_metadata(url, content=content)
+
+    assert metadata == {"author": "blueprint_author", "name": "target-blueprint"}

--- a/tests/utils/test_core_utils.py
+++ b/tests/utils/test_core_utils.py
@@ -8,15 +8,19 @@ import pytest
 
 from custom_components.blueprints_updater.const import CONF_MAX_BACKUPS, CONF_UPDATE_INTERVAL
 from custom_components.blueprints_updater.utils import (
+    get_cdn_url,
     get_config_bool,
     get_config_int,
     get_config_str,
     get_config_value,
     get_max_backups,
+    get_relative_path,
     get_update_interval,
+    normalize_url,
     redact_url,
     retry_async,
     sanitize_error_detail,
+    should_include_blueprint,
 )
 
 
@@ -304,3 +308,48 @@ def test_sanitize_error_detail():
     sanitized = sanitize_error_detail(long_msg, max_length=50)
     assert len(sanitized) <= 50
     assert sanitized.endswith("...")
+
+
+def test_retry_async_rejects_bool_max_retries():
+    """Verify retry_async rejects bool values instead of accepting them as integers."""
+    with pytest.raises(TypeError, match="max_retries must be an integer"):
+        retry_async(True, (Exception,))
+
+
+def test_source_url_helpers_return_safe_defaults_for_unknown_sources():
+    """Verify URL helpers keep unknown malformed sources inert."""
+    assert normalize_url("not-a-url") == "not-a-url"
+    assert get_cdn_url("not-a-url") is None
+
+
+def test_should_include_blueprint_filter_modes():
+    """Verify whitelist and blacklist filtering make opposite inclusion decisions."""
+    selected = {"automation/blocked.yaml"}
+
+    assert not should_include_blueprint("automation/blocked.yaml", "blacklist", selected)
+    assert should_include_blueprint("automation/allowed.yaml", "blacklist", selected)
+    assert should_include_blueprint("automation/blocked.yaml", "whitelist", selected)
+    assert not should_include_blueprint("automation/allowed.yaml", "whitelist", selected)
+    assert should_include_blueprint("automation/allowed.yaml", "all", selected)
+
+
+def test_redact_url_rejects_non_url_objects():
+    """Verify redaction falls back safely for values httpx cannot parse."""
+    assert redact_url(cast(str, object())) == "[REDACTED/INVALID URL]"
+
+
+def test_get_relative_path_reports_commonpath_failures(hass, monkeypatch):
+    """Verify invalid platform path comparisons are reported as unsafe paths."""
+    hass.config.path.return_value = "/config/blueprints"
+
+    def raise_commonpath_error(paths):
+        """Simulate os.path.commonpath failing on incompatible paths."""
+        raise ValueError(f"bad paths: {paths}")
+
+    monkeypatch.setattr(
+        "custom_components.blueprints_updater.utils.os.path.commonpath",
+        raise_commonpath_error,
+    )
+
+    with pytest.raises(ValueError, match="Invalid or unsafe path"):
+        get_relative_path(hass, "/config/blueprints/test.yaml")

--- a/tools/validate_compatibility.py
+++ b/tools/validate_compatibility.py
@@ -27,7 +27,7 @@ _REPO_ROOT = str(Path(__file__).resolve().parent.parent)
 _VENVS_ROOT = os.path.join(_REPO_ROOT, ".venvs")
 
 _REQUIRED_TEST_DEPS = [
-    "h2",
+    "httpx[http2]",
     "pytest",
     "pytest-homeassistant-custom-component",
 ]


### PR DESCRIPTION
## Summary by Sourcery

Expand test coverage for blueprint coordination, networking, utilities, provider edge cases, and storage error handling while updating CI dependencies and coverage configuration.

Enhancements:
- Add extensive tests for blueprint import, update, auto-update, diff generation, provider parsing, and error handling edge cases.
- Strengthen utility tests for URL handling, blueprint filtering, path safety, retry configuration, and restore error reporting.
- Enhance provider edge-case tests for GitLab URL normalization, registry behavior, and Home Assistant forum metadata selection.
- Extend storage tests to validate backup existence checks, unsafe paths, and filesystem failures during restore.

CI:
- Replace the h2 test dependency with httpx[http2] in CI setup and compatibility validation tooling.
- Enable branch coverage collection in pytest configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive tests covering blueprint import failure paths, provider response parsing, networking/storage edge cases, update-cycle behaviors, URL/path utilities, and other input-validation/edge-case scenarios across coordinator, providers, utils, and storage tests.
* **Chores**
  * Switched test tooling to an HTTP/2-capable HTTP client for CI.
  * Enabled branch coverage reporting for test runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luuquangvu/blueprints-updater/pull/82?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->