### PR TITLE
Improve selector normalization to avoid false-positive risk detection

### DIFF
--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -39,6 +39,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers.entity_platform import async_get_platforms
+from homeassistant.helpers.selector import validate_selector
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.translation import async_get_translations
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
@@ -2513,13 +2514,28 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, objec
                         sel = val.get("selector")
                         if isinstance(sel, dict) and sel:
                             selector_name = str(next(iter(sel.keys())))
+                            selector_value = sel.get(selector_name)
+                            try:
+                                validated_selector = validate_selector(sel)
+                                selector_config = (
+                                    BlueprintUpdateCoordinator._normalize_selector_config(
+                                        validated_selector.get(selector_name) or {}
+                                    )
+                                )
+                            except vol.Invalid:
+                                selector_config = (
+                                    BlueprintUpdateCoordinator._normalize_selector_config(
+                                        selector_value
+                                    )
+                                )
                         else:
                             selector_name = None
+                            selector_config = None
                         mandatory = "default" not in val
                         schema[key] = {
                             "mandatory": mandatory,
                             "selector": selector_name,
-                            "selector_config": sel,
+                            "selector_config": selector_config,
                         }
                     else:
                         schema[key] = {"mandatory": True, "selector": None, "selector_config": None}

--- a/tests/coordinator/test_schema_guard.py
+++ b/tests/coordinator/test_schema_guard.py
@@ -95,6 +95,93 @@ blueprint:
     )
 
 
+def test_detect_breaking_changes_invalid_falsy_selector_config(coordinator):
+    """An invalid falsy selector config changing to an empty config is risky."""
+    old_content = """
+blueprint:
+  name: Old
+  input:
+    controlled_entity:
+      selector:
+        entity: false
+"""
+    new_content = """
+blueprint:
+  name: New
+  input:
+    controlled_entity:
+      selector:
+        entity: {}
+"""
+
+    risks = coordinator._detect_breaking_changes(
+        old_content,
+        new_content,
+        {"automation.consumer": {"controlled_entity": "light.kitchen"}},
+    )
+
+    assert any(
+        risk["type"] == BlueprintRiskType.SELECTOR_MISMATCH
+        and risk["args"]["input"] == "controlled_entity"
+        for risk in risks
+    )
+
+
+def test_detect_breaking_changes_equivalent_normalized_selectors(coordinator):
+    """Home Assistant schema expansion does not create selector risks."""
+    old_content = """
+blueprint:
+  name: Old
+  input:
+    motion_sensor:
+      selector:
+        entity:
+          domain: binary_sensor
+          device_class: motion
+    target_entity:
+      selector:
+        target:
+          entity:
+            domain:
+              - light
+              - switch
+"""
+    new_content = """
+blueprint:
+  name: New
+  input:
+    motion_sensor:
+      selector:
+        entity:
+          domain:
+            - binary_sensor
+          device_class:
+            - motion
+          multiple: false
+    target_entity:
+      selector:
+        target:
+          entity:
+            - domain:
+                - light
+                - switch
+"""
+
+    risks = coordinator._detect_breaking_changes(
+        old_content,
+        new_content,
+        {
+            "automation.consumer": {
+                "motion_sensor": "binary_sensor.motion",
+                "target_entity": {"entity_id": "light.kitchen"},
+            }
+        },
+    )
+
+    assert all(risk["type"] != BlueprintRiskType.VALIDATION_FAILED for risk in risks)
+    assert all(risk["type"] != BlueprintRiskType.SELECTOR_MISMATCH for risk in risks)
+
+
 def test_normalize_selector_config_preserves_nested_presentation_keys():
     """Only presentation keys on the selector config itself are ignored."""
     normalized = BlueprintUpdateCoordinator._normalize_selector_config(


### PR DESCRIPTION
## Summary by Sourcery

Improve blueprint selector normalization and risk detection by validating and normalizing selector configurations before comparing schemas, ensuring structurally different but equivalent selectors are treated as compatible.

New Features:
- Normalize and compare validated selector configurations to avoid false-positive selector mismatch risks when blueprints expand Home Assistant selectors.

Bug Fixes:
- Prevent selector mismatch risks from being reported when old and new blueprints use equivalent selector configurations despite structural differences.

Enhancements:
- Leverage Home Assistant's selector validation to standardize selector values before normalization and risk detection.

Tests:
- Add a regression test ensuring equivalent normalized selectors do not trigger selector mismatch breaking change detection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and normalization of Home Assistant blueprint selector configurations.
  * Prevented false selector mismatch warnings for equivalent schema formats.
  * Preserved original configurations when selector validation fails.
  * Continued handling inputs without selectors correctly.

* **Tests**
  * Added coverage for scalar-to-list values, nested target entities, default multi-selection behavior, and invalid configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->