### PR TITLE
Fix the problem where updating a blueprint occasionally causes it to revert to an older version instead of the latest one

### DIFF
--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -257,6 +257,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
         self._safe_hostname_lock = asyncio.Lock()
         self._blueprint_validate_lock = asyncio.Lock()
         self._first_update_done = False
+        self._expected_hash_len: int | None = None
         if self.config_entry:
             self.config_entry.async_on_unload(self._async_cancel_background_task)
 
@@ -2504,6 +2505,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             session,
             path,
             normalized_url,
+            source_url,
             cdn_url,
             stored_etag=None,
             stored_last_modified=None,
@@ -2655,6 +2657,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
         session: httpx.AsyncClient,
         path: str,
         normalized_url: str,
+        source_url: str,
         cdn_url: str | None,
         stored_etag: str | None,
         stored_last_modified: str | None,
@@ -2667,6 +2670,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
             session: Async HTTP client session.
             path: Local path of the blueprint.
             normalized_url: The normalized raw GitHub URL.
+            source_url: The original blueprint source URL identity.
             cdn_url: The jsDelivr CDN URL, if applicable.
             stored_etag: Previously stored ETag.
             stored_last_modified: Previously stored Last-Modified date.
@@ -2681,6 +2685,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
         last_modified = stored_last_modified if (stored_remote_hash and not force) else None
 
         if cdn_url:
+            mismatch_fallback = False
             try:
                 _LOGGER.debug("Fetching blueprint via CDN: %s", redact_url(cdn_url))
                 remote_content, new_etag, new_last_modified = await self._async_fetch_content(
@@ -2690,7 +2695,29 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
                     remote_content is None
                     and (new_etag is not None or new_last_modified is not None)
                 ):
-                    return remote_content, new_etag, new_last_modified
+                    if self._expected_hash_len is None:
+                        self._expected_hash_len = len(
+                            self._hash_content("", already_normalized=True)
+                        )
+                    if (
+                        remote_content
+                        and stored_remote_hash
+                        and len(stored_remote_hash) == self._expected_hash_len
+                    ):
+                        ensured_content = self._ensure_source_url(remote_content, source_url)
+                        cdn_hash = self._hash_content(
+                            ensured_content, source_url, already_normalized=True
+                        )
+                        if cdn_hash != stored_remote_hash:
+                            _LOGGER.debug(
+                                "CDN content mismatch detected (CDN: %s, stored: %s); "
+                                "falling back to authoritative source URL for validation.",
+                                cdn_hash[:8],
+                                stored_remote_hash[:8],
+                            )
+                            mismatch_fallback = True
+                    if not mismatch_fallback:
+                        return remote_content, new_etag, new_last_modified
             except (TimeoutError, httpx.HTTPError, HomeAssistantError) as err:
                 _LOGGER.warning(
                     "CDN fetch failed for %s; falling back to original source: %s",
@@ -2745,6 +2772,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
                 session,
                 path,
                 normalized_url,
+                source_url,
                 cdn_url,
                 stored_etag,
                 stored_last_modified,
@@ -2842,6 +2870,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
                 session,
                 path,
                 normalized_url,
+                info.get("source_url", ""),
                 cdn_url,
                 stored_etag=None,
                 stored_last_modified=None,

--- a/tests/coordinator/test_last_modified_logic.py
+++ b/tests/coordinator/test_last_modified_logic.py
@@ -66,7 +66,7 @@ async def test_async_fetch_with_cdn_fallback_last_modified_propagation(coordinat
     coordinator._async_fetch_content = AsyncMock(return_value=("content", "etag", None))
 
     content, etag, last_modified = await coordinator._async_fetch_with_cdn_fallback(
-        session, "path", normalized_url, cdn_url, None, None, None, False
+        session, "path", normalized_url, normalized_url, cdn_url, None, None, None, False
     )
 
     assert content == "content"
@@ -83,6 +83,7 @@ async def test_async_fetch_with_cdn_fallback_last_modified_propagation(coordinat
     content2, etag2, last_modified2 = await coordinator._async_fetch_with_cdn_fallback(
         session,
         "path",
+        normalized_url,
         normalized_url,
         cdn_url,
         None,

--- a/tests/coordinator/test_update_cycle.py
+++ b/tests/coordinator/test_update_cycle.py
@@ -1278,7 +1278,7 @@ async def test_async_update_blueprint_cdn_gating(coordinator, cdn_config, expect
             mock_session, path, info, results_to_notify, updated_domains
         )
         _args, _kwargs = mock_fetch.call_args
-        cdn_url_arg = _args[3]
+        cdn_url_arg = _args[4]
 
         if expect_cdn:
             assert cdn_url_arg is not None

--- a/tests/utils/test_cdn.py
+++ b/tests/utils/test_cdn.py
@@ -93,7 +93,7 @@ async def test_async_fetch_with_cdn_fallback_success(coordinator):
     coordinator._async_fetch_content = AsyncMock(return_value=("content", "etag", None))
 
     content, etag, _last_modified = await coordinator._async_fetch_with_cdn_fallback(
-        session, "path", normalized_url, cdn_url, None, None, None, False
+        session, "path", normalized_url, normalized_url, cdn_url, None, None, None, False
     )
 
     assert content == "content"
@@ -113,7 +113,15 @@ async def test_async_fetch_with_cdn_fallback_304(coordinator):
     coordinator._async_fetch_content = AsyncMock(return_value=(None, "old_etag", None))
 
     content, etag, _last_modified = await coordinator._async_fetch_with_cdn_fallback(
-        session, "path", normalized_url, cdn_url, "old_etag", None, "old_hash", False
+        session,
+        "path",
+        normalized_url,
+        normalized_url,
+        cdn_url,
+        "old_etag",
+        None,
+        "old_hash",
+        False,
     )
 
     assert content is None
@@ -135,7 +143,7 @@ async def test_async_fetch_with_cdn_fallback_failure_fallback(coordinator):
     )
 
     content, etag, _last_modified = await coordinator._async_fetch_with_cdn_fallback(
-        session, "path", normalized_url, cdn_url, None, None, None, False
+        session, "path", normalized_url, normalized_url, cdn_url, None, None, None, False
     )
 
     assert content == "fallback_content"
@@ -161,7 +169,7 @@ async def test_async_fetch_with_cdn_enabled_but_no_cdn_url(coordinator):
     coordinator._async_fetch_content = AsyncMock(return_value=("orig", "orig_etag", None))
 
     content, _etag, _last_modified = await coordinator._async_fetch_with_cdn_fallback(
-        session, "path", normalized_url, cdn_url, None, None, None, False
+        session, "path", normalized_url, normalized_url, cdn_url, None, None, None, False
     )
 
     assert content == "orig"
@@ -185,6 +193,7 @@ async def test_async_fetch_with_cdn_fallback_etag_only(coordinator):
     content, etag, _last_modified = await coordinator._async_fetch_with_cdn_fallback(
         session,
         "path",
+        normalized_url,
         normalized_url,
         cdn_url,
         stored_etag,
@@ -220,6 +229,7 @@ async def test_async_fetch_with_cdn_fallback_force_ignores_etag_and_hash(coordin
         session,
         "path",
         normalized_url,
+        normalized_url,
         cdn_url,
         stored_etag,
         None,
@@ -246,7 +256,7 @@ async def test_async_fetch_with_cdn_fallback_silent_failure(coordinator):
     )
 
     content, etag, _last_modified = await coordinator._async_fetch_with_cdn_fallback(
-        session, "path", normalized_url, cdn_url, None, None, None, False
+        session, "path", normalized_url, normalized_url, cdn_url, None, None, None, False
     )
 
     assert content == "orig_content"
@@ -268,7 +278,7 @@ async def test_async_fetch_with_cdn_fallback_empty_content(coordinator):
     )
 
     content, etag, _last_modified = await coordinator._async_fetch_with_cdn_fallback(
-        session, "path", normalized_url, cdn_url, None, None, None, False
+        session, "path", normalized_url, normalized_url, cdn_url, None, None, None, False
     )
 
     assert content == "orig_content"
@@ -295,6 +305,7 @@ async def test_async_fetch_with_cdn_failure_preserves_conditional_etag(coordinat
         session,
         "path",
         normalized_url,
+        normalized_url,
         cdn_url,
         stored_etag,
         stored_last_modified,
@@ -314,3 +325,49 @@ async def test_async_fetch_with_cdn_failure_preserves_conditional_etag(coordinat
     assert args1[1] == normalized_url
     assert kwargs1.get("etag") == stored_etag
     assert kwargs1.get("last_modified") == stored_last_modified
+
+
+@pytest.mark.asyncio
+async def test_async_fetch_with_cdn_fallback_lag_detection(coordinator, monkeypatch):
+    """Test that if CDN returns lagged content, it falls back to the original source."""
+    session = MagicMock(spec=httpx.AsyncClient)
+    source_url = "https://github.com/u/r/blob/b/p.yaml"
+    normalized_url = "https://raw.githubusercontent.com/u/r/b/p.yaml"
+    cdn_url = "https://cdn.jsdelivr.net/gh/u/r@b/p.yaml"
+
+    new_content_raw = "blueprint:\n  name: Test\n"
+    lagged_content_raw = "blueprint:\n  name: Stale\n"
+
+    # Compute stored remote hash using the real methods with source_url
+    stored_remote_content = coordinator._ensure_source_url(new_content_raw, source_url)
+    stored_remote_hash = coordinator._hash_content(
+        stored_remote_content, source_url, already_normalized=True
+    )
+
+    mock_fetch_content = AsyncMock(
+        side_effect=[
+            (lagged_content_raw, "cdn_etag", None),
+            (new_content_raw, "origin_etag", None),
+        ]
+    )
+    monkeypatch.setattr(coordinator, "_async_fetch_content", mock_fetch_content)
+
+    content, etag, _last_modified = await coordinator._async_fetch_with_cdn_fallback(
+        session,
+        "path",
+        normalized_url,
+        source_url,
+        cdn_url,
+        None,
+        None,
+        stored_remote_hash,
+        False,
+    )
+
+    assert content == new_content_raw
+    assert etag == "origin_etag"
+    assert mock_fetch_content.call_count == 2
+
+    calls = mock_fetch_content.call_args_list
+    assert calls[0][0][1] == cdn_url
+    assert calls[1][0][1] == normalized_url

--- a/uv.lock
+++ b/uv.lock
@@ -228,14 +228,14 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.13.0"
+version = "4.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/b5/001890774a9552aff22502b8da382593109ce0c95314abaebbb116567545/anyio-4.14.0.tar.gz", hash = "sha256:b47c1f9ccf73e67021df785332508f99379c68fa7d0684e8e3492cb1d4b23f89", size = 253586, upload-time = "2026-06-15T22:00:49.021Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/16/9826f089383c593cdfc4a6e5aca94d9e91ae1692c57af82c3b2aa5e810f7/anyio-4.14.0-py3-none-any.whl", hash = "sha256:dd9b7a2a9799ed6552fde617b2c5df02b7fdd7d88392fc48101e51bae46164d9", size = 123506, upload-time = "2026-06-15T22:00:47.595Z" },
 ]
 
 [[package]]
@@ -565,30 +565,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.43.29"
+version = "1.43.31"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/85/a6/9c02ff00d08ea87908934351d244e35bb6fb5cbc169e1a14fc5bd80d124b/boto3-1.43.29.tar.gz", hash = "sha256:354006c512cdb87ef8214a095f2ade961c8145734475cd7a7e6b39260ff5494a", size = 113198, upload-time = "2026-06-12T19:32:23.442Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/8a/1d33e395da9319b162046ff7d7e75550756425c2a236d8682b4a1bbdec1c/boto3-1.43.31.tar.gz", hash = "sha256:8165b79c02955affbe4b4e9aa7c560684d0d4d86b4b9de66a37b45eb79fc4b69", size = 113122, upload-time = "2026-06-16T19:45:02.677Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/5c/f12a9978526c7068c873ccf9788161fc6af338c6a025f1354a46134a6e46/boto3-1.43.29-py3-none-any.whl", hash = "sha256:77c27ada27cdbf619a3bbc41fa9e991caef818d3a2988cf92ea722e107d90108", size = 140537, upload-time = "2026-06-12T19:32:21.682Z" },
+    { url = "https://files.pythonhosted.org/packages/13/66/67b54f12fc0c5b2dc6fd0c04ea4cf1e7fc4a9843de680a22070d1fd77901/boto3-1.43.31-py3-none-any.whl", hash = "sha256:69c5521ad864f33d4d53b0e18a3927697f4558210693b1cb4dd97da959d1f7b9", size = 140533, upload-time = "2026-06-16T19:44:59.93Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.43.29"
+version = "1.43.31"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6f/54/df99c5ca5c9ef275e34b87e177782e3ca054fc35f1f462c40fe180936c81/botocore-1.43.29.tar.gz", hash = "sha256:dce39d33b707aa162aa3820975f99d7f8f746d46576169fb42ce4f2b3b56b261", size = 15512384, upload-time = "2026-06-12T19:32:13.754Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/17/225ae5e7253441ae3beadf26aa12c2f9ce292f386a4877a2ed0bb17d6014/botocore-1.43.31.tar.gz", hash = "sha256:c249625faaa353c5b4004043706a394a4f3bcd3643e242f6b01fff6dc70e988b", size = 15540929, upload-time = "2026-06-16T19:44:47.202Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/b1/aa410c22355f8f6c4ac2433db6a1c557dd959acf2953ccae4bfc37488119/botocore-1.43.29-py3-none-any.whl", hash = "sha256:5d62f2a03ed279a50207ca2824e009313df15f082b6bb591a095a4f04c7faef3", size = 15194135, upload-time = "2026-06-12T19:32:09.463Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/1e/da5fdcb8438008d3c53a0c6de6a40cb10bdb7e02a6e034aef79bc2b66800/botocore-1.43.31-py3-none-any.whl", hash = "sha256:4c51c63f39515fc1a2b8e3e2c29e452009c988ba55ad489251658fdd3aedad6e", size = 15223619, upload-time = "2026-06-16T19:44:43.116Z" },
 ]
 
 [[package]]
@@ -2336,14 +2336,14 @@ wheels = [
 
 [[package]]
 name = "s3transfer"
-version = "0.18.0"
+version = "0.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/1f/12417f7f493fc45e1f9fd5d4a9b6c125cf8d2cf3f8ddbdfab3e76406e9d6/s3transfer-0.18.0.tar.gz", hash = "sha256:3760b8b7ec1315da54048b2d626276732bee4300d054d492d4e1d43e20d4ecbd", size = 160560, upload-time = "2026-05-28T19:39:09.124Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/94/dcdaeb1713cab9c84def276cfac7388b17c7d9855bbcfe88d77e4dbafd44/s3transfer-0.19.0.tar.gz", hash = "sha256:ce436931687addc4c1712d52d40b32f53e88315723f107ffa20ba82b05a0f685", size = 165171, upload-time = "2026-06-16T19:44:51.599Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/58/a58fc997655386daa2e25784e30c288aa3e3819e401f77029ee4899fb55a/s3transfer-0.18.0-py3-none-any.whl", hash = "sha256:239c13b09e65ad0346e1be7348b8a202dcad44ac7ea7c6eb858fc881dce739b6", size = 88572, upload-time = "2026-05-28T19:39:07.999Z" },
+    { url = "https://files.pythonhosted.org/packages/46/5f/4c174edad94f82de888ac00a5ddd8d07b35609b6c94f0bdf4d74af57703e/s3transfer-0.19.0-py3-none-any.whl", hash = "sha256:777cc2415536f1debadb5c2ef7779275d0fc0fe0e042411cdd6caebeb2685262", size = 90101, upload-time = "2026-06-16T19:44:50.439Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Close #108 

## Summary by Sourcery

Ensure CDN-based blueprint updates detect and avoid serving lagged content, falling back to the origin when CDN content appears outdated.

Bug Fixes:
- Prevent blueprints from reverting to older versions by detecting mismatches between CDN content and the stored remote hash and falling back to the origin source.

Tests:
- Add an async CDN fallback test that verifies lagged CDN content triggers a fetch from the origin URL and uses the newer content.

## Summary by Sourcery

Detect and avoid serving outdated CDN blueprint content by validating hashes and falling back to the authoritative source URL when necessary.

Bug Fixes:
- Prevent blueprints from reverting to older versions by comparing CDN-fetched content against the stored remote hash and falling back to the origin when mismatches are detected.

Enhancements:
- Track expected hash length and propagate the original source URL through CDN fetch helpers to support safer content validation.

Tests:
- Update existing CDN fallback tests for the extended source URL parameter and add a new async test that verifies lagged CDN content triggers an origin fetch and uses the newer content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CDN fallback for blueprint updates by adding stronger integrity checks. The system now verifies CDN-fetched content against expected hashes and ensures the original source URL metadata is preserved; on hash mismatch, it suppresses the CDN response and falls back to the authoritative fetch.

* **Tests**
  * Updated CDN fallback and update-cycle unit tests to reflect the revised call signature.
  * Added coverage to detect CDN “lagged” content and confirm fallback to the origin result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->