### PR TITLE
Improve blueprint validation by checking all referenced input keys

### DIFF
--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -46,6 +46,7 @@ from homeassistant.helpers.translation import async_get_translations
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import slugify
 from homeassistant.util import yaml as yaml_util
+from homeassistant.util.yaml.objects import Input
 
 try:
     from homeassistant.components.template.config import (
@@ -1321,6 +1322,80 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, objec
         except Exception:
             _LOGGER.exception("Failed to send auto-update notification")
 
+    @staticmethod
+    def _extract_defined_inputs(input_dict: object) -> set[str]:
+        """Extract all input keys defined in blueprint.input (including nested sections).
+
+        Args:
+            input_dict: The raw input mapping from the blueprint block.
+
+        Returns:
+            A set of all defined input key names.
+
+        """
+        keys: set[str] = set()
+        if not isinstance(input_dict, Mapping):
+            return keys
+
+        for k, v in input_dict.items():
+            if isinstance(v, Mapping) and "input" in v and isinstance(v["input"], Mapping):
+                keys.update(BlueprintUpdateCoordinator._extract_defined_inputs(v["input"]))
+            elif isinstance(k, str):
+                keys.add(k)
+        return keys
+
+    @staticmethod
+    def _extract_used_inputs(obj: object) -> list[str]:
+        """Recursively find all !input references in the parsed structure.
+
+        Args:
+            obj: Parsed blueprint YAML data or nested object.
+
+        Returns:
+            A list of input names referenced via !input tags.
+
+        """
+        used: list[str] = []
+        if isinstance(obj, Input):
+            used.append(obj.name)
+        elif isinstance(obj, Mapping):
+            for k, v in obj.items():
+                if isinstance(k, Input):
+                    used.append(k.name)
+                elif not isinstance(k, (str, bytes, bytearray)):
+                    used.extend(BlueprintUpdateCoordinator._extract_used_inputs(k))
+                used.extend(BlueprintUpdateCoordinator._extract_used_inputs(v))
+        elif isinstance(obj, Sequence) and not isinstance(obj, (str, bytes, bytearray)):
+            for item in obj:
+                used.extend(BlueprintUpdateCoordinator._extract_used_inputs(item))
+        return used
+
+    @staticmethod
+    def _validate_input_references(data: dict[str, object]) -> str | None:
+        """Verify that all !input tags reference defined blueprint inputs.
+
+        Args:
+            data: Parsed YAML dictionary of the blueprint.
+
+        Returns:
+            An error message if undefined inputs are referenced, or None if valid.
+
+        """
+        blueprint_meta = data.get("blueprint")
+        if not isinstance(blueprint_meta, Mapping):
+            return None
+
+        defined = BlueprintUpdateCoordinator._extract_defined_inputs(blueprint_meta.get("input"))
+        used = BlueprintUpdateCoordinator._extract_used_inputs(data)
+
+        if undefined := sorted({name for name in used if name not in defined}):
+            if len(undefined) == 1:
+                return f"Undefined input referenced: '!input {undefined[0]}'"
+            formatted = ", ".join(f"'!input {name}'" for name in undefined)
+            return f"Undefined inputs referenced: {formatted}"
+
+        return None
+
     def _validate_blueprint(
         self,
         data: dict[str, object],
@@ -1351,6 +1426,14 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, objec
                 redact_url(source_url),
             )
             return "invalid_blueprint"
+
+        if input_error := BlueprintUpdateCoordinator._validate_input_references(data):
+            _LOGGER.warning(
+                "Blueprint input validation failed for %s: %s",
+                redact_url(source_url),
+                input_error,
+            )
+            return format_error_message("blueprint_validation_error", input_error)
 
         schema = BlueprintUpdateCoordinator._get_blueprint_schema(expected_domain)
 

--- a/tests/coordinator/test_metadata.py
+++ b/tests/coordinator/test_metadata.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, mock_open, patch
 import pytest
 import yaml
 from homeassistant.util import yaml as yaml_util
+from homeassistant.util.yaml.objects import Input
 
 import custom_components.blueprints_updater.coordinator as coord_mod
 from custom_components.blueprints_updater.const import (
@@ -481,6 +482,156 @@ def test_validate_blueprint_missing_key(coordinator):
     )
     assert result is not None
     assert "invalid_blueprint" in result
+
+
+def test_validate_blueprint_rejects_undefined_input(coordinator):
+    """Test _validate_blueprint rejects blueprints referencing undefined !input tags."""
+    yaml_text = (
+        "blueprint:\n"
+        "  name: Test\n"
+        "  domain: automation\n"
+        "  input:\n"
+        "    valid_input:\n"
+        "      name: Valid\n"
+        "trigger: []\n"
+        "action:\n"
+        "  - action: light.turn_on\n"
+        "    target:\n"
+        "      entity_id: !input undefined_target\n"
+    )
+    data = yaml_util.parse_yaml(yaml_text)
+    assert isinstance(data, dict)
+
+    coordinator.hass.data = {}
+    result = coordinator._validate_blueprint(
+        data, "https://example.com/bp.yaml", expected_domain=DOMAIN_AUTOMATION
+    )
+    assert result is not None
+    assert "blueprint_validation_error" in result
+    assert "Undefined input referenced: '!input undefined_target'" in result
+
+
+def test_validate_blueprint_rejects_multiple_undefined_inputs(coordinator):
+    """Test _validate_blueprint formats multiple undefined !input references."""
+    yaml_text = (
+        "blueprint:\n"
+        "  name: Test\n"
+        "  domain: automation\n"
+        "  input: {}\n"
+        "trigger:\n"
+        "  - platform: state\n"
+        "    entity_id: !input trigger_entity\n"
+        "action:\n"
+        "  - action: light.turn_on\n"
+        "    target:\n"
+        "      entity_id: !input action_target\n"
+    )
+    data = yaml_util.parse_yaml(yaml_text)
+    assert isinstance(data, dict)
+
+    coordinator.hass.data = {}
+    result = coordinator._validate_blueprint(
+        data, "https://example.com/bp.yaml", expected_domain=DOMAIN_AUTOMATION
+    )
+    assert result is not None
+    assert "blueprint_validation_error" in result
+    assert "Undefined inputs referenced: '!input action_target', '!input trigger_entity'" in result
+
+
+def test_validate_blueprint_accepts_nested_section_inputs(coordinator):
+    """Test _validate_blueprint accepts !input references defined in nested sections."""
+    yaml_text = (
+        "blueprint:\n"
+        "  name: Test\n"
+        "  domain: automation\n"
+        "  input:\n"
+        "    section_header:\n"
+        "      name: Section\n"
+        "      input:\n"
+        "        nested_target:\n"
+        "          name: Nested\n"
+        "trigger: []\n"
+        "action:\n"
+        "  - action: light.turn_on\n"
+        "    target:\n"
+        "      entity_id: !input nested_target\n"
+    )
+    data = yaml_util.parse_yaml(yaml_text)
+    assert isinstance(data, dict)
+
+    coordinator.hass.data = {}
+    result = coordinator._validate_blueprint(
+        data, "https://example.com/bp.yaml", expected_domain=DOMAIN_AUTOMATION
+    )
+    assert result is None
+
+
+def test_extract_defined_inputs_helper(coordinator):
+    """Test _extract_defined_inputs helper handles non-mappings and nested structures."""
+    assert coordinator._extract_defined_inputs(None) == set()
+    assert coordinator._extract_defined_inputs([]) == set()
+    assert coordinator._extract_defined_inputs("string") == set()
+
+    inputs_data = {
+        "top_level": {"name": "Top"},
+        "section": {
+            "name": "Section",
+            "input": {
+                "sub_level": {"name": "Sub"},
+                "nested_section": {
+                    "input": {
+                        "deep_level": None,
+                    }
+                },
+                42: {"name": "Ignored integer key"},
+                object(): {"name": "Ignored non-string key"},
+            },
+        },
+    }
+    extracted = coordinator._extract_defined_inputs(inputs_data)
+    assert extracted == {"top_level", "sub_level", "deep_level"}
+
+
+def test_extract_used_inputs_helper(coordinator):
+    """Test _extract_used_inputs helper handles various object structures."""
+    assert coordinator._extract_used_inputs(None) == []
+    assert coordinator._extract_used_inputs("string") == []
+    assert coordinator._extract_used_inputs(123) == []
+
+    parsed = yaml_util.parse_yaml(
+        "list_inputs:\n  - !input first\n  - item:\n      key: !input second\n"
+    )
+    assert coordinator._extract_used_inputs(parsed) == ["first", "second"]
+
+    mapping_with_input_key = yaml_util.parse_yaml(
+        "mapping_inputs:\n  ? !input key_input\n  : some_value\n"
+    )
+    assert coordinator._extract_used_inputs(mapping_with_input_key) == ["key_input"]
+
+    nested_key_input = Input("nested_key")
+    inner_input = Input("inner_input")
+    list_inner_input = Input("list_inner")
+    direct_key_input = Input("direct_key")
+
+    complex_structure = {
+        # Direct Input as a mapping key
+        direct_key_input: {"value": "ignored"},
+        "tuple_key_mapping": {
+            # Non-string/bytes key (tuple) containing an Input
+            (nested_key_input, "other"): [
+                {"inner": inner_input},
+                "no_input",
+                [list_inner_input],
+            ],
+        },
+    }
+
+    assert coordinator._extract_used_inputs(complex_structure) == [
+        "direct_key",
+        "nested_key",
+        "inner_input",
+        "list_inner",
+    ]
 
 
 def test_ensure_source_url_structured_modification(coordinator):


### PR DESCRIPTION
## Summary by Sourcery

Validate every !input reference against the blueprint's declared inputs before schema validation.

Bug Fixes:
- Reject blueprints that reference undefined !input keys, including references in nested YAML structures and mapping keys.

Enhancements:
- Support validation of inputs declared within nested blueprint input sections and provide clear errors for one or multiple undefined references.

Tests:
- Add coverage for undefined input detection, multiple-reference error formatting, nested input declarations, and recursive input extraction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for validating Home Assistant blueprint input references.
  * Blueprint validation now detects undefined `!input` references, including nested inputs.
  * Reports clear errors for one or multiple undefined inputs.

* **Bug Fixes**
  * Prevents blueprints with invalid input references from passing validation.

* **Tests**
  * Added coverage for nested inputs, valid references, undefined references, and input extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->