### PR TITLE
Improve compatibility validation and coordinator lifecycle handling

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -126,6 +126,9 @@ jobs:
             ))
           ' tools/compatibility_matrix.json >/dev/null
 
+          uv run --no-project --with orjson --with packaging \
+            python tools/validate_compatibility.py --validate-matrix
+
           MATRIX_JSON=$(jq -c \
             --arg latest_ha "$MATCHED_LATEST_HA" \
             --arg latest_harness "$MATCHED_LATEST_HARNESS" '
@@ -260,7 +263,25 @@ jobs:
               REQUIRED_TEST_DEPS+=("$package")
             fi
           done
-          uv --no-config pip install --prerelease allow --python .venv/bin/python "$HA_SPEC" "${REQUIRED_TEST_DEPS[@]}"
+          AIODNS_SPEC="${HA_CONSTRAINT_SPECS[aiodns]-}"
+          if [[ "$AIODNS_SPEC" != aiodns==?* ]]; then
+            echo "::error::Invalid resolved aiodns constraint: $AIODNS_SPEC"
+            exit 1
+          fi
+          AIODNS_VERSION="${AIODNS_SPEC#aiodns==}"
+          TRANSITIVE_COMPATIBILITY_SPECS_JSON=$(uv run --no-project --with orjson --with packaging \
+            python tools/validate_compatibility.py --transitive-compatibility-specs-json \
+            --aiodns-version "$AIODNS_VERSION")
+          if ! jq -e 'type == "array" and all(.[]; type == "string" and length > 0)' \
+            <<< "$TRANSITIVE_COMPATIBILITY_SPECS_JSON" >/dev/null; then
+            echo "::error::Invalid transitive compatibility specs"
+            exit 1
+          fi
+          mapfile -t TRANSITIVE_COMPATIBILITY_SPECS < <(
+            jq -r '.[]' <<< "$TRANSITIVE_COMPATIBILITY_SPECS_JSON"
+          )
+          uv --no-config pip install --prerelease allow --python .venv/bin/python \
+            "$HA_SPEC" "${REQUIRED_TEST_DEPS[@]}" "${TRANSITIVE_COMPATIBILITY_SPECS[@]}"
 
       - name: Verify Home Assistant/test harness pair
         env:

--- a/custom_components/blueprints_updater/__init__.py
+++ b/custom_components/blueprints_updater/__init__.py
@@ -96,27 +96,34 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry,
         timedelta(hours=interval_hours),
     )
-    await blueprint_coordinator.async_setup()
-    await blueprint_coordinator.async_config_entry_first_refresh()
-
     coordinators = hass.data.setdefault(DOMAIN, {}).setdefault("coordinators", {})
-    coordinators[entry.entry_id] = blueprint_coordinator
+    platform_forwarding_started = False
 
-    platforms_forwarded = False
+    async def _async_rollback_setup() -> None:
+        """Release resources acquired during a partial config-entry setup."""
+        try:
+            if platform_forwarding_started:
+                await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+        finally:
+            coordinators.pop(entry.entry_id, None)
+            await blueprint_coordinator.async_shutdown()
+
     try:
+        await blueprint_coordinator.async_setup()
+        await blueprint_coordinator.async_config_entry_first_refresh()
+        coordinators[entry.entry_id] = blueprint_coordinator
+        platform_forwarding_started = True
         await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-        platforms_forwarded = True
         _async_register_services(hass)
         entry.async_on_unload(entry.add_update_listener(async_update_options))
         blueprint_coordinator.setup_complete = True
         blueprint_coordinator.async_set_updated_data(blueprint_coordinator.data)
     except asyncio.CancelledError:
+        await _async_rollback_setup()
         raise
     except Exception as err:
         _LOGGER.debug("Setup failed for entry %s, performing rollback: %s", entry.entry_id, err)
-        coordinators.pop(entry.entry_id, None)
-        if platforms_forwarded:
-            await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+        await _async_rollback_setup()
         raise
 
     return True
@@ -453,15 +460,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         True if the entry was unloaded successfully.
 
     """
-    if domain_data := hass.data.get(DOMAIN):
-        coordinators = domain_data.get("coordinators", {})
-        if blueprint_coordinator := coordinators.get(entry.entry_id):
-            await blueprint_coordinator.async_shutdown()
-
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok and (domain_data := hass.data.get(DOMAIN)):
         coordinators = domain_data.get("coordinators", {})
-        coordinators.pop(entry.entry_id, None)
+        if blueprint_coordinator := coordinators.pop(entry.entry_id, None):
+            await blueprint_coordinator.async_shutdown()
 
         if not coordinators:
             domain_data.pop("translation_cache", None)

--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -2617,9 +2617,9 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, objec
         """Extract and validate blueprint configuration from a HA entity.
 
         Attempts to recover blueprint inputs from available entity attributes.
-        Prioritizes public attributes (raw_config, config) before falling back
-        to internal attributes (_blueprint_inputs) used by Home Assistant Core
-        integrations like automation, script, and template.
+        Prefers public attributes when they still contain the blueprint instance
+        configuration, then falls back to the internal ``_blueprint_inputs``
+        attribute used by Home Assistant Core integrations.
 
         Args:
             entity: The Home Assistant entity object.
@@ -2627,17 +2627,15 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, objec
             configs: Dictionary to store the extracted configurations.
 
         """
-        raw_config = getattr(entity, "raw_config", None)
-        cfg = raw_config if isinstance(raw_config, dict) else None
-        if cfg is None:
-            entity_config = getattr(entity, "config", None)
-            if isinstance(entity_config, dict):
-                cfg = entity_config
-        if cfg is None:
-            cfg = getattr(entity, "_blueprint_inputs", None)
-
-        if isinstance(cfg, dict) and "use_blueprint" in cfg:
-            configs[entity_id] = cfg
+        candidates = (
+            getattr(entity, "raw_config", None),
+            getattr(entity, "config", None),
+            getattr(entity, "_blueprint_inputs", None),
+        )
+        for candidate in candidates:
+            if isinstance(candidate, dict) and "use_blueprint" in candidate:
+                configs[entity_id] = candidate
+                return
 
     @staticmethod
     def _get_affected_entities(configs: Mapping[str, Mapping[str, object]], key: str) -> list[str]:
@@ -3464,7 +3462,8 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, objec
                 full_configs = self._get_entities_configs(entity_ids)
                 configs: dict[str, dict[str, object]] = {}
                 for eid, cfg in full_configs.items():
-                    inp = cfg.get("input") if isinstance(cfg, dict) else None
+                    use_blueprint = cfg.get("use_blueprint") if isinstance(cfg, dict) else None
+                    inp = use_blueprint.get("input") if isinstance(use_blueprint, dict) else None
                     configs[eid] = (
                         {str(k): v for k, v in inp.items()} if isinstance(inp, dict) else {}
                     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,11 +61,6 @@ asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 pythonpath = ["."]
 testpaths = ["tests"]
-filterwarnings = [
-  "ignore::DeprecationWarning",
-  "ignore::pytest.PytestDeprecationWarning",
-  "error::DeprecationWarning:custom_components.blueprints_updater",
-]
 addopts = [
   "-n",
   "auto",
@@ -80,9 +75,6 @@ markers = ["real_network: tests that require real network access"]
 
 [tool.pyright]
 typeCheckingMode = "standard"
-reportUnreachable = "warning"           # Keep until ty implements this feature
-reportUnnecessaryComparison = "warning" # Keep until ty implements this feature
-reportUnnecessaryContains = "warning"   # Keep until ty implements this feature
 
 [tool.interrogate]
 fail-under = 100

--- a/tests/coordinator/test_update_cycle.py
+++ b/tests/coordinator/test_update_cycle.py
@@ -921,6 +921,54 @@ async def test_detect_risks_missing_relative_path(coordinator, mock_makedirs):
 
 
 @pytest.mark.asyncio
+async def test_detect_risks_uses_nested_consumer_inputs(coordinator):
+    """Pass inputs from HA's use_blueprint wrapper to schema risk checks."""
+    path = "/config/blueprints/automation/test.yaml"
+    info = {"relative_path": "automation/test.yaml", "name": "Test Blueprint"}
+    coordinator.data = {path: info}
+    full_configs = {
+        "automation.consumer": {
+            "id": "consumer",
+            "use_blueprint": {
+                "path": "test.yaml",
+                "input": {"target_boolean": "input_boolean.target"},
+            },
+        }
+    }
+
+    with (
+        patch.object(
+            coordinator,
+            "_get_entities_using_blueprint",
+            return_value=["automation.consumer"],
+        ),
+        patch.object(coordinator, "_get_entities_configs", return_value=full_configs),
+        patch.object(
+            coordinator.hass,
+            "async_add_executor_job",
+            new=AsyncMock(return_value="old blueprint"),
+        ),
+        patch.object(
+            coordinator,
+            "_detect_breaking_changes",
+            return_value=[],
+        ) as detect_breaking_changes,
+        patch.object(
+            coordinator,
+            "_async_validate_blueprint_consumers",
+            new=AsyncMock(return_value=[]),
+        ),
+    ):
+        await coordinator._detect_risks_for_update(path, info, "new blueprint")
+
+    detect_breaking_changes.assert_called_once_with(
+        "old blueprint",
+        "new blueprint",
+        {"automation.consumer": {"target_boolean": "input_boolean.target"}},
+    )
+
+
+@pytest.mark.asyncio
 async def test_async_install_blueprint(hass, coordinator, mock_makedirs):
     """Test installing a blueprint and reloading services."""
     path = "/config/blueprints/automation/test.yaml"

--- a/tests/entities/test_template_support.py
+++ b/tests/entities/test_template_support.py
@@ -60,3 +60,32 @@ async def test_template_config_extraction(hass: HomeAssistant):
 
     assert "template.my_entity" in configs
     assert configs["template.my_entity"]["use_blueprint"]["input"]["my_input"] == "my_value"
+
+
+@pytest.mark.asyncio
+async def test_blueprint_config_extraction_falls_back_after_substitution(
+    hass: HomeAssistant,
+) -> None:
+    """Recover original inputs when HA exposes a substituted public config."""
+    coordinator = BlueprintUpdateCoordinator(hass, MagicMock(), timedelta(hours=24))
+    entity = MagicMock()
+    entity.raw_config = {"trigger": [], "action": []}
+    entity.config = {"sequence": []}
+    entity._blueprint_inputs = {
+        "use_blueprint": {
+            "path": "test.yaml",
+            "input": {"my_input": "my_value"},
+        }
+    }
+
+    configs: dict[str, dict[str, object]] = {}
+    coordinator._populate_config_from_entity(entity, "automation.consumer", configs)
+
+    assert configs == {
+        "automation.consumer": {
+            "use_blueprint": {
+                "path": "test.yaml",
+                "input": {"my_input": "my_value"},
+            }
+        }
+    }

--- a/tests/integration/test_compatibility.py
+++ b/tests/integration/test_compatibility.py
@@ -4,7 +4,10 @@ from datetime import timedelta
 from pathlib import Path
 
 import pytest
+from homeassistant.components.automation import automations_with_blueprint
+from homeassistant.components.script import scripts_with_blueprint
 from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.blueprints_updater.const import DOMAIN, BlueprintRiskType
@@ -86,6 +89,144 @@ async def test_unmocked_automation_blueprint_consumer_validation(
     assert len(invalid_risks) == 1
     assert invalid_risks[0]["type"] == BlueprintRiskType.COMPATIBILITY
     assert invalid_risks[0]["args"]["entity"] == "automation.test_instance"
+
+
+@pytest.mark.asyncio
+async def test_live_automation_blueprint_consumer_discovery(
+    hass: HomeAssistant,
+) -> None:
+    """Recover original inputs from a live HA automation blueprint consumer."""
+    blueprint_path = Path(hass.config.path("blueprints", "automation", "compat.yaml"))
+    blueprint_path.parent.mkdir(parents=True, exist_ok=True)
+    blueprint_path.write_text(
+        "blueprint:\n"
+        "  name: Compatibility Consumer\n"
+        "  domain: automation\n"
+        "  input:\n"
+        "    target_boolean:\n"
+        "      selector:\n"
+        "        entity:\n"
+        "          domain: input_boolean\n"
+        "trigger:\n"
+        "  - platform: state\n"
+        "    entity_id: input_boolean.trigger_test\n"
+        "action:\n"
+        "  - service: input_boolean.turn_on\n"
+        "    target:\n"
+        "      entity_id: !input target_boolean\n",
+        encoding="utf-8",
+    )
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": [
+                {
+                    "id": "compatibility_consumer",
+                    "alias": "Compatibility Consumer",
+                    "use_blueprint": {
+                        "path": "compat.yaml",
+                        "input": {"target_boolean": "input_boolean.target_test"},
+                    },
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+
+    entity_ids = automations_with_blueprint(hass, "compat.yaml")
+    assert len(entity_ids) == 1
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={},
+        options={"update_interval": 24},
+        entry_id="live_consumer_entry",
+    )
+    entry.add_to_hass(hass)
+    coordinator = BlueprintUpdateCoordinator(hass, entry, timedelta(hours=24))
+
+    configs = coordinator._get_entities_configs(entity_ids)
+
+    assert configs[entity_ids[0]]["use_blueprint"] == {
+        "path": "compat.yaml",
+        "input": {"target_boolean": "input_boolean.target_test"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_live_script_blueprint_consumer_discovery(hass: HomeAssistant) -> None:
+    """Recover original inputs from a live HA script blueprint consumer."""
+    blueprint_path = Path(hass.config.path("blueprints", "script", "compat.yaml"))
+    blueprint_path.parent.mkdir(parents=True, exist_ok=True)
+    blueprint_path.write_text(
+        "blueprint:\n"
+        "  name: Compatibility Script Consumer\n"
+        "  domain: script\n"
+        "  input:\n"
+        "    delay_seconds:\n"
+        "      default: 1\n"
+        "      selector:\n"
+        "        number:\n"
+        "          min: 1\n"
+        "          max: 60\n"
+        "sequence:\n"
+        "  - delay:\n"
+        "      seconds: !input delay_seconds\n",
+        encoding="utf-8",
+    )
+    assert await async_setup_component(
+        hass,
+        "script",
+        {
+            "script": {
+                "compatibility_consumer": {
+                    "alias": "Compatibility Script Consumer",
+                    "use_blueprint": {
+                        "path": "compat.yaml",
+                        "input": {"delay_seconds": 5},
+                    },
+                }
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    entity_ids = scripts_with_blueprint(hass, "compat.yaml")
+    assert len(entity_ids) == 1
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={},
+        options={"update_interval": 24},
+        entry_id="live_script_consumer_entry",
+    )
+    entry.add_to_hass(hass)
+    coordinator = BlueprintUpdateCoordinator(hass, entry, timedelta(hours=24))
+
+    configs = coordinator._get_entities_configs(entity_ids)
+
+    assert configs[entity_ids[0]]["use_blueprint"] == {
+        "path": "compat.yaml",
+        "input": {"delay_seconds": 5},
+    }
+
+
+@pytest.mark.asyncio
+async def test_unmocked_translation_helper_contract(hass: HomeAssistant) -> None:
+    """Load an integration translation through HA's real translation helper."""
+    assert await async_setup_component(hass, DOMAIN, {})
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={},
+        options={"update_interval": 24},
+        entry_id="translation_contract_entry",
+    )
+    entry.add_to_hass(hass)
+    coordinator = BlueprintUpdateCoordinator(hass, entry, timedelta(hours=24))
+    coordinator.setup_complete = True
+
+    assert await coordinator.async_translate("up_to_date") == "Up to date"
 
 
 @pytest.mark.asyncio

--- a/tests/test_compatibility_matrix.py
+++ b/tests/test_compatibility_matrix.py
@@ -16,9 +16,9 @@ from tools.validate_compatibility import (
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _SUPPORTED_RANGE_BOUNDARIES = [
     ("2024.12.0", "0.13.190", "3.12"),
-    ("2025.1.0", "0.13.201", "3.12"),
+    ("2025.1.4", "0.13.205", "3.12"),
     ("2025.2.0", "0.13.210", "3.13"),
-    ("2026.2.0", "0.13.313", "3.13"),
+    ("2026.2.3", "0.13.316", "3.13"),
     ("2026.3.1", "0.13.317", "3.14"),
     ("latest", "latest", "3.14"),
 ]
@@ -118,3 +118,35 @@ def test_compatibility_main_exits_when_global_uv_is_missing(
 
     output = capsys.readouterr().out
     assert "VALIDATION_ERROR: 'global uv executable' not found." in output
+
+
+def test_refresh_dependencies_preserves_selection_and_legacy_transitive_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Apply legacy transitive constraints during a targeted dependency refresh."""
+    calls: list[tuple[Path, tuple[str, ...], str]] = []
+
+    def record_install(
+        python_bin: Path,
+        package_args: tuple[str, ...] | list[str],
+        step_label: str,
+    ) -> None:
+        calls.append((python_bin, tuple(package_args), step_label))
+
+    monkeypatch.setattr(validate_compatibility, "_run_uv_pip_install", record_install)
+    python_bin = Path("python")
+    selected = ("aiodns==3.5.0", "home-assistant-intents==2025.10.1")
+
+    validate_compatibility._refresh_compatibility_dependencies(
+        python_bin,
+        selected,
+        {"aiodns": "3.5.0"},
+    )
+
+    assert calls == [
+        (
+            python_bin,
+            (*selected, "pycares<5"),
+            "aiodns==3.5.0 home-assistant-intents==2025.10.1",
+        )
+    ]

--- a/tests/ui/test_init_edge_cases.py
+++ b/tests/ui/test_init_edge_cases.py
@@ -290,9 +290,11 @@ async def test_unload_failure_does_not_clear_services(hass: HomeAssistant) -> No
     """
     entry = MagicMock()
     entry.entry_id = "unload_failure_entry"
+    coordinator = MagicMock()
+    coordinator.async_shutdown = AsyncMock()
 
     hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN].setdefault("coordinators", {"dummy": object()})
+    hass.data[DOMAIN]["coordinators"] = {entry.entry_id: coordinator}
 
     with (
         patch.object(
@@ -307,7 +309,8 @@ async def test_unload_failure_does_not_clear_services(hass: HomeAssistant) -> No
         result = await async_unload_entry(hass, entry)
 
     assert result is False
-    assert hass.data[DOMAIN]["coordinators"]
+    assert hass.data[DOMAIN]["coordinators"] == {entry.entry_id: coordinator}
+    coordinator.async_shutdown.assert_not_awaited()
     mock_remove.assert_not_called()
 
     mock_unload_platforms.assert_called_once()
@@ -342,6 +345,7 @@ async def test_setup_entry_rollback(hass: HomeAssistant) -> None:
     coordinator_mock = MagicMock()
     coordinator_mock.async_setup = AsyncMock()
     coordinator_mock.async_config_entry_first_refresh = AsyncMock()
+    coordinator_mock.async_shutdown = AsyncMock()
     coordinator_mock.data = {}
 
     with (
@@ -363,6 +367,7 @@ async def test_setup_entry_rollback(hass: HomeAssistant) -> None:
 
         assert entry.entry_id not in hass.data.get(DOMAIN, {}).get("coordinators", {})
         mock_unload.assert_called_once()
+        coordinator_mock.async_shutdown.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -377,6 +382,7 @@ async def test_setup_entry_rollback_on_forward_failure(hass: HomeAssistant) -> N
     coordinator_mock = MagicMock()
     coordinator_mock.async_setup = AsyncMock()
     coordinator_mock.async_config_entry_first_refresh = AsyncMock()
+    coordinator_mock.async_shutdown = AsyncMock()
     coordinator_mock.data = {}
 
     with (
@@ -400,5 +406,39 @@ async def test_setup_entry_rollback_on_forward_failure(hass: HomeAssistant) -> N
             await async_setup_entry(hass, entry)
 
         assert entry.entry_id not in hass.data.get(DOMAIN, {}).get("coordinators", {})
-        mock_unload.assert_not_called()
+        mock_unload.assert_awaited_once_with(entry, bp_updater.PLATFORMS)
         mock_register_services.assert_not_called()
+        coordinator_mock.async_shutdown.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_setup_entry_rollback_on_initial_refresh_failure(hass: HomeAssistant) -> None:
+    """Shut down coordinator resources when the initial refresh fails."""
+    entry = MagicMock()
+    entry.entry_id = "refresh_failure_entry"
+    entry.data = {}
+    entry.options = {}
+    entry.state = ConfigEntryState.SETUP_IN_PROGRESS
+
+    coordinator_mock = MagicMock()
+    coordinator_mock.async_setup = AsyncMock()
+    coordinator_mock.async_config_entry_first_refresh = AsyncMock(
+        side_effect=HomeAssistantError("Refresh Failed")
+    )
+    coordinator_mock.async_shutdown = AsyncMock()
+
+    with (
+        patch(
+            "custom_components.blueprints_updater.BlueprintUpdateCoordinator",
+            return_value=coordinator_mock,
+        ),
+        patch.object(
+            hass.config_entries, "async_forward_entry_setups", new_callable=AsyncMock
+        ) as mock_forward,
+        pytest.raises(HomeAssistantError, match="Refresh Failed"),
+    ):
+        await async_setup_entry(hass, entry)
+
+    assert entry.entry_id not in hass.data.get(DOMAIN, {}).get("coordinators", {})
+    mock_forward.assert_not_awaited()
+    coordinator_mock.async_shutdown.assert_awaited_once()

--- a/tools/compatibility_matrix.json
+++ b/tools/compatibility_matrix.json
@@ -5,8 +5,8 @@
     "python_version": "3.12"
   },
   {
-    "ha_version": "2025.1.0",
-    "harness_version": "0.13.201",
+    "ha_version": "2025.1.4",
+    "harness_version": "0.13.205",
     "python_version": "3.12"
   },
   {
@@ -15,8 +15,8 @@
     "python_version": "3.13"
   },
   {
-    "ha_version": "2026.2.0",
-    "harness_version": "0.13.313",
+    "ha_version": "2026.2.3",
+    "harness_version": "0.13.316",
     "python_version": "3.13"
   },
   {

--- a/tools/validate_compatibility.py
+++ b/tools/validate_compatibility.py
@@ -52,7 +52,7 @@ _VENVS_ROOT = os.path.join(_REPO_ROOT, ".venvs")
 _VENV_DEPENDENCY_MARKER = ".blueprints_updater_test_dependencies.json"
 
 _TEST_HARNESS_PACKAGE = "pytest-homeassistant-custom-component"
-_HA_CONSTRAINED_TEST_DEPS = ()  # Reserved for future use.
+_HA_CONSTRAINED_TEST_DEPS = ("aiodns",)
 _REQUIRED_TEST_DEPS = (
     *_HA_CONSTRAINED_TEST_DEPS,
     "httpx[http2]",
@@ -82,6 +82,7 @@ _PACKAGE_NAME_PATTERN = re.compile(
 )
 
 _MATRIX_FILE = os.path.join(_REPO_ROOT, "tools", "compatibility_matrix.json")
+_HACS_FILE = os.path.join(_REPO_ROOT, "hacs.json")
 
 _PYPI_HA_JSON_URL = "https://pypi.org/pypi/homeassistant/json"
 _PYPI_TEST_HARNESS_JSON_URL = "https://pypi.org/pypi/pytest-homeassistant-custom-component/json"
@@ -154,6 +155,24 @@ def _required_test_deps(test_dependency_versions: dict[str, str]) -> list[str]:
         if normalize_package_name(package) not in seen
     )
     return deps
+
+
+def _transitive_compatibility_specs(
+    test_dependency_versions: dict[str, str],
+) -> tuple[str, ...]:
+    """Constrain transitive packages whose later majors broke historical HA pins."""
+    aiodns_version = test_dependency_versions.get("aiodns")
+    if aiodns_version is not None and Version(aiodns_version).release[0] < 4:
+        return ("pycares<5",)
+    return ()
+
+
+def _validate_package_version(label_name: str, label_value: str) -> str:
+    """Return a normalized PEP 440 package version."""
+    try:
+        return str(Version(label_value))
+    except InvalidVersion as err:
+        raise ValueError(f"Invalid {label_name} value {label_value!r}") from err
 
 
 def _dependency_pin_marker_payload(
@@ -248,7 +267,7 @@ def _parse_requirements_dependency_version(
                 "expected a version after '=='."
             )
         version = version_tokens[0]
-        return _validate_version_label(f"{package}_version", version)
+        return _validate_package_version(f"{package}_version", version)
     raise ValueError(f"Could not find {package!r} in Home Assistant {source_name}")
 
 
@@ -481,7 +500,45 @@ def _test_matrix() -> list[CompatibilityConfig]:
                 python_ver=py_ver,
             )
         )
+    _validate_matrix_supported_range(entries, _minimum_supported_ha_version())
     return entries
+
+
+def _minimum_supported_ha_version() -> str:
+    """Return the minimum Home Assistant version declared to HACS."""
+    with open(_HACS_FILE, encoding="utf-8") as file_handle:
+        loaded = orjson.loads(file_handle.read())
+    if not isinstance(loaded, dict):
+        raise ValueError("HACS metadata must be an object")
+    return _validate_version_label(
+        "hacs_homeassistant",
+        _require_str_field("hacs_homeassistant", loaded.get("homeassistant")),
+    )
+
+
+def _validate_matrix_supported_range(
+    entries: Sequence[CompatibilityConfig],
+    minimum_ha_version: str,
+) -> None:
+    """Require ordered transition checkpoints across the declared HA support range."""
+    if not entries:
+        raise ValueError("Compatibility matrix must not be empty")
+    if entries[-1]["ha_ver"] != "latest" or entries[-1]["harness_ver"] != "latest":
+        raise ValueError("Compatibility matrix must end with the moving latest pair")
+    if any(entry["ha_ver"] == "latest" for entry in entries[:-1]):
+        raise ValueError("Compatibility matrix latest pair must be the final row")
+
+    fixed_versions = [Version(entry["ha_ver"]) for entry in entries[:-1]]
+    minimum_version = Version(minimum_ha_version)
+    if not fixed_versions or fixed_versions[0] != minimum_version:
+        raise ValueError(
+            "Compatibility matrix first row must match the HACS minimum "
+            f"Home Assistant version {minimum_ha_version}"
+        )
+    if len(set(fixed_versions)) != len(fixed_versions):
+        raise ValueError("Compatibility matrix contains duplicate fixed Home Assistant versions")
+    if fixed_versions != sorted(fixed_versions):
+        raise ValueError("Compatibility matrix fixed Home Assistant versions must be ordered")
 
 
 def _require_str_field(label_name: str, value: object) -> str:
@@ -809,10 +866,11 @@ def _install_compatibility_dependencies(
 ) -> None:
     """Install Home Assistant and required test dependencies."""
     required_test_deps = _required_test_deps(test_dependency_versions)
+    transitive_specs = _transitive_compatibility_specs(test_dependency_versions)
     ha_spec = f"homeassistant=={ha_version}"
     _run_uv_pip_install(
         python_bin,
-        [ha_spec, *required_test_deps],
+        [ha_spec, *required_test_deps, *transitive_specs],
         ha_spec,
     )
 
@@ -820,11 +878,13 @@ def _install_compatibility_dependencies(
 def _refresh_compatibility_dependencies(
     python_bin: Path,
     refresh_dependencies: tuple[str, ...],
+    test_dependency_versions: dict[str, str],
 ) -> None:
     """Upgrade selected compatibility dependencies."""
+    transitive_specs = _transitive_compatibility_specs(test_dependency_versions)
     _run_uv_pip_install(
         python_bin,
-        refresh_dependencies,
+        [*refresh_dependencies, *transitive_specs],
         " ".join(refresh_dependencies),
     )
 
@@ -926,6 +986,7 @@ def _install_dependencies(
         _refresh_compatibility_dependencies(
             python_bin,
             refresh_deps,
+            test_dependency_versions,
         )
     if needs_install or refresh_deps:
         _cleanup_compatibility_bytecode(venv_path)
@@ -1333,9 +1394,23 @@ def main() -> None:
         help="Print newest harness-backed Home Assistant pair JSON",
     )
     parser.add_argument(
+        "--validate-matrix",
+        action="store_true",
+        help="Validate the source compatibility matrix and exit",
+    )
+    parser.add_argument(
         "--required-test-dependency-metadata-json",
         action="store_true",
         help="Print compatibility test dependency package metadata as JSON and exit",
+    )
+    parser.add_argument(
+        "--transitive-compatibility-specs-json",
+        action="store_true",
+        help="Print transitive compatibility specs for a resolved aiodns version",
+    )
+    parser.add_argument(
+        "--aiodns-version",
+        help="Resolved Home Assistant aiodns version for transitive compatibility specs",
     )
     parser.add_argument(
         "--parse-constraint-spec",
@@ -1352,6 +1427,30 @@ def main() -> None:
 
     if args.required_test_dependency_metadata_json:
         print(orjson.dumps(_required_test_dependency_metadata()).decode(), flush=True)
+        return
+
+    if args.validate_matrix:
+        try:
+            entries = _test_matrix()
+        except (OSError, ValueError) as err:
+            print(f"VALIDATION_ERROR: {err}", flush=True)
+            sys.exit(1)
+        print(f"STEP_OK: compatibility matrix validated ({len(entries)} rows)", flush=True)
+        return
+
+    if args.transitive_compatibility_specs_json:
+        if args.aiodns_version is None:
+            parser.error("--transitive-compatibility-specs-json requires --aiodns-version")
+        try:
+            aiodns_version = _validate_package_version(
+                "aiodns_version",
+                args.aiodns_version,
+            )
+            specs = _transitive_compatibility_specs({"aiodns": aiodns_version})
+        except ValueError as err:
+            print(f"VALIDATION_ERROR: {err}", flush=True)
+            sys.exit(1)
+        print(orjson.dumps(specs).decode(), flush=True)
         return
 
     if args.resolve_latest_json:

--- a/uv.lock
+++ b/uv.lock
@@ -531,30 +531,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.43.66"
+version = "1.43.67"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/90/8f/92486dc60e9caf63a766bce02c561381455169a1b7090548d1fdc14d6b8d/boto3-1.43.66.tar.gz", hash = "sha256:ffc77129a4e5519bdbd9b278e4fe9e6276c9d951e0d2b60d626977bdb957cb38", size = 112668, upload-time = "2026-08-06T19:38:42.066Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/bf/ef5de9b55523bc2141d072fbe6614627088e3e6f97b47850216e99de6a1c/boto3-1.43.67.tar.gz", hash = "sha256:75fe983b70d39cfdc274dc51f9bb02b8a0a104bdad4fa073c1af85a35e707c91", size = 112665, upload-time = "2026-08-07T19:30:20.418Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/bc/131d596cf673f7b7c6b52ff88fa05f73bbdf9dff70d93e31d4b62645def3/boto3-1.43.66-py3-none-any.whl", hash = "sha256:8d097a41e2f545c25252105570f782bb035b1ac13d6213c772d1c895dc7cedeb", size = 140027, upload-time = "2026-08-06T19:38:40.651Z" },
+    { url = "https://files.pythonhosted.org/packages/77/0f/b41f8968452dc6bf3b83f15f5e9f76a27fd93e246906aeb2e0555f494375/boto3-1.43.67-py3-none-any.whl", hash = "sha256:082cf9df068168cb44028a1703822374c1eb7e48fa49470d7e8a76f0c977d0bc", size = 140025, upload-time = "2026-08-07T19:30:18.49Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.43.66"
+version = "1.43.67"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5d/81/9ce1f5fe88b4b1429edf83189b8994ffb9883fc20bdd46b7ee9d1cc1da24/botocore-1.43.66.tar.gz", hash = "sha256:dde324cbe8be14b536b78f4fafe192f94fffcc70716bde804044e62495af8c3c", size = 15880416, upload-time = "2026-08-06T19:38:37.603Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/1c/3a75deae60e36bd0ee5c27d040384756b2ea1c90bd7c8c9658335a18b4f5/botocore-1.43.67.tar.gz", hash = "sha256:6fe5cfa0c8676ba809efe505b618ec00f30d1af2d014bf316a7aa4ee86accb20", size = 15889514, upload-time = "2026-08-07T19:30:15.638Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/e6/53f0e28dea0f17a1b041bb3356d0c21fda7ba4198a515cfaf4d5f3088fe3/botocore-1.43.66-py3-none-any.whl", hash = "sha256:0fa62529579469a9224c186eba87e7e561db87dfad20c63ce5d52e427c7fa325", size = 15566310, upload-time = "2026-08-06T19:38:34.446Z" },
+    { url = "https://files.pythonhosted.org/packages/21/be/38af8e96f3d200c9d34eab8e9f69a4468388ed6030ea04ff012974e5af5a/botocore-1.43.67-py3-none-any.whl", hash = "sha256:48ab8e9fac26fbc2a700d57010251003e6a5f731cf74d8540fb796bc8f3fc0ef", size = 15575924, upload-time = "2026-08-07T19:30:12.116Z" },
 ]
 
 [[package]]
@@ -1094,7 +1094,7 @@ wheels = [
 
 [[package]]
 name = "homeassistant"
-version = "2026.8.0"
+version = "2026.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiodns" },
@@ -1148,9 +1148,9 @@ dependencies = [
     { name = "yarl" },
     { name = "zeroconf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8d/30/1e25c48871a24942de234439ac66ddbe649138c217b358c20162c1d29481/homeassistant-2026.8.0.tar.gz", hash = "sha256:2e966cf00edda6ba04ff1c6f707c073b9df5e4480b52dbd59451cec8f30610f9", size = 36732240, upload-time = "2026-08-05T15:34:54.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/79/7080f2d230ae65aab9947b8b3fa7a06b37ee23b833f99611c8f49e1c06da/homeassistant-2026.8.1.tar.gz", hash = "sha256:608d4ad6520e5c16c8d9f42eaa15984f1ab6e9c896ac872f2a3c3831cc9c45bf", size = 36762112, upload-time = "2026-08-07T18:23:42.615Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/b7/4fb4e27596058f0a7014140b4fb75056d518fdda8f04c8aeecca5bf6fd4b/homeassistant-2026.8.0-py3-none-any.whl", hash = "sha256:3b1ff7a5db94d4c33a4228c08950bde1bcecb08893fae3c7513e743fba20c059", size = 59723818, upload-time = "2026-08-05T15:34:49.578Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/77/1fa0722a0b8417069844a067a2d16aeaa28b2894f462b37553e421f29bfd/homeassistant-2026.8.1-py3-none-any.whl", hash = "sha256:35005ce5491f64e48dfa0ca8436751474b8d8ec346a2406c2e2ba0f40427afcd", size = 59782958, upload-time = "2026-08-07T18:23:34.177Z" },
 ]
 
 [[package]]
@@ -2069,7 +2069,7 @@ wheels = [
 
 [[package]]
 name = "pytest-homeassistant-custom-component"
-version = "0.13.354"
+version = "0.13.355"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohasupervisor" },
@@ -2102,9 +2102,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "unidiff" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/48/ac4af2bb13ad79148cd62ca0ef92cb3b36d6d5fc2f9e8703880e27e298d3/pytest_homeassistant_custom_component-0.13.354.tar.gz", hash = "sha256:c2522b9b05143dcca4034d34db7bf65fab19f63efa4f4b0307e6ec36d55251bc", size = 76934, upload-time = "2026-08-06T07:36:43.766Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/a1/042c503037dec2b3563b44d000db54f90945ebabb0e9f091cef1591fb816/pytest_homeassistant_custom_component-0.13.355.tar.gz", hash = "sha256:26330915c72b2482113510f9edff44f3abd6e07e13b920ecaadf45996391b439", size = 76933, upload-time = "2026-08-08T05:39:16.672Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/b0/2284352838e69d4261abfceb120266afcd17d44a3d143342becfd92ada0a/pytest_homeassistant_custom_component-0.13.354-py3-none-any.whl", hash = "sha256:9dff5671d081612221905ad937da2ff2c025908314ccadb9c58f64f89754bfbe", size = 82841, upload-time = "2026-08-06T07:36:42.213Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/4d/fc134f1cad2e126b8cd632bfaf0cf6e50225eff5cc3ccf08718d06a35464/pytest_homeassistant_custom_component-0.13.355-py3-none-any.whl", hash = "sha256:0cc1b56a1292663166ce0ed08e3f0b8bdb1b7c011350d29193c1aa8ce0573a3b", size = 82842, upload-time = "2026-08-08T05:39:15.313Z" },
 ]
 
 [[package]]
@@ -2308,27 +2308,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.16.1"
+version = "0.16.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/70/25/7113f6d5498888c5fb7db34081cba7d5971c4cb1bfb26819966eee68f003/ruff-0.16.1.tar.gz", hash = "sha256:fedad7c801dabd3fb9741d76aca39246e6ddd9ca446a015875207bf19f1e6bc7", size = 4877500, upload-time = "2026-07-30T19:37:01.379Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/e1/4508a569211b35599016e84ba65c1a992b7a4004b4b6c4bea02a851cba1b/ruff-0.16.2.tar.gz", hash = "sha256:c3d7828d12e8927a6fc65fe38e2c2541b9e762d360a1786d752cb1b8883b3c9c", size = 4885811, upload-time = "2026-08-07T13:31:01.432Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/bd/694da69368e0973de65df2ddc73ab18d43c469d5963d9b150911de6bc513/ruff-0.16.1-py3-none-linux_armv6l.whl", hash = "sha256:58edb313b88f0c5460a26adf5f39a37a3be789494a15e3e411e35fa78b89f9a0", size = 10839126, upload-time = "2026-07-30T19:36:13.697Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/f0/b626e5d5bd0dd9576263658ef12885e2288afd1029a48e26ffed65ec1ac1/ruff-0.16.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:fde5a99e2f97479af66edd6622c6d5a2a7592c77cf4153d9e4428f5eeb55b60c", size = 11070253, upload-time = "2026-07-30T19:36:17.14Z" },
-    { url = "https://files.pythonhosted.org/packages/83/63/f40acfb6b35b88623e71684942b552c3edd96035f5d98f313815f7b277de/ruff-0.16.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e0d4c20532fca4f7fa609369161d968dd28f65d83dabbd61d8e9c7edbf7001f6", size = 10561425, upload-time = "2026-07-30T19:36:20.04Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/dd/14ec0e9c2b4d315547dd38765004b4863e354e1b52cb308272215d9f6f6d/ruff-0.16.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:30affbcedf59ad5703d9c91f82266e02b47739f797e1a7b6e158e5526a6dae38", size = 10948879, upload-time = "2026-07-30T19:36:22.476Z" },
-    { url = "https://files.pythonhosted.org/packages/33/e9/9d870cbae575030fdef595f04b4b97573c525b5497cce4f4498cf2f85446/ruff-0.16.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:24e9c631573cbca9d20f1283f8f479b2afa4a8503504822bd71a293889f16743", size = 10643691, upload-time = "2026-07-30T19:36:24.914Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/09/12743d544e2173f53ecd27217c65f90d2bc0f8424a66a60339e56bbc0457/ruff-0.16.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b41bdd48fb420987a9b5212e4957c26ad4abce401fa9ea9d4d85843727945f4f", size = 11435354, upload-time = "2026-07-30T19:36:28.447Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/89/a1652b2daee52083c9554a6333b678a8b01d0400f976827bb87857f9449a/ruff-0.16.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b0d1e1393b7648079e13669de1c1f4fde06d4583e84d8fd5c1551e0a77a2aa75", size = 12259033, upload-time = "2026-07-30T19:36:31.326Z" },
-    { url = "https://files.pythonhosted.org/packages/16/96/ecdcb8c54ee7b123b487f807eb014e6e019155a0b81dfb669acd52f28ce3/ruff-0.16.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:07bf434b1c95f4e093be4532068ef4fcf00924eb2ade8796075980902d6fd54a", size = 11667981, upload-time = "2026-07-30T19:36:34.394Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/90/c52e12e0d862e9572f2a33aa227409143520abe53111e9a6babbac7b4af8/ruff-0.16.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39897739f112253ee4fdd2e8aa9a4f9ded99fb2be367d5f31dfa4ded6025584c", size = 11468183, upload-time = "2026-07-30T19:36:37.339Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/6b/4ffb7ad1d83eb16cf8cbb3c8815d3f11c88460fd162d4b372a2059be1c2a/ruff-0.16.1-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:82ae3c0c0d74daf17b968a10b7b3bb3ef297ab7de0c1f749646b25e690ccb150", size = 11470071, upload-time = "2026-07-30T19:36:39.91Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/72/32ae7db4c0b5e32ab611787caa19d1546800676d79f7483b7100a3561bf4/ruff-0.16.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4d5f2ed10f8242d83fc08d521301089364e3375375705356f20c0e31606ef3ef", size = 10919503, upload-time = "2026-07-30T19:36:42.65Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/ca/3d901ba6ad6fc38da39c3448fc6c59ac945679293a17c3ceb6d6c1cba13e/ruff-0.16.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a4665b309891f83f3e3c25447935f1213e9abbd4b5640af7a1f2def9f8d413c1", size = 10649861, upload-time = "2026-07-30T19:36:45.18Z" },
-    { url = "https://files.pythonhosted.org/packages/92/79/894ef1ced26552d5f8c9cf6d85b0687840e1128c55aeab7b9c2d54a0d880/ruff-0.16.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:26e9ca5c9bc3971f20d3cf18a957f52ffd6a5f6564ff15c4912a144dcac22494", size = 11148137, upload-time = "2026-07-30T19:36:47.936Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/69/3609a09fa1cb46cc28b762363e440a354204e5dff01bd0c8d7437874d6b9/ruff-0.16.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:67e1e1e3fa4f0c82f0e36d4cd61e661f6e7a6196cb1aa92fe0828fa7b8f257cd", size = 11559211, upload-time = "2026-07-30T19:36:50.448Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/8a/fb22af2fd78a736e241fabf67e30ce1799a64244026377a49e133af90762/ruff-0.16.1-py3-none-win32.whl", hash = "sha256:d31765e131295b8445caf301e3e8a85b34d1b9b211b4109b7ba457888b051806", size = 10838258, upload-time = "2026-07-30T19:36:53.298Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/35/e57fd9fb5d423961df087a00b12d42c0a830288dc2f3b45ecca299158b4f/ruff-0.16.1-py3-none-win_amd64.whl", hash = "sha256:09b05e8b90c2cb06ad63464350e7a45e8e44a2dfe52072ebfba6666ca8d3f596", size = 11961111, upload-time = "2026-07-30T19:36:56.107Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/46/240ea004bf6dc4feb40e9832f2205a476a47dd5b8a3f8211a5fc5f95e20e/ruff-0.16.1-py3-none-win_arm64.whl", hash = "sha256:dbaadaac38c70239f056d306b7476f246b0bf000fa6b3876402acbf5b227eaf8", size = 11309414, upload-time = "2026-07-30T19:36:58.79Z" },
+    { url = "https://files.pythonhosted.org/packages/14/57/db19951540f98859c956b50bdb4d31089b4d91e9f15e2968e7d5193806d5/ruff-0.16.2-py3-none-linux_armv6l.whl", hash = "sha256:3c8de4cf2181f01d57946d87d777aa52916976fc09942aed89938fab5e013318", size = 10847925, upload-time = "2026-08-07T13:30:14.468Z" },
+    { url = "https://files.pythonhosted.org/packages/13/5a/995fe85a8470d3e391ac0f7fa8054bb454eaf33ee138196d6172ed1079c0/ruff-0.16.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9a48cc05c6fbc811ca81b5d7ba95375affea6582d1b8024e455e41afbbf55344", size = 11072662, upload-time = "2026-08-07T13:30:18.143Z" },
+    { url = "https://files.pythonhosted.org/packages/32/53/370d767c61c71a971a4ace36703a7ecd8c393956349a7325d7fab2b56827/ruff-0.16.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a2c0d14fcbb26c91f0f867a6dc9bd71bbc30b1b6151829c884f23faeab2e5700", size = 10566771, upload-time = "2026-08-07T13:30:20.899Z" },
+    { url = "https://files.pythonhosted.org/packages/85/d6/9d96948caf5a632be62d62202d5ec914d6856f204fd79eb036e5915e79ea/ruff-0.16.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:335c621622c4650330be50842561c6586ac6971bb8ab5407fe34dcc9efb16bbe", size = 10975825, upload-time = "2026-08-07T13:30:23.517Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/92/ea87129b3414acb0b5770563779c51804d37ac67675c7ba35447ddb14773/ruff-0.16.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:20e66910f2c37cc753f9ef6580c914a621b80c4fa3549d3e3521e29d0f5bfc3f", size = 10649437, upload-time = "2026-08-07T13:30:26.097Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/43/f8f291dcd4af5bb7872b74fdfa41a7cd7c856ca1d4069670971cf1b9f5cb/ruff-0.16.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c7e36fbfba65510548156902bcf1350a979a958ce0347ce0f90d73894036b39f", size = 11446761, upload-time = "2026-08-07T13:30:28.752Z" },
+    { url = "https://files.pythonhosted.org/packages/71/4a/ef991fb2fcf516ab71f0808adcdd8da5e18c8cde447f4ceaf5f47a5132a5/ruff-0.16.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f0eab35f80df8f134aae5d1630e751901321d317cc8e50dc39e36fa3ed34cd12", size = 12336364, upload-time = "2026-08-07T13:30:31.468Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/24/f615e74f307e6ca0e56a482872477b856c70d530aa356abfb6dfe5ca8a80/ruff-0.16.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:40ea8c0594feb894e89c8c61ab9c103d38b0ea72dfde6c594107147ca31b1140", size = 11630720, upload-time = "2026-08-07T13:30:34.426Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/d3/8ef50149e8412a77f7ab409efdef0e2b23803707a3863da4fc64cb23d459/ruff-0.16.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ab3d62dde0b19facdd632008cc4827fc28ada7736c6bd35ab6f1050f0bfed53f", size = 11466130, upload-time = "2026-08-07T13:30:36.958Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a7/a19334985c4dea8c381981fa252cd854c7ee52dc4b1686dc16f4a911c702/ruff-0.16.2-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:e43e1f5b8388da9eca1b9e88328d47a5cec794633ccf6f7484ac2dd15eee92c0", size = 11523634, upload-time = "2026-08-07T13:30:39.822Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6c/96d192b0e742412ceda08c0a50f9669b253dde9fd6a60ea1a10c9fa79a63/ruff-0.16.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:c24788a980581e1d7ea3a0cbe4344c4fbeb0a6a9b1f4713aa46bb104f8294690", size = 10949807, upload-time = "2026-08-07T13:30:42.745Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/51/e26599ceca11e79ee255c7df515995561edf87e9ca1893284e44d98f5a86/ruff-0.16.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:81806b08329130005dd4a8a8394a0c9da8c6f4cafb16ba438d2a2ee6a18bedf1", size = 10646891, upload-time = "2026-08-07T13:30:45.522Z" },
+    { url = "https://files.pythonhosted.org/packages/68/01/800c4b1f97bc8d7c6029e06b1f20473a3cf1e13c4933d8f3342add83fc55/ruff-0.16.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:4ce4e02bad779bef557f541a1b31f20d6abeae1cc05ed1b1ac019d4ffd1044c8", size = 11162063, upload-time = "2026-08-07T13:30:48.131Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d0/1477ea50fc5a0d4b0b71d1d63d50770bdd794d90b43e37a7618e63ec9894/ruff-0.16.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e0422abdf70070255fc4073ce9dfc814cc03db577013761ddd09bc1e4a9a4fbd", size = 11556038, upload-time = "2026-08-07T13:30:50.686Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/76/a7776f32048d991e16d4fa8ff91790b877342d3596cc3ed04acdbf1aaedc/ruff-0.16.2-py3-none-win32.whl", hash = "sha256:bf3a63d78fb39f4bf5ac8ae52051c5520505301abe19ba4e204c453b3f09bb0b", size = 10872850, upload-time = "2026-08-07T13:30:53.471Z" },
+    { url = "https://files.pythonhosted.org/packages/00/0d/929c800d920e61397d82a01b60bffc68da3052c17d31de59efaad2e4ed75/ruff-0.16.2-py3-none-win_amd64.whl", hash = "sha256:bcabe2f6d0fc7819f1431793005af4e4de7371927d037345bf941252b195b9fa", size = 12023338, upload-time = "2026-08-07T13:30:56.193Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6c/93e26c22c5f78ff87363e07da49c84955affbeb1098bd1936bf3b3f293bf/ruff-0.16.2-py3-none-win_arm64.whl", hash = "sha256:d614e95cedf38a2053fd351c55b103ba30d017d61688fdbfd40ee0412852a99f", size = 11374065, upload-time = "2026-08-07T13:30:58.775Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary by Sourcery

Enhance compatibility validation and coordinator lifecycle handling for blueprint consumers and test harness.

New Features:
- Discover blueprint inputs from live Home Assistant automation and script consumers via real blueprints.
- Load integration translations through Home Assistant's real translation helper within compatibility tests.

Bug Fixes:
- Ensure coordinator resources are properly shut down and rolled back on setup failures, including initial refresh, forward setup, and unload edge cases.
- Pass nested use_blueprint input mappings into breaking-change detection to validate consumer schemas correctly.
- Recover original blueprint inputs when Home Assistant exposes substituted public configs for template-based entities.

Enhancements:
- Refine entity config extraction to prefer public configs but reliably fall back to internal blueprint inputs when needed.
- Validate the compatibility matrix against the HACS-declared minimum Home Assistant version and enforce ordered, non-duplicated version checkpoints.
- Constrain transitive dependencies (such as pycares) based on Home Assistant-compatible aiodns versions in the compatibility validation tool.
- Update supported compatibility range boundaries to reflect newer Home Assistant, test harness, and Python versions.

Build:
- Include HACS metadata in compatibility tooling and adjust dependency installation to account for transitive constraints.
- Tighten test dependency configuration by adding aiodns as a constrained Home Assistant test dependency and adjusting tooling around it.
- Relax certain pytest and pyright warning configurations in pyproject.toml to simplify tooling output.

Tests:
- Add integration tests covering live automation and script blueprint consumer discovery and translation helper behavior.
- Extend coordinator tests to verify passing nested consumer inputs into risk detection and lifecycle rollback behavior in error scenarios.
- Add entity tests to confirm fallback behavior when recovering blueprint configs after Home Assistant substitutes public configuration.
- Adjust compatibility matrix tests to align with the updated supported range boundaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when setup or refresh operations fail, ensuring incomplete registrations are cleaned up safely.
  * Improved blueprint configuration discovery across supported Home Assistant representations.
  * Corrected extraction of nested blueprint inputs for breaking-change detection.

* **Compatibility**
  * Updated supported Home Assistant versions and compatibility validation.
  * Improved handling of compatibility constraints and metadata checks.

* **Tests**
  * Added coverage for setup rollback, unload failures, blueprint recovery, live consumer discovery, localized status text, and compatibility scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->