### PR TITLE
Improve compatibility validation for Python and HA constraints

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,22 +34,22 @@ jobs:
         run: uv sync --all-groups
 
       - name: Run Ruff
-        run: uv run --no-project ruff check
+        run: uv run ruff check
 
       - name: Run Ruff Format
-        run: uv run --no-project ruff format --check
+        run: uv run ruff format --check
 
       - name: Run Ty Check
-        run: uv run --no-project ty check
+        run: uv run ty check
 
       - name: Run Pyright
-        run: uv run --no-project pyright
+        run: uv run pyright
 
       - name: Run Interrogate
-        run: uv run --no-project interrogate
+        run: uv run interrogate
 
       - name: Run Tests
-        run: uv run --no-project pytest
+        run: uv run pytest
 
   setup-matrix:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-.venv*/
+.venv/
+.venvs/
 .idea/
 .vscode/
 __pycache__/
@@ -7,3 +8,4 @@ __pycache__/
 node_modules/
 scratch/
 .coverage
+.coverage.*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,58 +2,58 @@ repos:
   - repo: local
     hooks:
       - id: ruff-format
-        name: ruff-format
-        entry: uv run --no-project ruff format
+        name: Run Ruff Format
+        entry: uv run ruff format
         language: system
         pass_filenames: false
         always_run: true
 
       - id: ruff-check
-        name: ruff-check
-        entry: uv run --no-project ruff check --fix
+        name: Run Ruff Check
+        entry: uv run ruff check --fix
         language: system
         pass_filenames: false
         always_run: true
 
       - id: ty-check
-        name: ty-check
-        entry: uv run --no-project ty check
+        name: Run Ty Check
+        entry: uv run ty check
         language: system
         pass_filenames: false
         always_run: true
 
       - id: pyright
-        name: pyright
-        entry: uv run --no-project pyright
+        name: Run Pyright
+        entry: uv run pyright
         language: system
         pass_filenames: false
         always_run: true
 
       - id: interrogate
-        name: interrogate
-        entry: uv run --no-project interrogate
+        name: Run Interrogate
+        entry: uv run interrogate
         language: system
         pass_filenames: false
         always_run: true
 
       - id: prettier
-        name: prettier
+        name: Run Prettier
         entry: npx prettier --log-level warn --write .
         language: system
         pass_filenames: false
         always_run: true
 
       - id: pytest
-        name: pytest
-        entry: uv run --no-project pytest
+        name: Run Pytest
+        entry: uv run pytest
         language: system
         pass_filenames: false
         always_run: true
         stages: [pre-push]
 
       - id: compatibility
-        name: compatibility
-        entry: uv run --no-project tools/validate_compatibility.py
+        name: Run Compatibility Check
+        entry: uv run tools/validate_compatibility.py
         language: system
         pass_filenames: false
         always_run: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = ["httpx[http2]"]
 
 [dependency-groups]
 dev = [
-  "homeassistant>=2026.6.0",
+  "homeassistant",
   "interrogate",
   "orjson",
   "packaging",
@@ -18,13 +18,14 @@ dev = [
   "pytest-cov",
   "pytest-homeassistant-custom-component",
   "pytest-timeout",
+  "pytest-xdist",
   "ruff",
   "tomlkit",
   "ty",
 ]
 
 [tool.uv]
-override-dependencies = ["homeassistant>=2026.6.0"]
+override-dependencies = ["homeassistant>=2026.7.0"]
 
 [tool.ruff]
 line-length = 100
@@ -68,6 +69,8 @@ filterwarnings = [
   "ignore::pytest.PytestDeprecationWarning",
 ]
 addopts = [
+  "-n",
+  "auto",
   "--quiet",
   "--cov=custom_components",
   "--cov-fail-under=90",

--- a/tools/validate.py
+++ b/tools/validate.py
@@ -22,6 +22,7 @@ from collections.abc import Callable
 from pathlib import Path
 
 import orjson
+from packaging.version import InvalidVersion, Version
 
 _DEPENDENCY_SYNC_TIMEOUT_SECONDS = 300
 _DEPENDENCY_UPDATE_TIMEOUT_SECONDS = 120
@@ -612,7 +613,12 @@ def _check_and_sync_ha_constraints(repo_root: str) -> None:
             except md.PackageNotFoundError:
                 drifted.append((norm_pkg, "not installed", req_ver))
             else:
-                if installed_ver != req_ver:
+                is_drifted = False
+                try:
+                    is_drifted = Version(installed_ver) != Version(req_ver)
+                except InvalidVersion:
+                    is_drifted = installed_ver != req_ver
+                if is_drifted:
                     drifted.append((norm_pkg, installed_ver, req_ver))
 
         if drifted:
@@ -705,50 +711,50 @@ def _validate_pipeline() -> None:
         print_notice=_print_npm_dependency_update_notice,
     )
 
-    ruff_format_label = "uv run --no-project ruff format"
+    ruff_format_label = "uv run ruff format"
     print(f"STEP_START: {ruff_format_label}", flush=True)
     subprocess.run(
-        ["uv", "run", "--no-project", "ruff", "format"],
+        ["uv", "run", "ruff", "format"],
         check=True,
         cwd=repo_root,
         timeout=_VALIDATION_STEP_TIMEOUT_SECONDS,
     )
     print(f"STEP_OK: {ruff_format_label}", flush=True)
 
-    ruff_check_label = "uv run --no-project ruff check --fix"
+    ruff_check_label = "uv run ruff check --fix"
     print(f"STEP_START: {ruff_check_label}", flush=True)
     subprocess.run(
-        ["uv", "run", "--no-project", "ruff", "check", "--fix"],
+        ["uv", "run", "ruff", "check", "--fix"],
         check=True,
         cwd=repo_root,
         timeout=_VALIDATION_STEP_TIMEOUT_SECONDS,
     )
     print(f"STEP_OK: {ruff_check_label}", flush=True)
 
-    ty_check_label = "uv run --no-project ty check"
+    ty_check_label = "uv run ty check"
     print(f"STEP_START: {ty_check_label}", flush=True)
     subprocess.run(
-        ["uv", "run", "--no-project", "ty", "check"],
+        ["uv", "run", "ty", "check"],
         check=True,
         cwd=repo_root,
         timeout=_VALIDATION_STEP_TIMEOUT_SECONDS,
     )
     print(f"STEP_OK: {ty_check_label}", flush=True)
 
-    pyright_label = "uv run --no-project pyright"
+    pyright_label = "uv run pyright"
     print(f"STEP_START: {pyright_label}", flush=True)
     subprocess.run(
-        ["uv", "run", "--no-project", "pyright"],
+        ["uv", "run", "pyright"],
         check=True,
         cwd=repo_root,
         timeout=_VALIDATION_STEP_TIMEOUT_SECONDS,
     )
     print(f"STEP_OK: {pyright_label}", flush=True)
 
-    interrogate_label = "uv run --no-project interrogate"
+    interrogate_label = "uv run interrogate"
     print(f"STEP_START: {interrogate_label}", flush=True)
     subprocess.run(
-        ["uv", "run", "--no-project", "interrogate"],
+        ["uv", "run", "interrogate"],
         check=True,
         cwd=repo_root,
         timeout=_VALIDATION_STEP_TIMEOUT_SECONDS,
@@ -765,10 +771,10 @@ def _validate_pipeline() -> None:
     )
     print(f"STEP_OK: {prettier_label}", flush=True)
 
-    pytest_label = "uv run --no-project pytest"
+    pytest_label = "uv run pytest"
     print(f"STEP_START: {pytest_label}", flush=True)
     subprocess.run(
-        ["uv", "run", "--no-project", "pytest"],
+        ["uv", "run", "pytest"],
         check=True,
         cwd=repo_root,
         timeout=_VALIDATION_STEP_TIMEOUT_SECONDS,

--- a/tools/validate_compatibility.py
+++ b/tools/validate_compatibility.py
@@ -25,6 +25,14 @@ from string import ascii_letters, digits
 from typing import Any, TypedDict
 
 import orjson
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+
+try:
+    from .validate import normalize_package_name
+except ImportError:
+    from validate import normalize_package_name
+
 
 _REPO_ROOT = str(Path(__file__).resolve().parent.parent)
 
@@ -35,7 +43,11 @@ _VENV_DEPENDENCY_MARKER = ".blueprints_updater_test_dependencies.json"
 _REQUIRED_TEST_DEPS = (
     "httpx[http2]",
     "pytest",
+    "pytest-asyncio",
+    "pytest-cov",
     "pytest-homeassistant-custom-component",
+    "pytest-timeout",
+    "pytest-xdist",
 )
 
 _COMPATIBILITY_PYTEST_ARGS = ["--no-cov"]
@@ -68,16 +80,6 @@ class CompatibilityConfig(TypedDict):
 
     ha_ver: str
     python_ver: str
-
-
-def normalize_package_name(package_name: str) -> str:
-    """Normalize a package name to its canonical base form."""
-    try:
-        import validate
-    except ImportError:
-        from tools import validate
-
-    return validate.normalize_package_name(package_name)
 
 
 def _expected_required_test_dep_versions(
@@ -813,6 +815,58 @@ def _prepare_version_and_deps(
     return ha_ver_to_install, test_dependency_versions
 
 
+def _get_python_interpreter_version(python_bin: Path) -> str:
+    """Get the Python interpreter version inside the venv."""
+    result = subprocess.run(
+        [
+            "uv",
+            "--no-config",
+            "run",
+            "--no-project",
+            "--python",
+            str(python_bin),
+            "python",
+            "-c",
+            "import sys; print(sys.version.split()[0])",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=_REPO_ROOT,
+        timeout=_COMPATIBILITY_METADATA_PROBE_TIMEOUT_SECONDS,
+    )
+    return result.stdout.strip()
+
+
+def _verify_python_version_compatibility(python_bin: Path, ha_ver_to_install: str) -> None:
+    """Verify that Python interpreter satisfies Home Assistant's requires-python."""
+    try:
+        url = f"https://pypi.org/pypi/homeassistant/{ha_ver_to_install}/json"
+        requirements_text = _fetch_remote_text(url)
+        payload = orjson.loads(requirements_text)
+        requires_python = payload.get("info", {}).get("requires_python")
+        if not requires_python:
+            print(
+                f"STEP_INFO: PyPI metadata for HA {ha_ver_to_install} does not specify "
+                "requires-python; skipping compatibility verification",
+                flush=True,
+            )
+            return
+        actual_py_ver = _get_python_interpreter_version(python_bin)
+        spec = SpecifierSet(requires_python)
+        if Version(actual_py_ver) not in spec:
+            raise ValueError(
+                f"Python interpreter {actual_py_ver} at {python_bin} does not satisfy "
+                f"Home Assistant {ha_ver_to_install} constraint '{requires_python}'"
+            )
+    except ValueError:
+        raise
+    except Exception as err:
+        raise ValueError(
+            f"Failed to fetch or verify PyPI requires-python for HA {ha_ver_to_install}: {err}"
+        ) from err
+
+
 def _prepare_venv_and_install(
     venv_path: Path,
     python_bin: Path,
@@ -825,12 +879,18 @@ def _prepare_venv_and_install(
     """Ensure the virtual environment is prepared and dependencies are installed.
 
     Returns:
-        bool: True if setup succeeded, False if python binary is missing.
+        bool: True if setup succeeded, False if python binary is missing or incompatible.
     """
     created_venv = _ensure_venv(venv_path, py_ver)
 
     if not python_bin.exists():
         print(f"VALIDATION_ERROR: python not found at {python_bin}", flush=True)
+        return False
+
+    try:
+        _verify_python_version_compatibility(python_bin, ha_ver_to_install)
+    except ValueError as err:
+        print(f"VALIDATION_ERROR: {err}", flush=True)
         return False
 
     installed_ha = _get_installed_ha_version(python_bin)

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.14.2"
 
 [manifest]
-overrides = [{ name = "homeassistant", specifier = ">=2026.6.0" }]
+overrides = [{ name = "homeassistant", specifier = ">=2026.7.0" }]
 
 [[package]]
 name = "acme"
@@ -419,16 +419,16 @@ wheels = [
 
 [[package]]
 name = "bleak-retry-connector"
-version = "4.6.1"
+version = "4.6.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bleak" },
     { name = "bluetooth-adapters", marker = "sys_platform == 'linux'" },
     { name = "dbus-fast", marker = "sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7a/fc/5de052d5995bfea6f5237b4e848e3fd2978777e5371d92dbce725d21181a/bleak_retry_connector-4.6.1.tar.gz", hash = "sha256:ac2d19362f96757708dff2b0fedfefd5a8d8efb724027a777e54cc8ac2fc5a3d", size = 18827, upload-time = "2026-05-21T21:28:38.018Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/64/acd7d6989a7f0294990c42f035698beccf3da04182b76c1180d3d35850fd/bleak_retry_connector-4.6.3.tar.gz", hash = "sha256:c2fa859bc8b645b8eecde6dfefc49662765d4f43f0b0e2a18a50034660073201", size = 18926, upload-time = "2026-07-22T22:23:32.193Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/7c/4490be0547296648e4dfb77c0a1949c3cdc8963c9b621aecc168f1d4cb76/bleak_retry_connector-4.6.1-py3-none-any.whl", hash = "sha256:018ba421babe05785e5a6497c73f3894772fad0f7fa5b054d48beb3d180ce0c4", size = 18759, upload-time = "2026-05-21T21:28:36.032Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f7/f9592d6bb4a303d7a58cc097c788ccadec3ea127d56899db41fa4efab7fd/bleak_retry_connector-4.6.3-py3-none-any.whl", hash = "sha256:d6bf724245d62667edf30b1fdb423a364eaf0a46825a2b7183b46eebc0f934b3", size = 18835, upload-time = "2026-07-22T22:23:30.841Z" },
 ]
 
 [[package]]
@@ -452,6 +452,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-homeassistant-custom-component" },
     { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "tomlkit" },
     { name = "ty" },
@@ -462,7 +463,7 @@ requires-dist = [{ name = "httpx", extras = ["http2"] }]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "homeassistant", specifier = ">=2026.6.0" },
+    { name = "homeassistant" },
     { name = "interrogate" },
     { name = "orjson" },
     { name = "packaging" },
@@ -473,6 +474,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-homeassistant-custom-component" },
     { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "tomlkit" },
     { name = "ty" },
@@ -532,30 +534,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.43.53"
+version = "1.43.54"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6c/da/0e90eab875f2eb4b8708fef2c198f2559ed1e451a1016f1cd4fcdcfbfbe3/boto3-1.43.53.tar.gz", hash = "sha256:c80425acab314d7af09609562053f565139e1fe49108eacfcc1601ebfaee235b", size = 112678, upload-time = "2026-07-21T19:28:53.002Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/1b/497945d5e1fdacebbc7eacd6fa0c29c9a929ebb24cb5da5b61a434c6771e/boto3-1.43.54.tar.gz", hash = "sha256:3fe21f37f5b34e00fc360190f363229cef425f3c0e80a6f2b6a52f6501c3ec90", size = 112660, upload-time = "2026-07-22T19:30:53.92Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/27/7e72d25fdde77668b7bd4fa47381192dd2aa64fb77265e4bab786fd9fe2a/boto3-1.43.53-py3-none-any.whl", hash = "sha256:5383e705d8a976a14f23bb8c113c07a396931a019db98fce4cdc68650ec6e4d8", size = 140025, upload-time = "2026-07-21T19:28:50.957Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/96/9ed374cee1431e9837a721a107f44b8b7f2b17c9c9fc3bacb479057c6e0f/boto3-1.43.54-py3-none-any.whl", hash = "sha256:8353beda3ce4037758b24ab6bce7162e6cc084fd14c88637956d208d76cee244", size = 140025, upload-time = "2026-07-22T19:30:52.119Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.43.53"
+version = "1.43.54"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/db/6b/ebcefacc4de3cd4f1c449540d86877f76c2f5e586a620831012decbb2b2c/botocore-1.43.53.tar.gz", hash = "sha256:36d93dd8db68ee75f6b61ca9f775161b8168844e4601698701530e6efdded141", size = 15720336, upload-time = "2026-07-21T19:28:41.547Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/44/70c8ce96d8da4573dbd0008abe940de4b19e25c0a5bffcbda3b3d1061b3b/botocore-1.43.54.tar.gz", hash = "sha256:5b58969503eda747e0b69c33735edfc02dab3d31fe3bba87dd83ea787152ffa4", size = 15727582, upload-time = "2026-07-22T19:30:40.259Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/e5/1b60e394f0fff97ee70dd16913382b7dffda85b98e639c0c9e8ff56cfaa7/botocore-1.43.53-py3-none-any.whl", hash = "sha256:b7ee9a70d187e5348883c820990ccd9436ab14e2bd6622741fc96fe561e816b8", size = 15404628, upload-time = "2026-07-21T19:28:37.475Z" },
+    { url = "https://files.pythonhosted.org/packages/31/12/35df5617a133a2af6f03b6e66d76e0ca283cc4a5be0c0bddb7bf836d4534/botocore-1.43.54-py3-none-any.whl", hash = "sha256:22b447e6c5e295d610a00df262efdffb062805d293c00e94f52a4cd3fe9d391d", size = 15410626, upload-time = "2026-07-22T19:30:36.053Z" },
 ]
 
 [[package]]
@@ -938,25 +940,34 @@ wheels = [
 name = "greenlet"
 version = "3.5.4"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/74/b13368064b09053253555d3f2839cc2684d22d5aed0d2ccffbf7a6736558/greenlet-3.5.4.tar.gz", hash = "sha256:0232ae1de90a8e07867bb127d7a6ba2301e859145489f25cda8a6096dabe1d20", size = 206538, upload-time = "2026-07-22T12:47:14.468Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/a7/6ab1d4f9cd548d15ab90da29947f2076100130bb179b0bde59f795a459e3/greenlet-3.5.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:7e8afa5eac028f8140ceafe5ceec66e6aa127ddcb21452d2a564dcd2900b5f22", size = 295410, upload-time = "2026-07-22T11:40:35.747Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/7a/422f63b4715cbc0b24385305407adf38b48f6bb68b3e6b04090e994d0f5a/greenlet-3.5.4-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:73b37afe369021423ea53dd3123e04bffa7e93ac64429b9f50835b2e4fcae7cf", size = 661286, upload-time = "2026-07-22T12:26:43.8Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/31/5a1cac663bf5582190c5a714ef81364f03cde232227f39748f8ae4c11da5/greenlet-3.5.4-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3ef964f56dfcb6f9bbef2a190d9126795eac408716aeae47b5e7c73c32aafca9", size = 673517, upload-time = "2026-07-22T12:29:04.815Z" },
     { url = "https://files.pythonhosted.org/packages/15/4a/2a82a1e3f8aaca020853ac8d12211280ca2b231aa08ea39f636f1060c319/greenlet-3.5.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c53ff01a5c53a40f2c16820ebc56d7c61a77f5fbe009dadd96292d5682f80f8", size = 670917, upload-time = "2026-07-22T11:51:13.589Z" },
     { url = "https://files.pythonhosted.org/packages/68/b0/e379a152b17bfdfa95795af4049e37c0fd1b4d81f020d426db104ed07c77/greenlet-3.5.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ecca4d80d55a01ad6b23b33262662956149fbb7b2c6be2910f1705921958cbf3", size = 1628478, upload-time = "2026-07-22T12:25:06.678Z" },
     { url = "https://files.pythonhosted.org/packages/5e/43/bffdfa64f7317f954c5c1230b5dd5922676ce198689a68c1ac1ed4b1b1a5/greenlet-3.5.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2ffbc533e0eaf8e80d8471411646ab88fe58f641d508c0b02b24494479f4d9ec", size = 1692021, upload-time = "2026-07-22T11:51:17.008Z" },
     { url = "https://files.pythonhosted.org/packages/d0/11/f799f9637e2c6e9b0b716015e339040598b058cf7654dfc0d67468b177ed/greenlet-3.5.4-cp314-cp314-win_amd64.whl", hash = "sha256:305f69e6c4523d7f6979ed001cff4e5853c063e5da04880296603aa0227e544c", size = 248031, upload-time = "2026-07-22T11:40:11.007Z" },
     { url = "https://files.pythonhosted.org/packages/05/75/625bcdd74d5e6b2dca1ecba3c3ac77bcf8a026c21a649a46cef23e421f97/greenlet-3.5.4-cp314-cp314-win_arm64.whl", hash = "sha256:f260930bbbbcf9caee661211235a5111c86dfe5832fdf6ae4570da1e0995320f", size = 246892, upload-time = "2026-07-22T11:40:27.357Z" },
     { url = "https://files.pythonhosted.org/packages/ec/69/35c62ed49c320cb4d98e14698ccca5467d3bfe683984172be9cb564d9ce3/greenlet-3.5.4-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:41ddab54e4b238f4a6c323f39b4e59e176affd5a94d461a9fb7583dac74240a3", size = 305571, upload-time = "2026-07-22T11:40:31.659Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6c/64d60216b3640dcb0b62d913dd9e0d80030c09115bb2e4ba70c95d10ca45/greenlet-3.5.4-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b3dabe3e2809013052c68bdf0b7fa5f5f2859c43a80803131ad61af9cabd7867", size = 672568, upload-time = "2026-07-22T12:26:45.298Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/de/ba3ab0a96292e53039530333b0d2ae18d9e508f3a325cd7bf15f8172944c/greenlet-3.5.4-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:27d3f00718634d4520a3a150154ac5da36f257869d41321953375b90bfbbc72c", size = 680076, upload-time = "2026-07-22T12:29:06.125Z" },
     { url = "https://files.pythonhosted.org/packages/a5/be/aeada79083c6f1c15f45d77a332f9c441af263ee298e3eb17522cd337d22/greenlet-3.5.4-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cbd60b5763c6543c1827e48faaf14ea9bfbad245f52b1a4d76a2a2d8884c6c66", size = 676733, upload-time = "2026-07-22T11:51:16.027Z" },
     { url = "https://files.pythonhosted.org/packages/e9/10/2392fc3a98948652ef5fd1e7275c04f861dd13f74b78a2b4309f4ee4d090/greenlet-3.5.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f00f910f0e7b35416c63b23ad78b769aeccfc1775f712b43c4ee525624a2eef7", size = 1637327, upload-time = "2026-07-22T12:25:07.879Z" },
     { url = "https://files.pythonhosted.org/packages/55/c6/e7237a3dfa1f205ed0d9ea1e46d70bd2811b32d516266399fb59d28ab90a/greenlet-3.5.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:91c26423753b92caf41ab3f98fd547d7374d4d9fc2d85be041886c1579d9255e", size = 1697493, upload-time = "2026-07-22T11:51:19.214Z" },
     { url = "https://files.pythonhosted.org/packages/55/e3/4ba8154ba2a3d43729e499f72471b4b5c993f3826d3e24da81d5f06d6572/greenlet-3.5.4-cp314-cp314t-win_amd64.whl", hash = "sha256:ee032b91fd8ec29ec6c4cea2b8c561b178435134bd0752c7334b94e9c736c132", size = 251637, upload-time = "2026-07-22T11:40:37.44Z" },
     { url = "https://files.pythonhosted.org/packages/90/03/e3f96dfc100261a29545ddc8270cafe58f9195b6651466910e820910de77/greenlet-3.5.4-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:178111881dd7a6c946471fda85485ec796e1043c2b939f694b096e2ecf986809", size = 296076, upload-time = "2026-07-22T11:39:38.364Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/3d/da52d208e5c977bce8667e784729e584e38b5785f4c1ec0f4c836e9a1c42/greenlet-3.5.4-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d92df08dd65fede97fc37aad36c2e9dcda3b31c467f8e0c2c096456cb818e927", size = 666870, upload-time = "2026-07-22T12:26:46.691Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/8a/7e6dee25cb8a8cf9b362c8e597cc269593378bd916f16c736c059a52e85a/greenlet-3.5.4-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:99e8f8c4ebc4fd80aa26c1280ae9ad43a0976e786349703a181cf0bae60413e5", size = 677678, upload-time = "2026-07-22T12:29:07.508Z" },
     { url = "https://files.pythonhosted.org/packages/6c/21/5a38699fa45de749e3857d93b8f07e4c20489e77c2d35d915a2e1c456606/greenlet-3.5.4-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:394de08dad5ffcb1f50c2159d93e398d9d2da3ed437645eaa54771fa720db9f0", size = 676067, upload-time = "2026-07-22T11:51:18.163Z" },
     { url = "https://files.pythonhosted.org/packages/5e/ba/863116ab8ff1ca7a729e327800268939d182db47aa433db70e216e7d9194/greenlet-3.5.4-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:c883d61f2282d72c767a14936641b3efcbde9d82f1080712aaea0b1d3126cb88", size = 1633489, upload-time = "2026-07-22T12:25:09.605Z" },
     { url = "https://files.pythonhosted.org/packages/fa/06/7466ced82818d6132462d7f26b3f83c66ea15d2b193a6c0088d558ed7d95/greenlet-3.5.4-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:2a924f15d17957e252a810acefcb5942f5ca712298e8b6fcaed9a307d357522c", size = 1696584, upload-time = "2026-07-22T11:51:21.304Z" },
     { url = "https://files.pythonhosted.org/packages/f9/4d/55b638489260065de9ffce606c8b5d04507bef705de4b212a0c3d6a1a0df/greenlet-3.5.4-cp315-cp315-win_amd64.whl", hash = "sha256:ed17e5f3420360d5b459de8462efb52060399a5326a613d4cde31cef63ef95da", size = 248297, upload-time = "2026-07-22T11:42:04.055Z" },
     { url = "https://files.pythonhosted.org/packages/bb/08/9dd4ae635da93d41dc268bc34bd62a9d711ed8b8825c5d22ac910c7d6e6d/greenlet-3.5.4-cp315-cp315-win_arm64.whl", hash = "sha256:f908898d6fa484ce4b6f447ce70ea99b52c503fee419e53cf74d60a16bc9e667", size = 247423, upload-time = "2026-07-22T11:44:00.764Z" },
     { url = "https://files.pythonhosted.org/packages/19/66/7c87ed9cdbf1d49c2c6cd1c7b9dd4d16c33b24235ca03972293a1876b30c/greenlet-3.5.4-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:1833637f17d5e7472548a48575c394fe39f1b1890d676d162d86593610f44d8c", size = 306487, upload-time = "2026-07-22T11:41:25.118Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/05/0a4201e7c0054866eefc05da234f236dd4c950d0fbf9ca0517141f01b269/greenlet-3.5.4-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:12cda9122e03341f1cb6b8207a19d7a9d375e52f1b4e9243918375f40fd7b4b9", size = 676479, upload-time = "2026-07-22T12:26:48.129Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c0/4b6b8c5a3aec70f0649cd89662d120fdd6421e2bdc8e3b15c3ab5ec568d8/greenlet-3.5.4-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d83ae0e32d14957ab7170785a20f582635c8474deab1bfbb552b17e769a6ce25", size = 684321, upload-time = "2026-07-22T12:29:08.925Z" },
     { url = "https://files.pythonhosted.org/packages/24/c9/b49c31c9a972eee91e260445770e922244a7efc542697f51a012ec046d0f/greenlet-3.5.4-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9f1467de1bb767f75db0aa34c195e3a496d8d1278c796e70c24ce205d3e99cde", size = 681293, upload-time = "2026-07-22T11:51:20.43Z" },
     { url = "https://files.pythonhosted.org/packages/95/6f/7f2d4653770500eee667866016d42d7a68e3d3462f80df6b8e3fcd48a0eb/greenlet-3.5.4-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:0fa53040b78b578120eecdc0265e3f1051487cc425d11a2b7c761daadf4feaa8", size = 1642474, upload-time = "2026-07-22T12:25:10.819Z" },
     { url = "https://files.pythonhosted.org/packages/5a/d8/8cba31036a4caae448087ba5d150660ab03b4a0f54d9150f6495a3be7262/greenlet-3.5.4-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:60e0bc961d367df506660e9ac0177a76bc6d81305300704b0977d1634f76efe2", size = 1701012, upload-time = "2026-07-22T11:51:23.17Z" },
@@ -2291,14 +2302,14 @@ wheels = [
 
 [[package]]
 name = "s3transfer"
-version = "0.19.1"
+version = "0.19.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/65/da/4bef7ce7bb989b222aa4785a413896dbec53306dfc59c6ce7d16a7ffbd6a/s3transfer-0.19.1.tar.gz", hash = "sha256:d3d6371dc3f1e5c5427b2b457bcf13bcf87bec334c95aed18642eae61f6926f3", size = 165354, upload-time = "2026-07-10T19:32:04.849Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/43/35e4d8aa320bffe8287fe8f65f578fa2d2db0a64212f0e710dce58267854/s3transfer-0.19.2.tar.gz", hash = "sha256:ba0309fd86be3c27dbf78cdd813c13c5e1df16e5874b99d2535ebbdfb9892993", size = 165592, upload-time = "2026-07-22T19:30:44.432Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/23/e84c64ad0e8bc59cd1b2ef98def848deff0ef3456c542afe74d51e9e8c85/s3transfer-0.19.1-py3-none-any.whl", hash = "sha256:d5fd7005ee39307455ad5f310b5ea67f4b1960d7fed5b3671ee50c249de675de", size = 90072, upload-time = "2026-07-10T19:32:03.673Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl", hash = "sha256:d8168eccca828cbb2cd573675333f3bddd254313a9c42494b84c76b539e8ba25", size = 90216, upload-time = "2026-07-22T19:30:43.251Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary by Sourcery

Strengthen compatibility validation between the Python interpreter and Home Assistant, and refine version/constraint handling across tooling and configuration.

New Features:
- Verify that the Python interpreter used in compatibility checks satisfies Home Assistant's requires-python constraint from PyPI metadata.

Bug Fixes:
- Compare installed vs required Home Assistant constraint versions using packaging.Version where possible to avoid string-based mismatches, falling back to raw string comparison for invalid versions.

Enhancements:
- Reuse the shared normalize_package_name helper from tools.validate instead of defining a local wrapper in the compatibility validator.
- Improve pre-commit hook naming to clearly describe each command being run.

Build:
- Relax the dev dependency on homeassistant in pyproject.toml while updating the uv override to target homeassistant>=2026.7.0.

Tests:
- Enable pytest-xdist and configure pytest to run tests in parallel with -n auto.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved ignore rules for virtual environment and coverage artifact files.
  * Clarified automated check names in pre-commit.
  * Updated development tooling and enabled parallel test execution by default.
* **Bug Fixes**
  * Improved accuracy of Home Assistant constraint drift detection.
  * Added pre-install validation to fail fast when the running Python version is incompatible.
  * Expanded compatibility test coverage with additional pytest plugins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->