### PR TITLE
Expand Home Assistant compatibility tests

### DIFF
--- a/tests/integration/test_compatibility.py
+++ b/tests/integration/test_compatibility.py
@@ -1,8 +1,14 @@
 """Integration tests for supported Home Assistant test environments."""
 
+from datetime import timedelta
 from pathlib import Path
 
+import pytest
 from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.blueprints_updater.const import DOMAIN, BlueprintRiskType
+from custom_components.blueprints_updater.coordinator import BlueprintUpdateCoordinator
 
 
 async def test_hass_uses_isolated_config_directory(
@@ -11,3 +17,169 @@ async def test_hass_uses_isolated_config_directory(
 ) -> None:
     """Keep legacy and current HA test runs isolated from shared package data."""
     assert Path(hass.config.config_dir) == tmp_path
+
+
+@pytest.mark.asyncio
+async def test_unmocked_automation_blueprint_consumer_validation(
+    hass: HomeAssistant,
+) -> None:
+    """Validate automation blueprint input substitution against real HA Core validators."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={},
+        options={"update_interval": 24},
+        entry_id="test_compat_auto_val",
+    )
+    entry.add_to_hass(hass)
+
+    coordinator = BlueprintUpdateCoordinator(hass, entry, timedelta(hours=24))
+
+    valid_automation_bp = (
+        "blueprint:\n"
+        "  name: Test Automation Blueprint\n"
+        "  domain: automation\n"
+        "  input:\n"
+        "    target_boolean:\n"
+        "      name: Target Boolean\n"
+        "      selector:\n"
+        "        entity:\n"
+        "          domain: input_boolean\n"
+        "trigger:\n"
+        "  - platform: state\n"
+        "    entity_id: input_boolean.trigger_test\n"
+        "action:\n"
+        "  - service: input_boolean.turn_on\n"
+        "    target:\n"
+        "      entity_id: !input target_boolean\n"
+    )
+
+    valid_consumer_config: dict[str, object] = {
+        "use_blueprint": {
+            "path": "automation/test_auto.yaml",
+            "input": {
+                "target_boolean": "input_boolean.target_test",
+            },
+        }
+    }
+
+    risks = await coordinator._async_validate_blueprint_consumers(
+        relative_path="automation/test_auto.yaml",
+        blueprint_content=valid_automation_bp,
+        configs={"automation.test_instance": valid_consumer_config},
+    )
+
+    assert risks == []
+
+    invalid_consumer_config: dict[str, object] = {
+        "use_blueprint": {
+            "path": "automation/test_auto.yaml",
+            "input": {},
+        }
+    }
+
+    invalid_risks = await coordinator._async_validate_blueprint_consumers(
+        relative_path="automation/test_auto.yaml",
+        blueprint_content=valid_automation_bp,
+        configs={"automation.test_instance": invalid_consumer_config},
+    )
+
+    assert len(invalid_risks) == 1
+    assert invalid_risks[0]["type"] == BlueprintRiskType.COMPATIBILITY
+    assert invalid_risks[0]["args"]["entity"] == "automation.test_instance"
+
+
+@pytest.mark.asyncio
+async def test_unmocked_script_blueprint_consumer_validation(
+    hass: HomeAssistant,
+) -> None:
+    """Validate script blueprint input substitution against real HA Core validators."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={},
+        options={"update_interval": 24},
+        entry_id="test_compat_script_val",
+    )
+    entry.add_to_hass(hass)
+
+    coordinator = BlueprintUpdateCoordinator(hass, entry, timedelta(hours=24))
+
+    valid_script_bp = (
+        "blueprint:\n"
+        "  name: Test Script Blueprint\n"
+        "  domain: script\n"
+        "  input:\n"
+        "    delay_seconds:\n"
+        "      name: Delay\n"
+        "      default: 1\n"
+        "      selector:\n"
+        "        number:\n"
+        "          min: 1\n"
+        "          max: 60\n"
+        "sequence:\n"
+        "  - delay:\n"
+        "      seconds: !input delay_seconds\n"
+    )
+
+    valid_script_config: dict[str, object] = {
+        "use_blueprint": {
+            "path": "script/test_script.yaml",
+            "input": {
+                "delay_seconds": 5,
+            },
+        }
+    }
+
+    risks = await coordinator._async_validate_blueprint_consumers(
+        relative_path="script/test_script.yaml",
+        blueprint_content=valid_script_bp,
+        configs={"script.test_script_instance": valid_script_config},
+    )
+
+    assert risks == []
+
+
+@pytest.mark.asyncio
+async def test_unmocked_template_blueprint_consumer_validation(
+    hass: HomeAssistant,
+) -> None:
+    """Validate template blueprint input substitution against real HA Core validators."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={},
+        options={"update_interval": 24},
+        entry_id="test_compat_template_val",
+    )
+    entry.add_to_hass(hass)
+
+    coordinator = BlueprintUpdateCoordinator(hass, entry, timedelta(hours=24))
+
+    valid_template_bp = (
+        "blueprint:\n"
+        "  name: Test Template Blueprint\n"
+        "  domain: template\n"
+        "  input:\n"
+        "    sensor_name:\n"
+        "      name: Sensor Name\n"
+        "      selector:\n"
+        "        text:\n"
+        "sensor:\n"
+        "  - name: !input sensor_name\n"
+        '    state: "OK"\n'
+    )
+
+    valid_template_config: dict[str, object] = {
+        "use_blueprint": {
+            "path": "template/test_template.yaml",
+            "input": {
+                "sensor_name": "My Template Sensor",
+            },
+        }
+    }
+
+    risks = await coordinator._async_validate_blueprint_consumers(
+        relative_path="template/test_template.yaml",
+        blueprint_content=valid_template_bp,
+        configs={"template.my_sensor": valid_template_config},
+    )
+
+    assert risks == []

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -225,3 +225,30 @@ async def test_config_migration_and_options_update(hass: HomeAssistant) -> None:
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
+
+
+@pytest.mark.asyncio
+async def test_setup_failure_rollback_cleans_up_coordinator(hass: HomeAssistant) -> None:
+    """Test that platform setup failure rolls back coordinator registration."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={},
+        options={"update_interval": 24},
+        entry_id="failed_setup_entry",
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "custom_components.blueprints_updater.coordinator.BlueprintUpdateCoordinator._async_background_refresh"
+        ),
+        patch(
+            "homeassistant.config_entries.ConfigEntries.async_forward_entry_setups",
+            side_effect=RuntimeError("Platform setup failed"),
+        ),
+    ):
+        assert not await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinators = hass.data.get(DOMAIN, {}).get("coordinators", {})
+    assert entry.entry_id not in coordinators

--- a/tests/integration/test_persistence.py
+++ b/tests/integration/test_persistence.py
@@ -77,3 +77,97 @@ async def test_pending_reload_persists_and_retries_after_restart(hass: HomeAssis
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
     hass.services.async_remove(DOMAIN_AUTOMATION, "reload")
+
+
+async def _setup_unmocked_store_coordinator(
+    hass: HomeAssistant,
+    relative_path: str,
+    content: str,
+    entry_id: str,
+) -> tuple[MockConfigEntry, Path]:
+    """Helper to set up a MockConfigEntry and blueprint file with HA's real Store."""
+    bp_path = Path(hass.config.path("blueprints")) / relative_path
+    bp_path.parent.mkdir(parents=True, exist_ok=True)
+    bp_path.write_text(content, encoding="utf-8")
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={},
+        options={"update_interval": 24},
+        entry_id=entry_id,
+    )
+    entry.add_to_hass(hass)
+    return entry, bp_path
+
+
+@pytest.mark.asyncio
+async def test_unmocked_storage_persistence_lifecycle(hass: HomeAssistant) -> None:
+    """Ensure metadata survives a Store round-trip and validators are cleared on mismatch."""
+    from homeassistant.helpers.storage import Store
+
+    relative_path = "automation/unmocked_store.yaml"
+    content = (
+        "blueprint:\n"
+        "  name: Unmocked Store\n"
+        "  domain: automation\n"
+        "  source_url: https://example.com/unmocked.yaml\n"
+    )
+    entry, bp_path = await _setup_unmocked_store_coordinator(
+        hass, relative_path, content, "unmocked_store_entry"
+    )
+
+    with (
+        patch("custom_components.blueprints_updater.coordinator.Store", side_effect=Store),
+        patch(
+            "custom_components.blueprints_updater.coordinator."
+            "BlueprintUpdateCoordinator._async_update_blueprint_in_place",
+            new_callable=AsyncMock,
+        ),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        coordinator = hass.data[DOMAIN]["coordinators"][entry.entry_id]
+        await coordinator.async_wait_until_done()
+
+        bp_key = str(bp_path)
+        assert bp_key in coordinator.data
+
+        # Seed simulated non-None remote values on the matching coordinator.data entry
+        coordinator.data[bp_key].update(
+            {
+                "remote_hash": "a1b2c3d4e5f6",
+                "etag": '"etag-12345"',
+                "last_modified": "Fri, 07 Aug 2026 12:00:00 GMT",
+                "source_url": "https://example.com/unmocked.yaml",
+            }
+        )
+
+        await coordinator._async_save_metadata()
+
+        # Assert persisted metadata contains the non-None values before unloading
+        assert relative_path in coordinator._persisted_metadata
+        pre_unload_saved = coordinator._persisted_metadata[relative_path]
+        assert pre_unload_saved["etag"] == '"etag-12345"'
+        assert pre_unload_saved["remote_hash"] == "a1b2c3d4e5f6"
+        assert pre_unload_saved["last_modified"] == "Fri, 07 Aug 2026 12:00:00 GMT"
+
+        # Simulate entry restart (unload + setup)
+        assert await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        reloaded_coordinator = hass.data[DOMAIN]["coordinators"][entry.entry_id]
+        await reloaded_coordinator.async_wait_until_done()
+
+        # Verify metadata survived Store round-trip and validators are cleared on hash mismatch
+        assert relative_path in reloaded_coordinator._persisted_metadata
+        restarted_saved = reloaded_coordinator._persisted_metadata[relative_path]
+
+        assert restarted_saved["etag"] is None
+        assert restarted_saved["last_modified"] is None
+
+        assert await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()

--- a/tests/integration/test_services.py
+++ b/tests/integration/test_services.py
@@ -289,3 +289,29 @@ async def test_restore_service_translates_preparation_revision_mismatch(
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
+
+
+@pytest.mark.asyncio
+async def test_async_purge_entity_registry_removes_registry_and_state(
+    hass: HomeAssistant,
+) -> None:
+    """Test _async_purge_entity_registry removes entity entry and state machine state."""
+    from custom_components.blueprints_updater.update import _async_purge_entity_registry
+
+    entity_reg = er.async_get(hass)
+    entry = entity_reg.async_get_or_create(
+        domain="update",
+        platform=DOMAIN,
+        unique_id="test_purge_unique_id",
+        suggested_object_id="test_purge_entity",
+    )
+    entity_id = entry.entity_id
+
+    hass.states.async_set(entity_id, "on", {"friendly_name": "Purge Test"})
+    assert hass.states.get(entity_id) is not None
+    assert entity_reg.async_get(entity_id) is not None
+
+    await _async_purge_entity_registry(hass, entity_reg, entity_id)
+
+    assert hass.states.get(entity_id) is None
+    assert entity_reg.async_get(entity_id) is None

--- a/tests/utils/test_file_store.py
+++ b/tests/utils/test_file_store.py
@@ -1,0 +1,144 @@
+"""Direct unit tests for BlueprintFileStore atomic transactions and backup rotation."""
+
+import asyncio
+import os
+from pathlib import Path
+
+import pytest
+
+from custom_components.blueprints_updater.exceptions import FileRevisionMismatchError
+from custom_components.blueprints_updater.file_store import (
+    BlueprintFileStore,
+    FileRevisionPrecondition,
+)
+
+
+@pytest.mark.asyncio
+async def test_file_store_atomic_install_and_rotate_backups(tmp_path: Path) -> None:
+    """Test installing content atomically and rotating backups up to max_backups."""
+    target_file = tmp_path / "test_blueprint.yaml"
+    file_path = str(target_file)
+
+    initial_content = "blueprint:\n  name: Version 1\n"
+    res1 = BlueprintFileStore.install(
+        file_path=file_path,
+        content=initial_content,
+        max_backups=2,
+        create_backup=False,
+        precondition=FileRevisionPrecondition.missing(),
+    )
+    assert target_file.read_text(encoding="utf-8") == initial_content
+    assert res1.backups_count == 0
+
+    precondition1 = BlueprintFileStore.capture_precondition(file_path)
+    assert precondition1.must_exist is True
+    assert precondition1.content_hash == res1.content_hash
+
+    v2_content = "blueprint:\n  name: Version 2\n"
+    res2 = BlueprintFileStore.install(
+        file_path=file_path,
+        content=v2_content,
+        max_backups=2,
+        create_backup=True,
+        precondition=precondition1,
+    )
+    assert target_file.read_text(encoding="utf-8") == v2_content
+    assert res2.backups_count == 1
+    assert BlueprintFileStore.read_backup(file_path, 1) == initial_content
+
+    precondition2 = BlueprintFileStore.capture_precondition(file_path)
+
+    v3_content = "blueprint:\n  name: Version 3\n"
+    res3 = BlueprintFileStore.install(
+        file_path=file_path,
+        content=v3_content,
+        max_backups=2,
+        create_backup=True,
+        precondition=precondition2,
+    )
+    assert target_file.read_text(encoding="utf-8") == v3_content
+    assert res3.backups_count == 2
+    assert BlueprintFileStore.read_backup(file_path, 1) == v2_content
+    assert BlueprintFileStore.read_backup(file_path, 2) == initial_content
+
+
+@pytest.mark.asyncio
+async def test_file_store_precondition_mismatch_raises(tmp_path: Path) -> None:
+    """Test that a stale content hash precondition raises FileRevisionMismatchError."""
+    target_file = tmp_path / "mismatch_blueprint.yaml"
+    file_path = str(target_file)
+
+    target_file.write_text("blueprint:\n  name: Original\n", encoding="utf-8")
+
+    stale_precondition = FileRevisionPrecondition.existing("0" * 64)
+
+    with pytest.raises(FileRevisionMismatchError, match="content changed"):
+        BlueprintFileStore.install(
+            file_path=file_path,
+            content="blueprint:\n  name: New\n",
+            max_backups=3,
+            create_backup=True,
+            precondition=stale_precondition,
+        )
+
+
+@pytest.mark.asyncio
+async def test_file_store_restore_prevalidated_content(tmp_path: Path) -> None:
+    """Test restoring prevalidated content while preserving current file as backup."""
+    target_file = tmp_path / "restore_target.yaml"
+    file_path = str(target_file)
+
+    target_file.write_text("blueprint:\n  name: Current Corrupted\n", encoding="utf-8")
+    precondition = BlueprintFileStore.capture_precondition(file_path)
+
+    good_content = "blueprint:\n  name: Known Good\n"
+    res = BlueprintFileStore.restore(
+        file_path=file_path,
+        validated_content=good_content,
+        max_backups=3,
+        precondition=precondition,
+    )
+
+    assert target_file.read_text(encoding="utf-8") == good_content
+    assert res.backups_count == 1
+    assert "Corrupted" in BlueprintFileStore.read_backup(file_path, 1)
+
+
+@pytest.mark.asyncio
+async def test_file_store_path_transaction_lock(tmp_path: Path) -> None:
+    """Test serializing path mutations through path locks with concurrent tasks."""
+    target_file = tmp_path / "lock_test.yaml"
+    file_path = str(target_file)
+
+    task1_entered = asyncio.Event()
+    task1_release = asyncio.Event()
+    task2_entered = asyncio.Event()
+
+    async def _task1() -> None:
+        """Acquire transaction lock and signal entry."""
+        async with BlueprintFileStore.transaction(file_path):
+            target_file.write_text("blueprint:\n  name: Task 1\n", encoding="utf-8")
+            task1_entered.set()
+            await task1_release.wait()
+
+    async def _task2() -> None:
+        """Acquire transaction lock after task1 releases."""
+        async with BlueprintFileStore.transaction(file_path):
+            task2_entered.set()
+            target_file.write_text("blueprint:\n  name: Task 2\n", encoding="utf-8")
+
+    t1 = asyncio.create_task(_task1())
+    await task1_entered.wait()
+
+    t2 = asyncio.create_task(_task2())
+    await asyncio.sleep(0.01)
+
+    assert not task2_entered.is_set()
+    assert target_file.read_text(encoding="utf-8") == "blueprint:\n  name: Task 1\n"
+    assert os.path.exists(file_path)
+
+    task1_release.set()
+    await asyncio.gather(t1, t2)
+
+    assert task2_entered.is_set()
+    assert target_file.read_text(encoding="utf-8") == "blueprint:\n  name: Task 2\n"

--- a/uv.lock
+++ b/uv.lock
@@ -531,30 +531,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.43.63"
+version = "1.43.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4a/b7/3fdd53534170ef7d99d1707071e57ea0aeb0dec84ed0206d31e8c78f54d7/boto3-1.43.63.tar.gz", hash = "sha256:647c0f0b59710ce12a49323382bb5ece1b4e02199c736d19d555330dca7e947f", size = 112658, upload-time = "2026-08-03T19:55:05.178Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/8f/92486dc60e9caf63a766bce02c561381455169a1b7090548d1fdc14d6b8d/boto3-1.43.66.tar.gz", hash = "sha256:ffc77129a4e5519bdbd9b278e4fe9e6276c9d951e0d2b60d626977bdb957cb38", size = 112668, upload-time = "2026-08-06T19:38:42.066Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/57/a91420a14ef26fe52fc0706b5af21c00b2e4ff1c57b0c4272370c9b80399/boto3-1.43.63-py3-none-any.whl", hash = "sha256:859a8d1c50505a5cefb8629790dd34602ddb85bfd7ea5d34a362ab1793513636", size = 140024, upload-time = "2026-08-03T19:55:03.4Z" },
+    { url = "https://files.pythonhosted.org/packages/07/bc/131d596cf673f7b7c6b52ff88fa05f73bbdf9dff70d93e31d4b62645def3/boto3-1.43.66-py3-none-any.whl", hash = "sha256:8d097a41e2f545c25252105570f782bb035b1ac13d6213c772d1c895dc7cedeb", size = 140027, upload-time = "2026-08-06T19:38:40.651Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.43.63"
+version = "1.43.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/5f/b33913aab846bc88a2720976435adb944d1ef57b92beed829233fe1953d9/botocore-1.43.63.tar.gz", hash = "sha256:854e45247f00b0732496ea1f0c5d0cf3c31d58b48eb052c31c27ab1087dfddf1", size = 15824662, upload-time = "2026-08-03T19:54:55.233Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/81/9ce1f5fe88b4b1429edf83189b8994ffb9883fc20bdd46b7ee9d1cc1da24/botocore-1.43.66.tar.gz", hash = "sha256:dde324cbe8be14b536b78f4fafe192f94fffcc70716bde804044e62495af8c3c", size = 15880416, upload-time = "2026-08-06T19:38:37.603Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/ae/8ddbf97a12fba9b6ce50ac1c2209ebd2ab3b240229a1fbe5de66ffcbd05f/botocore-1.43.63-py3-none-any.whl", hash = "sha256:8deed86feacc8f8d2491f1d170562af191f8b33924052d834f4217d5d797e5a9", size = 15509076, upload-time = "2026-08-03T19:54:52.455Z" },
+    { url = "https://files.pythonhosted.org/packages/84/e6/53f0e28dea0f17a1b041bb3356d0c21fda7ba4198a515cfaf4d5f3088fe3/botocore-1.43.66-py3-none-any.whl", hash = "sha256:0fa62529579469a9224c186eba87e7e561db87dfad20c63ce5d52e427c7fa325", size = 15566310, upload-time = "2026-08-06T19:38:34.446Z" },
 ]
 
 [[package]]
@@ -1094,7 +1094,7 @@ wheels = [
 
 [[package]]
 name = "homeassistant"
-version = "2026.8.0b4"
+version = "2026.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiodns" },
@@ -1148,9 +1148,9 @@ dependencies = [
     { name = "yarl" },
     { name = "zeroconf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/06/667651f53432cc50f7477153270509c26512d27ebdb6db8904d96c4935aa/homeassistant-2026.8.0b4.tar.gz", hash = "sha256:c7946a644931f85e24afef4bffa08a0a9384494727f730ab9f338d01497d7444", size = 36467250, upload-time = "2026-08-03T09:17:33.068Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/30/1e25c48871a24942de234439ac66ddbe649138c217b358c20162c1d29481/homeassistant-2026.8.0.tar.gz", hash = "sha256:2e966cf00edda6ba04ff1c6f707c073b9df5e4480b52dbd59451cec8f30610f9", size = 36732240, upload-time = "2026-08-05T15:34:54.073Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/c8/3dc5f087dc463e346cba4a54585ed0430a865e53db213671ccbdda38f86c/homeassistant-2026.8.0b4-py3-none-any.whl", hash = "sha256:ac67c9b9278eba6b6ddcfa68c106fc829adb1e79efd3433c09e46a05f5c7e404", size = 59385985, upload-time = "2026-08-03T09:17:27.533Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/b7/4fb4e27596058f0a7014140b4fb75056d518fdda8f04c8aeecca5bf6fd4b/homeassistant-2026.8.0-py3-none-any.whl", hash = "sha256:3b1ff7a5db94d4c33a4228c08950bde1bcecb08893fae3c7513e743fba20c059", size = 59723818, upload-time = "2026-08-05T15:34:49.578Z" },
 ]
 
 [[package]]
@@ -1491,11 +1491,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.2"
+version = "26.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
 ]
 
 [[package]]
@@ -1559,11 +1559,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.2"
+version = "26.2.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/db/96/e6f8e9d9d7b9cc4457092712a7e919c3186aa2c2fa9ffed2c5d29cc947e8/pip-26.2.tar.gz", hash = "sha256:2d8542afcc84cdd8e846c2b36b2861fad1da376dd98f8e7113e9108a3c331690", size = 1848845, upload-time = "2026-07-29T21:57:56.407Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/15/4500e320e6b101ec3b719ae85b697d9940b6cda672bc555bd6016fc60c6f/pip-26.2.1.tar.gz", hash = "sha256:f6ad667e89a1fe78046c8f13232b247200f5258d7828f3f7883d660878e0813f", size = 1848877, upload-time = "2026-08-04T22:51:14.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/36/a3aed958d60531cb442b7ab4596cda7b3621cfb916f8ae1d6769795c7dc1/pip-26.2-py3-none-any.whl", hash = "sha256:931c303696af6fa3417112103b1cad26890e5a07eccb5b99783700e33f2b8aad", size = 1816475, upload-time = "2026-07-29T21:57:54.763Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6e/1736e5b4ae2b778ef2f81c47d797de9f891d4d8acb047a24ca37a60294dd/pip-26.2.1-py3-none-any.whl", hash = "sha256:71138adf1f4ca900cdb7d289c21b7494329f2332b6d85f0e1c42108c0384ed3e", size = 1816632, upload-time = "2026-08-04T22:51:12.472Z" },
 ]
 
 [[package]]
@@ -2069,7 +2069,7 @@ wheels = [
 
 [[package]]
 name = "pytest-homeassistant-custom-component"
-version = "0.13.352"
+version = "0.13.354"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohasupervisor" },
@@ -2102,9 +2102,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "unidiff" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/5b/fb129c3fba954498e505d661fa6cdc6515cd52fa6b8adda0e0182533a3e9/pytest_homeassistant_custom_component-0.13.352.tar.gz", hash = "sha256:4355af26cfb58eb03c6c6287c535ef0bceee3f1131adc1135ff56b98ee98e98b", size = 76933, upload-time = "2026-08-04T07:34:22.996Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/48/ac4af2bb13ad79148cd62ca0ef92cb3b36d6d5fc2f9e8703880e27e298d3/pytest_homeassistant_custom_component-0.13.354.tar.gz", hash = "sha256:c2522b9b05143dcca4034d34db7bf65fab19f63efa4f4b0307e6ec36d55251bc", size = 76934, upload-time = "2026-08-06T07:36:43.766Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/16/6fc79c1f45ea5bbc369cbbee1a0afab2f38dc9d20a2edd8f53e321e4b2c8/pytest_homeassistant_custom_component-0.13.352-py3-none-any.whl", hash = "sha256:d03dcc1193c38b16fd83293340ae4c4888b947f706730e1fd5eba0cda4157521", size = 82845, upload-time = "2026-08-04T07:34:21.632Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b0/2284352838e69d4261abfceb120266afcd17d44a3d143342becfd92ada0a/pytest_homeassistant_custom_component-0.13.354-py3-none-any.whl", hash = "sha256:9dff5671d081612221905ad937da2ff2c025908314ccadb9c58f64f89754bfbe", size = 82841, upload-time = "2026-08-06T07:36:42.213Z" },
 ]
 
 [[package]]
@@ -2501,27 +2501,27 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.66"
+version = "0.0.69"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cd/58/4f6ab2a86589e422a3cf840bcf6114c565e4c39ddf4d0b7cd328af5b52b4/ty-0.0.66.tar.gz", hash = "sha256:24bddd4479ce445b51ac015410dd2d34af1cadd62a77f5b3cb269149ed83f9b5", size = 6520402, upload-time = "2026-08-04T01:09:47.714Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/5b/7a618632dfe9373b7df572ecd7a08c8f799d772fbc317da82dd3aa363207/ty-0.0.69.tar.gz", hash = "sha256:b65106e9ff24fa76e25e1142fb09c85244e815c40450e3021d2bf652c231bb43", size = 6565094, upload-time = "2026-08-06T10:04:25.667Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/4d/bbc28310d6d887ef73e5800f062c4bf54caa35a1b47d70c7b03d0515ecf1/ty-0.0.66-py3-none-linux_armv6l.whl", hash = "sha256:8b46450438b54b732338e4d7a78a7d2f5e1a012a13d77d121aacaca20fb814e2", size = 12409743, upload-time = "2026-08-04T01:09:01.229Z" },
-    { url = "https://files.pythonhosted.org/packages/73/4e/c3d2eb2242fa0a2ef445ca2c7009dc9118e5b3dcb8b8a8bec70d58c8e4bc/ty-0.0.66-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:8e4adbe662bc3c62b52b83d46b07f703fdc3c123bb72601606c58be5ea017ed3", size = 12078362, upload-time = "2026-08-04T01:09:04.233Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/ba/7a4b5e45d701a8de6b714dacf6ffca91b0411baaceaa781d494037623a18/ty-0.0.66-py3-none-macosx_11_0_arm64.whl", hash = "sha256:776814351735847eb934f9a3cbea21d2278ba14aa0fc099f683da11bc2d5c90a", size = 11583289, upload-time = "2026-08-04T01:09:06.973Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/4a/fbb1f71ee2999f981f8c4b3b139231e4bcff4ede0c3b37e858fd1334ed26/ty-0.0.66-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cca1da877f613965b954bfd22d495386e260ec767c5536c8022cca98a260ea5d", size = 12137274, upload-time = "2026-08-04T01:09:09.592Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/07/9e0662f6603a5ac171ae6b314396e677ead4b45695fc948efb0a4837051f/ty-0.0.66-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:aa523e777bc36c0fbf8ded5844096f46cbfc3712fe5a003351a94259b7e86cf4", size = 12207047, upload-time = "2026-08-04T01:09:12.533Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/cc/12e01bc2ea47fa7bf20fc6cdd3249d6a340be9be4edc52b1d77256245dd0/ty-0.0.66-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3f7993c1f95f80a4e44056e6aaf8e46e608d778db131ae5ce59262ab59358f9a", size = 12919304, upload-time = "2026-08-04T01:09:15.175Z" },
-    { url = "https://files.pythonhosted.org/packages/75/88/c6c0d3a8e71c9cdb560cc5c627a4bba6c47b5eec460b2f8c449b57c6d03a/ty-0.0.66-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f9b29354bcbac9f53b6952d8f46789bd81eeb9bdd7a68df7d26e654ca7498c3c", size = 13470963, upload-time = "2026-08-04T01:09:17.849Z" },
-    { url = "https://files.pythonhosted.org/packages/27/c2/2f8c18063412ad80e1b3f87afce7bd50982b4a048166607b67f80660a9fb/ty-0.0.66-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fbf4e5325f7f584d9c346946e7c415b2e3cd3b8f1119d468082a90a6afd020ce", size = 13244773, upload-time = "2026-08-04T01:09:20.59Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/f6/fdae2b95831116dffc055ad53a99a8f21437263651047b3ad46def4950a3/ty-0.0.66-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bd304363764bd723c22fb20b17035c345420fdf66fee856934b158ebde08a91", size = 12751343, upload-time = "2026-08-04T01:09:23.225Z" },
-    { url = "https://files.pythonhosted.org/packages/14/1e/7e75f0371d11463a256dc2bee98b0df401e0fa06021e200b8b601d21949d/ty-0.0.66-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:205d8589bd957ea9718d488b731b2fbdd0d1b1cefd37c79f52c0deb7cafddfef", size = 13068057, upload-time = "2026-08-04T01:09:26.052Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/84/f20f24518f6f0bea936e2e668ede250b9ce0774624559931599bd1f42772/ty-0.0.66-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7304a1df54741a2343801354f41d7ad87974acb541ee3e93c26cb6a1a0b863af", size = 12082318, upload-time = "2026-08-04T01:09:28.877Z" },
-    { url = "https://files.pythonhosted.org/packages/08/20/70ca0eac2427d4a58a81a3a9426b20e46fb4a5a13aefc9edc2e5172e1243/ty-0.0.66-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:cf2c062863e5da0f588b0b120fec0da2e81c0913ee4cd07b50d77aa60ffd8deb", size = 12228978, upload-time = "2026-08-04T01:09:31.905Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/01/5a461ab34456d788248780830aed673c9e0e796f6e9dd92d3dbf02e04d7f/ty-0.0.66-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a58d32c879d86428978332adf21e85009ec269314a23d330c3483c65b57aedc7", size = 12471917, upload-time = "2026-08-04T01:09:34.418Z" },
-    { url = "https://files.pythonhosted.org/packages/46/ed/f8eb5eff7c9ee644490c6d2626425935c097acc54871adf659ea70624a2c/ty-0.0.66-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b2f810fa3516c977630d78dbe9161592b3c27029fa9bb81074366624d9b5e4b6", size = 12858086, upload-time = "2026-08-04T01:09:37.602Z" },
-    { url = "https://files.pythonhosted.org/packages/02/7f/8a78361f752274a550a7f6f07f127b246ece7d7fdde31121d22074e46eab/ty-0.0.66-py3-none-win32.whl", hash = "sha256:d28c3df565a387c1c5ea359aa452a46d19163616ef71be819058a424a62f1ae1", size = 11782494, upload-time = "2026-08-04T01:09:40.136Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/e2/deed22b823ce309b8410d50414fd15afe9e90aee8b8ca04789ba55c21231/ty-0.0.66-py3-none-win_amd64.whl", hash = "sha256:e3a457f3312c078f24c47d0da6e4f73de34d0a77ed2de22571c066c80b2fd5e7", size = 12893338, upload-time = "2026-08-04T01:09:42.825Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/ce/6c828f42ef1ed39f53f57f9c0cdcdf03e23666fa7a29d799042a2c34bcb4/ty-0.0.66-py3-none-win_arm64.whl", hash = "sha256:2f62ae247b9c75674fcc060635f9f00210357da7681de59234d97b50fb9e9e94", size = 12227381, upload-time = "2026-08-04T01:09:45.365Z" },
+    { url = "https://files.pythonhosted.org/packages/06/60/6534092f4d2c15e2491807edd609c2e50d527c1fed957acf40b9f110b64a/ty-0.0.69-py3-none-linux_armv6l.whl", hash = "sha256:98bfd383b273540829af673e7f98b9c1c4bcc8547d12a1a3806cd0bec7f0e087", size = 12364185, upload-time = "2026-08-06T10:03:47.137Z" },
+    { url = "https://files.pythonhosted.org/packages/34/2b/5c29689bd4f74c2e3394d983d85e4011b629f2ce3730c9442553b8554bf8/ty-0.0.69-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:964621ddd05771660017c51b4e74078d861d9fc863c21ef2a500db1ab62c9ccf", size = 12042510, upload-time = "2026-08-06T10:03:49.481Z" },
+    { url = "https://files.pythonhosted.org/packages/09/46/fa085bde4d23516d7ef14b24736fc5dd7dc498f60f52b3d077e59ffdea20/ty-0.0.69-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3ffea4048dd0da4c9c97393b4be0901098a9065b06fa81be2477cbde65d8a151", size = 11549397, upload-time = "2026-08-06T10:03:51.747Z" },
+    { url = "https://files.pythonhosted.org/packages/25/cc/97b9efb2061dcab6fef1e94a4ad99df0bb45bd2cc15d4f5794c787ee0552/ty-0.0.69-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a8684d4a70aadd1eab0f41bdba835e3288ef49db8402a8e6ca81bab52ed5d610", size = 12115567, upload-time = "2026-08-06T10:03:53.79Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/c1/a5e0404965093835f3e62544e661784ec0aa8ef0b006ed50af50b19c107e/ty-0.0.69-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:afaaba240ab4122e2069a796836d10be81b4ddb053ae268b3dff962a0b4ca5c7", size = 12149770, upload-time = "2026-08-06T10:03:55.993Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/39/8cad6b205a4abe8a044ca0c84aea71e8ccda29b07a75a5f090e310605580/ty-0.0.69-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:11ea63ef07d4e33aeb1a775cf5f2c736b3ed22fa6f8b1b608591612c36795044", size = 12941278, upload-time = "2026-08-06T10:03:58.324Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/8b/8766d96b732c2a060d70dc8ccafcc4d6a54109a2a95f1deb0705de88892b/ty-0.0.69-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cb3730b1268e92a2907d7aea3afe8dd1b360ae65862f0557080cf479d481b424", size = 13426509, upload-time = "2026-08-06T10:04:00.621Z" },
+    { url = "https://files.pythonhosted.org/packages/02/1f/e991b2cde953ea5b94d6a9a4c45c87937bd916bc09235f764407bf471c0a/ty-0.0.69-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a544ff57a752ef186ed40b5a2f44c17402af4cdefeb74a311ca02ebd57c4fca0", size = 13106582, upload-time = "2026-08-06T10:04:02.818Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/bb/73538f1b99e3558fd9db87b98698426f0f60fc8666da0b1efd0e70e275eb/ty-0.0.69-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:87ed2cbca20caddfdf8e3e14d213ce91b67e75feed78900f4aaf3ef884954028", size = 12708931, upload-time = "2026-08-06T10:04:05.233Z" },
+    { url = "https://files.pythonhosted.org/packages/87/cd/484a5208d74c4ad1155933906295ccdce9aa81a257d8df2ab9e41bd60133/ty-0.0.69-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2684efcbce5b6fe45045faf610b377b50781b6d2aa7e61ea23ecf5b3d2bce421", size = 12985322, upload-time = "2026-08-06T10:04:07.587Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/81/b75003f0d4da9ab3bc8fd4f4802f836cb9921ff7e70f460604f7b769a0b5/ty-0.0.69-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:da9aeb26fdac1d2214937542b59e0d4d1ba94ec7a3f45444f33c846de1eb1d63", size = 12063910, upload-time = "2026-08-06T10:04:09.835Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/76/088469f547ef63dceefc4a75826aedee5014f9371dc5171cde931896a82c/ty-0.0.69-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:00e7677cd14ede381f705f71104ea7b8ea0ce217a8634e19a89781953de0e9ad", size = 12166823, upload-time = "2026-08-06T10:04:12.114Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/c9/ce88a0bec0d46d8ae180b99c6ec014866fecc4cba1727b5feec8877b2765/ty-0.0.69-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d91965eb799649833d0d6042db09cd03d15289125245337cc46a2606effb7bda", size = 12483136, upload-time = "2026-08-06T10:04:14.33Z" },
+    { url = "https://files.pythonhosted.org/packages/63/9e/6fae0ff225a0012642cf72c077e20f8f448c0a80771bc3360e8178fe2f32/ty-0.0.69-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1f03359cd8e5c412aa0c181118fa9b9061a4dddaedbb61bac0a424fb0814d402", size = 12799025, upload-time = "2026-08-06T10:04:16.445Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/43/78a658d18b2a4ccf35b053392f2213bf12e3c63b2abea512d3b6751d1f4c/ty-0.0.69-py3-none-win32.whl", hash = "sha256:ec460e01586b1eb91894c4a8403bee3e045a47e7a4ada943cc27ce8e348e88cf", size = 11787774, upload-time = "2026-08-06T10:04:18.622Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/5e/88db1f674403f2b81316a853a44a81ed220621fa96f8f7ae586fb6ca7513/ty-0.0.69-py3-none-win_amd64.whl", hash = "sha256:18976ca26a4e28fc3249477f79a695d5502e670803f2e080d89ac905baef3c6e", size = 12864038, upload-time = "2026-08-06T10:04:20.748Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/7b/6fc6efd00c69103d70f2bdbe824343089cd70b17b3079170057d3e5a3ac0/ty-0.0.69-py3-none-win_arm64.whl", hash = "sha256:7d4ca3bb74d91cb9947ba3f3b4cb131ad6a2b3ecc76d34040c4ec6092d2e411d", size = 12196693, upload-time = "2026-08-06T10:04:22.902Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary by Sourcery

Expand Home Assistant integration compatibility coverage and validate blueprint persistence and lifecycle behavior.

Tests:
- Add integration tests validating automation, script, and template blueprint consumer configurations against Home Assistant core validation.
- Add integration test ensuring storage-backed metadata persists across reloads and clears stale remote validators on hash mismatch.
- Add integration test verifying failed platform setup rolls back coordinator registration.
- Add integration test confirming entity registry purge removes both registry entries and state machine state.
- Add unit tests for BlueprintFileStore covering atomic installs, backup rotation, precondition mismatch handling, restores, and path-level transaction locking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for blueprint validation across automation, script, and template configurations.
  * Added integration checks for setup failure handling, persistence across reloads, and cleanup of removed entities.
  * Added coverage for reliable file installation, backup rotation, restoration, stale-update protection, and transaction locking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->