### PR TITLE
Remove uv and npm package ecosystems from Dependabot configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,13 +4,3 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-
-  - package-ecosystem: "uv"
-    directory: "/"
-    schedule:
-      interval: "daily"
-
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "daily"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dev = [
   "packaging",
   "prek",
   "pyright",
-  "pytest>=9",
+  "pytest",
   "pytest-asyncio",
   "pytest-cov",
   "pytest-homeassistant-custom-component",

--- a/uv.lock
+++ b/uv.lock
@@ -454,7 +454,7 @@ dev = [
     { name = "packaging" },
     { name = "prek" },
     { name = "pyright" },
-    { name = "pytest", specifier = ">=9" },
+    { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-homeassistant-custom-component" },
@@ -518,30 +518,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.43.14"
+version = "1.43.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/79/4b/616367e871ce3f1cb3e8545a97736b6331b9fb081497f2d44c5b2aa6959d/boto3-1.43.14.tar.gz", hash = "sha256:5c0a994b3182061ee101812e721100717a4d664f9f4ceaf4a86b6d032ce9fc2d", size = 113142, upload-time = "2026-05-22T19:28:47.861Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/1f/ef8f2967570c221681056134d02e70ebd490b795c17cf44d52f898344fbd/boto3-1.43.15.tar.gz", hash = "sha256:8dbb1a129c693313218a099d4f086f3bb48f50159b74b5bd8869e1037fde4101", size = 113161, upload-time = "2026-05-26T19:45:14.203Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/00/59cb9329c18e2d3aa23062ceaa87d065f2e81e7d2931df24d64e9a7815aa/boto3-1.43.14-py3-none-any.whl", hash = "sha256:574335744656cfed0b362a0a0467aaf2eb2bf15526edcd02d31d3c661f4b09e4", size = 140536, upload-time = "2026-05-22T19:28:46.49Z" },
+    { url = "https://files.pythonhosted.org/packages/af/8f/373833a5ca86f5b89c7d918c6130aece8d5e43b0c8bdbefac75145abf3f3/boto3-1.43.15-py3-none-any.whl", hash = "sha256:67510ef57a79f0d53b963b0dd1d1741d1e3de1eb2ef6cf1737b6a6bddd34b8cb", size = 140537, upload-time = "2026-05-26T19:45:11.152Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.43.14"
+version = "1.43.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/78/3c/798d2f7deb118241930c7c6bcfb0b970d3f0245bf580700663199aeed2c3/botocore-1.43.14.tar.gz", hash = "sha256:b9e500737e43d2f147c9d4e23b54360335e77d4c0ba90a318f51b65e06cb8516", size = 15382604, upload-time = "2026-05-22T19:28:36.363Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/06/4eb6a40f2a5861cd48743765a80e5a6534f26ec0e9884502572cfadeca50/botocore-1.43.15.tar.gz", hash = "sha256:eed2e24962af03ec361a1dc6924f6b2cff0215a0a2f5c690eab655f43d1f700f", size = 15383526, upload-time = "2026-05-26T19:44:57.627Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/7e/6e64821077cd2efc4aa51b7d638fb6d48e1c7c450201c529fbaf1de8bfd3/botocore-1.43.14-py3-none-any.whl", hash = "sha256:1f4a2a95ea78c10398e78431e98c1fe47adb54a7b10a32975144c1f541186658", size = 15061424, upload-time = "2026-05-22T19:28:32.682Z" },
+    { url = "https://files.pythonhosted.org/packages/51/34/dfdd494cf22a88be269bcf648d28a65f85dcc0f914f52a02f8e740d6ccaf/botocore-1.43.15-py3-none-any.whl", hash = "sha256:bda4923998d1bf17f8eb6bc767a0923fbb9e525ecd50f839b041e469b46e1c94", size = 15063140, upload-time = "2026-05-26T19:44:54.54Z" },
 ]
 
 [[package]]
@@ -775,23 +775,23 @@ wheels = [
 
 [[package]]
 name = "dbus-fast"
-version = "5.0.14"
+version = "5.0.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7f/6b/d4c8871e772ddf73e76bfd725dbb6fa82eb11492b370b423892016f0e579/dbus_fast-5.0.14.tar.gz", hash = "sha256:9c30a134be1a1e4021630e551de040ec38705213c0889ecfdb0218f83beaffa3", size = 82447, upload-time = "2026-05-26T01:50:02.429Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/f0/7d26505ee2a53bc0c47aef4182609b6e1e18845be35ce9a0c6ea2c21f232/dbus_fast-5.0.15.tar.gz", hash = "sha256:a992fcbefb609ad2eebb881c18eeb429bfe814ebe51e535a8710386f54dbdb94", size = 82451, upload-time = "2026-05-26T23:16:19.792Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/8d/2d76ca98c3622dd1c1bf8c510d5d252fa89846690c141a0d69e807c346fd/dbus_fast-5.0.14-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1fe7ed6c1d3dba3ea1273dc6533d97f94c59aeafc5d403cf326c3803cf54e594", size = 811064, upload-time = "2026-05-26T01:58:58.416Z" },
-    { url = "https://files.pythonhosted.org/packages/89/bd/4ad021a670be9f9f25ee3a1277c43e2f297cd9387b15cd1a904bd3b1070f/dbus_fast-5.0.14-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43d8f040eb550243576d37bf7fd364691138f7fdab854a20a21e4d5f418c6b34", size = 855422, upload-time = "2026-05-26T01:59:00.319Z" },
-    { url = "https://files.pythonhosted.org/packages/15/11/65c79391ca43d2c589418d6f5cd9e86ca39445513fdf55c1076a7b17f0fb/dbus_fast-5.0.14-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:302a11e09aca71150a8357ced1523201c483d5511bd5b19143c86694a0929c1e", size = 834031, upload-time = "2026-05-26T01:59:02.31Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/a9/4ecc78ff70f6c11b2b78c796bc326bc4eff016da4483739635bfe8d3549e/dbus_fast-5.0.14-cp314-cp314-manylinux_2_41_x86_64.whl", hash = "sha256:647dd4f2dfa0cc8783373132490d5b6ed5400f04ae263bd89b66175bd3f51f40", size = 853731, upload-time = "2026-05-26T01:49:59.769Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/ef/9be45c01e0b1b40cec3acde7b59988ec273e0959803975ec5e7ef1b672a5/dbus_fast-5.0.14-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:40dd1dd800a933e1ce6c46dd9bbabc080eda7fa1fe7ba9c7fd4261384c469eb7", size = 818869, upload-time = "2026-05-26T01:59:03.78Z" },
-    { url = "https://files.pythonhosted.org/packages/56/86/63c1128391dc08da84651aa9bd3f5ff421b0edb9955537c30962c5d519e2/dbus_fast-5.0.14-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:7a805827a3c47a3cf1247afade584a79966975641c763e1e9bdb284bcab69ef3", size = 834137, upload-time = "2026-05-26T01:59:05.505Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/9c/fec14d9fa583699253fb6fde1f4f447675a5f0403146d757cbf8424b62ea/dbus_fast-5.0.14-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:83612082a226f8dbfad3b05f00dd0b5bef19780e3869edb698a8788574d61de9", size = 862481, upload-time = "2026-05-26T01:59:07.173Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/4f/6604e8637e937802a16e6e51ed80da18f36f3169d9109403fc17718b921f/dbus_fast-5.0.14-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:490b87147d794176d2a3bcddb8eedfa14a39411328bb9dc33004cf77cdb79008", size = 1534811, upload-time = "2026-05-26T01:59:10.84Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/19/f4b3c6d3d37d01739d5229c0b593cc7efb779ea7c2a80b0db601e78a4908/dbus_fast-5.0.14-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ce02f26b08a6f448039151a2bf0a0d482472a1cff16a0819a30aa903f77ca504", size = 1613396, upload-time = "2026-05-26T01:59:12.949Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/7f/c2024fd9f61ae6bd53224cca3fef11beda5d768826bc17895df78928a52b/dbus_fast-5.0.14-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c4a02284bffae08ae2b81ea4b75cbc67a4b7dd9f9ad206c537947813859877c0", size = 822526, upload-time = "2026-05-26T01:59:14.667Z" },
-    { url = "https://files.pythonhosted.org/packages/07/75/a064ce2135cd7b93c8703b457ce79216e9cda51b469d56d845a90b044d31/dbus_fast-5.0.14-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:21f49af595a6e66a20d4bb19ebaca3e63f448c3821f0fe1de4ff27c042b31f37", size = 1550168, upload-time = "2026-05-26T01:59:16.766Z" },
-    { url = "https://files.pythonhosted.org/packages/40/98/30c7b30251d29ba78466a6a49d274c53101d8b3f49dc4b9b1286a5c1a1f5/dbus_fast-5.0.14-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c45878b92e2326190a6173a254d7b37eb23d72401b92e8cda5c88e8bfd1dc1c6", size = 823535, upload-time = "2026-05-26T01:59:18.713Z" },
-    { url = "https://files.pythonhosted.org/packages/18/f4/cd878b446a431730535798bdf8aa2e8d5aeb7854fa0ccf60490ff1799a6b/dbus_fast-5.0.14-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7075d890b1453998be5bb5433eea1184db84d6deebb44d9069dda1df5968a127", size = 1629393, upload-time = "2026-05-26T01:59:20.689Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/cf/7ebb31cc3489c5570d5ac61a0e854b209a3b4d606253dbe2cef3cf632823/dbus_fast-5.0.15-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:293725d5e2365cacd06c1a796d0487afe2bba2117e0a3f501f540a323d2140a2", size = 810776, upload-time = "2026-05-26T23:26:05.16Z" },
+    { url = "https://files.pythonhosted.org/packages/11/be/1813d99d321e258f7acbfc4973a2c9a2e045360215e81ea81f517b1c467d/dbus_fast-5.0.15-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dabc8639846a0ac79260902e516bffa2a022d2b00d287fa9a4fac4a0ec6612f2", size = 855622, upload-time = "2026-05-26T23:26:06.721Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d0/8c2246c3ad90fe039a42376cf53a2f7d2119478d24c7ea614f98768828b5/dbus_fast-5.0.15-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f031880167483e228548330764975be61babe590390cdaa04b8185f69d984f6c", size = 833543, upload-time = "2026-05-26T23:26:08.338Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e7/310a333abf399de7df43a4c7d7c7abe0a90db51b6795298baf314bae6217/dbus_fast-5.0.15-cp314-cp314-manylinux_2_41_x86_64.whl", hash = "sha256:d272e4896e6b5bebf5ef11c576d7f8cdb411d1c460331a6853bb54c9c8f4b2aa", size = 853870, upload-time = "2026-05-26T23:16:16.976Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/73/f2bde195ea6cb2ddf85a8b6eb48bdf200dd76c06b70053ab50aff5b6eb89/dbus_fast-5.0.15-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:576d83a9257ab564ee5bfef3f57f55edb1cd956662e4fb739514a5b9549addee", size = 818564, upload-time = "2026-05-26T23:26:09.926Z" },
+    { url = "https://files.pythonhosted.org/packages/53/c9/b03f05af4c0f25ad860f62c6b5a725a07028916f967aa53fc27978f7d9ed/dbus_fast-5.0.15-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:3e6e46a26e747d9ce68ac81f84ee7c6be30d584476a871add1e003bbc3891576", size = 833707, upload-time = "2026-05-26T23:26:11.443Z" },
+    { url = "https://files.pythonhosted.org/packages/87/06/fb549cc91e0e23ca0a6183a33447c164cf74ce02e13ff83997adeee9f0c4/dbus_fast-5.0.15-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2988d3434fd5a0392a676190e79817c265528221c50a849424a7601aec1cdd56", size = 862510, upload-time = "2026-05-26T23:26:13.416Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/40/e85b9250b41f515b0a9afff66e89f03955e13f962597facd416c4465f7c3/dbus_fast-5.0.15-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:31102b2aced446f928cc17eb7a6790b23d7c56893177253991ac569c57fc72d5", size = 1534447, upload-time = "2026-05-26T23:26:17.318Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/14/672376dd6e7748d4e8fcd3c3350a569d99e39acf30a15666f126615e1e10/dbus_fast-5.0.15-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10e4c69046687cc982ed7f4e2a7e713141861ac946833bc55834cceccdce9dee", size = 1613266, upload-time = "2026-05-26T23:26:19.078Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/42/02d2a8304b0afd7d825cbace2e77e71b302b620f4b0e68caa200192c91de/dbus_fast-5.0.15-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0c1f78a48225a88d76e763b1687cdd5ed3b4cb958fcae0ad09db5458df74f367", size = 821650, upload-time = "2026-05-26T23:26:20.78Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/76/21aa60f39d52549212df3426fbfdec5fe0c3dff59b644fe7459e5fe39946/dbus_fast-5.0.15-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f446612476825a341f1d514e35eb081b1f6ee7730b8aa68d03ecb676ca187798", size = 1549759, upload-time = "2026-05-26T23:26:22.637Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/36/c2b67c43b94d70af14d7eaf453f83ff3ce889b07011f2a173f6e209fb50e/dbus_fast-5.0.15-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:da75d114777bdd9157b9772d67cd83e2a853e0b9069ccd1e3976c755c77f7f58", size = 822700, upload-time = "2026-05-26T23:26:24.582Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/61/ae9b3b3206abf3210da0d606054781d3ea0fcc2841e93b03c67f07147168/dbus_fast-5.0.15-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1a44c2e995ca7417ae829d3adce5d6ce5acabfe141a107cde27575a53ccd9642", size = 1629227, upload-time = "2026-05-26T23:26:26.222Z" },
 ]
 
 [[package]]
@@ -984,7 +984,7 @@ wheels = [
 
 [[package]]
 name = "habluetooth"
-version = "6.7.4"
+version = "6.7.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "async-interrupt" },
@@ -996,27 +996,27 @@ dependencies = [
     { name = "btsocket" },
     { name = "dbus-fast", marker = "sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/44/29/4854a69a33902e87ee1de2bacd540978986592cd382f1e6de3b858506d6a/habluetooth-6.7.4.tar.gz", hash = "sha256:ac1d6f11bdd4abbdc775818772ae501e5156dce8298aedc1f1255e2aa98bffdd", size = 75163, upload-time = "2026-05-25T15:22:53.692Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/ab/54d4e7f337f30f584670ad70863ac079ea4d4a04a53a18a4ab8bad921586/habluetooth-6.7.8.tar.gz", hash = "sha256:e6db5564952ade81b1ffcadb010f5824b5991081fefc6d843b512bb9c5be6300", size = 76036, upload-time = "2026-05-27T00:38:09.963Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a1/dc/6b36e76060ade86c67e5a2e4b8396a61a7a76075e883aceae21a99751751/habluetooth-6.7.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:51e0c88857aa02b6f36d2fd890007247449d42b2fe379da363b20335db00ec9d", size = 759957, upload-time = "2026-05-25T15:33:26.949Z" },
-    { url = "https://files.pythonhosted.org/packages/35/b3/4825273b6f9dbb837fc13f0ff1300dff590756f1d50851eb49fa38f56eca/habluetooth-6.7.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c80ddbc7ac4b8916551103088bae27b1cdd85ccf632f615c3ddcf52c65d4f6bd", size = 891688, upload-time = "2026-05-25T15:33:28.546Z" },
-    { url = "https://files.pythonhosted.org/packages/15/18/5574aaea5b5eb6d81b768d5c583743638b397550aa4c7e586f0c9cd6c28f/habluetooth-6.7.4-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:5dbe0e013e8cbd6a47d66a6393914039a94a216dd1ad07ff8c3aa6ea7ce1f866", size = 852873, upload-time = "2026-05-25T15:33:30.209Z" },
-    { url = "https://files.pythonhosted.org/packages/49/74/f4ff2cdfba3240eb345fba89f57deb78ca342d13c94e664f72dc0484ce29/habluetooth-6.7.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:25f5155512fba6ca1c70474d95276eebc254cc48373d1b5c04f0c5455c3875a4", size = 943100, upload-time = "2026-05-25T15:33:32.277Z" },
-    { url = "https://files.pythonhosted.org/packages/90/5d/929f08960f717abeda9dbe0f16fcd1f08a3cb981c35db3f26d65e5c28c9a/habluetooth-6.7.4-cp314-cp314-manylinux_2_41_x86_64.whl", hash = "sha256:d988e99f24309546e83d7471ed132b302f4e88874cb5fbcd765a81fb039cbf3b", size = 941869, upload-time = "2026-05-25T15:22:51.007Z" },
-    { url = "https://files.pythonhosted.org/packages/15/7d/c3f8dfd0a5aa93f9d53271ee2f964846926757235e2392dd6663eabbdb33/habluetooth-6.7.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9a0c5a1e61d5cb8d89f970d39ac943f074da0f20a7922b4315573fd9b2e08311", size = 903968, upload-time = "2026-05-25T15:33:34.361Z" },
-    { url = "https://files.pythonhosted.org/packages/63/fd/dfd2474ddc6b7d6d1d8647f7094f74a7785bb4662644443fd63d75213273/habluetooth-6.7.4-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:73e48765037e92cb3c977891764f4c1128179c628b9bd6ce2fd681eff33a242b", size = 857816, upload-time = "2026-05-25T15:33:36.472Z" },
-    { url = "https://files.pythonhosted.org/packages/97/88/a4cad2394ccb1330f3cd28e2fcb5399317d5d9bd107366328eb499f4b223/habluetooth-6.7.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a8d3f6353c7537be5121103a563f2257d08f8a0d59afd7820fffc0d3a00a7bef", size = 952360, upload-time = "2026-05-25T15:33:38.21Z" },
-    { url = "https://files.pythonhosted.org/packages/66/31/19f66ceb93bc4f74e90a68a146721d45b519349ad2c3173c073318e6b21b/habluetooth-6.7.4-cp314-cp314-win32.whl", hash = "sha256:9b15eaae0cd94554d5e3dd26979c003e49cab2c379d192d7d57aeaa23cd5459f", size = 618488, upload-time = "2026-05-25T15:33:39.943Z" },
-    { url = "https://files.pythonhosted.org/packages/34/cf/5b27bf1ddea8f489b0974fc6d140ac2b7e076edbc893f389691a38140343/habluetooth-6.7.4-cp314-cp314-win_amd64.whl", hash = "sha256:7df5a88973c6e978611c20a039c9f480db24fe63b183e4a01be1a9bb7e44f9c2", size = 716094, upload-time = "2026-05-25T15:33:41.963Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/c6/ce5e206b5c875a148501ad87f34bf2251bc2d7cd5ededd32c67ef5793186/habluetooth-6.7.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1b77a518647c2faf06b3504263b96a26d9d34aa63e8b4763b234ec1237115e3f", size = 1498113, upload-time = "2026-05-25T15:33:44.386Z" },
-    { url = "https://files.pythonhosted.org/packages/26/9e/d0781e36ca8b63fa6a44f69dcc6929f235a7245b1e0c35cc20bfe82ca566/habluetooth-6.7.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b2f1c8c7ca80855b030a2bfe3d940a91dc130971be55ce0e2d1276b1d81825a3", size = 1696142, upload-time = "2026-05-25T15:33:46.451Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/57/71758c74b5836423312325dabc9965232a885b399e22094711c5eed0301e/habluetooth-6.7.4-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3169ee187d5e4a4d31c76378ca5ab606ba3df28d20a34a0938d17589180b3de5", size = 820900, upload-time = "2026-05-25T15:33:48.121Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/69/a07216df3329c58a2b99d8aee70c014ca16fd721309f419bb11cc9188c92/habluetooth-6.7.4-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7aa46ca59388767bbafac600b7c963424ab3857a4dc707633a63b70d17318fda", size = 1780846, upload-time = "2026-05-25T15:33:50.109Z" },
-    { url = "https://files.pythonhosted.org/packages/66/47/8dbaf8655baf7001815404372aa1f3ef18734b8f52becd9da908b2cf84b8/habluetooth-6.7.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:defb5586a9648e89cd4d743c1c432138ffa51dfeb5a6062d5d85f254ed1b25ee", size = 1722893, upload-time = "2026-05-25T15:33:52.078Z" },
-    { url = "https://files.pythonhosted.org/packages/53/f1/8723f51ea8f404f926f1cde936201cef2d73aaf015f2e082dec41e9297f0/habluetooth-6.7.4-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:43bfaebca738d1463d9b0a90c117f971721ca00ca8b0c72c31fbbc32ba3cb10d", size = 851376, upload-time = "2026-05-25T15:33:53.908Z" },
-    { url = "https://files.pythonhosted.org/packages/81/c7/df63b32b578fe10a1413889af1b3a5970f51615a6a6dbd4c51f893147ec0/habluetooth-6.7.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:376ce7a32cdee55d82961c102b96bd9e9d02dec05e913a7a5a0beb4a5d2eb2df", size = 1801605, upload-time = "2026-05-25T15:33:55.703Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/a1/be23eed020f8025ecb0d4eaa8609efe920e6159d20d67f57f60905437490/habluetooth-6.7.4-cp314-cp314t-win32.whl", hash = "sha256:b63fcaccb15d5b315c11d5bdc28adb203a82a5928e4937925a9f121a64916894", size = 1205355, upload-time = "2026-05-25T15:33:57.843Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/37/2622aff236d6832dfeb13d3ff2210766e38e19b5223e782dc085bcda418a/habluetooth-6.7.4-cp314-cp314t-win_amd64.whl", hash = "sha256:d8015b1bf454bb2d3b10c167aa5b41e08b60e154fddcc65ff9b9c44df748cc40", size = 1409943, upload-time = "2026-05-25T15:33:59.961Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/58/ba4becf45f7e62b0c931a6a062e8a6ffc73bc1aa70a029eed88fb988b3f2/habluetooth-6.7.8-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c57d700f7af999807101576dea2781b976264758c2309d772394c39d6a360164", size = 758959, upload-time = "2026-05-27T00:49:38.012Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/37/99935c88d4546cc916bfcca1dc87aa6fd6de2aa288af0c35205c8502cd33/habluetooth-6.7.8-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:901aa9dbbd143b93e525a1d7ecc2955d6da9b953b9279263263e013372140698", size = 889313, upload-time = "2026-05-27T00:49:39.901Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/0e/ed723662c9f182dec628c78a125f0207d173c69f0c7bc5ea51a241c069d0/habluetooth-6.7.8-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:544d5850ca25a42dffd3f8fe3f19d96253d9e0b99e26bd5fa4cfb14eb1d49570", size = 851787, upload-time = "2026-05-27T00:49:41.445Z" },
+    { url = "https://files.pythonhosted.org/packages/41/25/09c99d0a1e2b766f01ad249e5f78ea44f05c1c262f7e9019dddbb4937c3f/habluetooth-6.7.8-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e0e47166290a7141c91610f2be7284f6d9eedb9afae646085b9e6eb1b2242e9", size = 940852, upload-time = "2026-05-27T00:49:42.941Z" },
+    { url = "https://files.pythonhosted.org/packages/73/66/fe54e7e2791f0fd939666b449137db8c3e557579f512ed885917bb197f5a/habluetooth-6.7.8-cp314-cp314-manylinux_2_41_x86_64.whl", hash = "sha256:7aaa44537b9f9194d0620e6d352c285e2cca934dda34e87d1ab8033af87135f9", size = 939699, upload-time = "2026-05-27T00:38:07.4Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/06/2e037c6f049c19a70f829b11e360a001e7a36a4b826c0fbf66900ac6a707/habluetooth-6.7.8-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:740c554fbe55b6e4cd47863c5d66d4c9f1c0424b301bfa666ad2bc9160b5b3fc", size = 901580, upload-time = "2026-05-27T00:49:44.624Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/5e/bd32b3211992c01be18db44aeb6d0d2f5cd842875651552e95f6cbe82324/habluetooth-6.7.8-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:3d047acdd35f89476430286a03c370e25f7d33caa36124c2b0e4cc5d97560281", size = 856194, upload-time = "2026-05-27T00:49:46.378Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/20/89e9b9ff4857fcf30967d93656fda1c32fe0234c360ed362e7ae4d337996/habluetooth-6.7.8-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:dad65ef79cffa86081c2c1cdd3259acbdd4ba5d8acf1e24a8571b49e6831985e", size = 950682, upload-time = "2026-05-27T00:49:47.847Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/2b/8026ea194563625896c43a3e98cd5a3a0e59650e547595da2b4f9f39e311/habluetooth-6.7.8-cp314-cp314-win32.whl", hash = "sha256:9f7268a32b5a23f05bb89d85f61db1428e342d8f8abdc8c2c801194b1554b47f", size = 617274, upload-time = "2026-05-27T00:49:49.588Z" },
+    { url = "https://files.pythonhosted.org/packages/63/2c/d5d09101433d4360aad5ee25ed1295688a5365410ca8e52368bec271c484/habluetooth-6.7.8-cp314-cp314-win_amd64.whl", hash = "sha256:db1dbfcc0a3bf28afba573d5d10c82307a19641a30a7422bea8e5a2247282984", size = 713916, upload-time = "2026-05-27T00:49:51.021Z" },
+    { url = "https://files.pythonhosted.org/packages/da/9b/4170ba10c554eaab591dc13a95f0f9382bebc5f7ad6566e450a735092032/habluetooth-6.7.8-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:073fda4652db9695a6891c17f713e60a21dae7a8167b40c394eb1e3374b5c928", size = 1494812, upload-time = "2026-05-27T00:49:52.457Z" },
+    { url = "https://files.pythonhosted.org/packages/92/bb/e9747eab3a0ae08b6d1bdc530a584a9e41132648ab0115d9f9a3db67289b/habluetooth-6.7.8-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4530b33915837e614b62fe68d4a31f10786ba4ce245a61be595028d4030a69cf", size = 1689984, upload-time = "2026-05-27T00:49:54.23Z" },
+    { url = "https://files.pythonhosted.org/packages/38/71/dc9171d510b069dfcca0f021b52618ccf3f1aa5cb035a5f81a869844eb53/habluetooth-6.7.8-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:9d582e29293d3fbd73f1c5f88e85f110b3b5573c117aae3c97c5c0f006862e77", size = 819645, upload-time = "2026-05-27T00:49:55.878Z" },
+    { url = "https://files.pythonhosted.org/packages/61/ee/22cb662556e021ab4cd32841e4a202fea3b443aa9af317c9d4b22825c091/habluetooth-6.7.8-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:42cfa28954af28713e20302fefba8995ff2e842e33366b5c2d7740094e46092f", size = 1774675, upload-time = "2026-05-27T00:49:57.438Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/5c/06bb8071283f9265b658aa2f3935cdeb1f683795b1073e1cea3000959972/habluetooth-6.7.8-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:915f181800289b397d9eacef1bfda7426f2c403e2db73f5a96d9f6dca3ea68ac", size = 1716364, upload-time = "2026-05-27T00:49:59.253Z" },
+    { url = "https://files.pythonhosted.org/packages/44/30/17dd9b7b844728e696470f40cbfd1ff0221885327a23b21901f15cea7de3/habluetooth-6.7.8-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:09be03cc7dbad9939c8f52b13443baa21b6468d324eee1ed464208a1abfad423", size = 850161, upload-time = "2026-05-27T00:50:00.857Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/03/bd18afb1683382e4b4c267449358c5a1499601fa60c3fcb51f5ffccaadcc/habluetooth-6.7.8-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cfd7e0e964e3c79003c15d3ef22427d0ea125d14709028cf8ff47a326f68edec", size = 1795774, upload-time = "2026-05-27T00:50:02.546Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/09/4740af67363563b4877cee59330de44c8f31faf39b9824840ddca6c6b8e7/habluetooth-6.7.8-cp314-cp314t-win32.whl", hash = "sha256:de073a6f41047412189b797293e22f098b5bc1a3e17dffe008d2c3c97b267ece", size = 1202232, upload-time = "2026-05-27T00:50:04.26Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/39/8c2f685317d8bedc6960609d3fca79fe6899d7b289aa58edc7c77d4abb78/habluetooth-6.7.8-cp314-cp314t-win_amd64.whl", hash = "sha256:31bf53d8cbb7d85ca6f9d1a0180081c6ea3a5d4c32d03148643cf58e5fdc7641", size = 1403860, upload-time = "2026-05-27T00:50:06.624Z" },
 ]
 
 [[package]]
@@ -2252,14 +2252,14 @@ wheels = [
 
 [[package]]
 name = "s3transfer"
-version = "0.17.0"
+version = "0.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/ec/7c692cde9125b77e84b307354d4fb705f98b8ccad59a036d5957ca75bfc3/s3transfer-0.17.0.tar.gz", hash = "sha256:9edeb6d1c3c2f89d6050348548834ad8289610d886e5bf7b7207728bd43ce33a", size = 155337, upload-time = "2026-04-29T22:07:36.33Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/b3/bcdc2f58fa92592db511beda154c2c08d28f21f6c4637f06a42a24b10c21/s3transfer-0.17.1.tar.gz", hash = "sha256:042dd5e3b1b512355e35a23f0223e426b7042e80b97830ea2680ddce327fc45e", size = 159439, upload-time = "2026-05-26T19:45:01.714Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/72/c6c32d2b657fa3dad1de340254e14390b1e334ce38268b7ad51abda3c8c2/s3transfer-0.17.0-py3-none-any.whl", hash = "sha256:ce3801712acf4ad3e89fb9990df97b4972e93f4b3b0004d214be5bce12814c20", size = 86811, upload-time = "2026-04-29T22:07:34.966Z" },
+    { url = "https://files.pythonhosted.org/packages/85/dd/904873250a6554fbae40cddbf9198e3cc37a2f1319d5e1a5ce82fe269c17/s3transfer-0.17.1-py3-none-any.whl", hash = "sha256:5b9827d1044159bbb01b86ef8902760ea39281927f5de31de75e1d657177bf4c", size = 88264, upload-time = "2026-05-26T19:45:00.452Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary by Sourcery

Update dependency management configuration by simplifying Dependabot ecosystems and adjusting Python tooling constraints.

Build:
- Remove uv and npm package ecosystems from Dependabot configuration, leaving only GitHub Actions updates enabled.

Chores:
- Relax the pytest development dependency constraint and remove the uv lockfile from version control.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Dependabot configuration to track GitHub Actions dependencies daily
  * Removed automated update configurations for uv and npm
  * Modified pytest development dependency constraint

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luuquangvu/blueprints-updater/pull/88?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->