### PR TITLE
Make sure source URLs and hashes are handled consistently to avoid triggering false update flags for unchanged blueprints

### DIFF
--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -882,7 +882,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, objec
         if (
             isinstance(resolved_prev_url, str)
             and isinstance(curr_url, str)
-            and resolved_prev_url != curr_url
+            and not registry.are_same_source(resolved_prev_url, curr_url)
         ):
             return self._invalidate_blueprint_metadata(
                 path, resolved_prev_url, curr_url, prev if isinstance(prev, dict) else info
@@ -4493,7 +4493,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, objec
 
     @staticmethod
     def _hash_content(
-        content: str, source_url: str | None = None, already_normalized: bool = False
+        content: str, source_url: object = None, already_normalized: bool = False
     ) -> str:
         """Calculate a deterministic SHA-256 hash of normalized content.
 
@@ -4517,12 +4517,15 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, objec
         if already_normalized:
             return hashlib.sha256(content.encode("utf-8")).hexdigest()
 
-        if not source_url:
+        if not isinstance(source_url, str) or not source_url.strip():
             return hashlib.sha256(
                 BlueprintUpdateCoordinator._normalize_content(content).encode("utf-8")
             ).hexdigest()
 
-        normalized = BlueprintUpdateCoordinator._ensure_source_url(content, source_url)
+        canonical_source_url = BlueprintUpdateCoordinator._canonicalize_source_url(source_url)
+        normalized = BlueprintUpdateCoordinator._ensure_source_url_cached(
+            content, canonical_source_url
+        )
         return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
 
     @staticmethod
@@ -4593,14 +4596,14 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, objec
 
     @staticmethod
     def _ensure_source_url(content: object, source_url: object) -> str:
-        """Ensure the target source_url is present in the blueprint metadata.
+        """Ensure the target canonical source_url is present in the blueprint metadata.
 
         Always uses structured YAML parsing to guarantee data integrity and
         consistency with Home Assistant's core blueprint handling.
 
-        Note: This method intentionally overwrites any existing `source_url`
-        in the blueprint metadata with the provided `source_url` to ensure
-        the integration tracks the authoritative source.
+        Note: This method canonicalizes the source_url and overwrites any
+        existing `source_url` in the blueprint metadata to ensure the
+        integration tracks the authoritative canonical source.
 
         It also applies semantic normalization using Home Assistant's official
         schemas (AUTOMATION_BLUEPRINT_SCHEMA or BLUEPRINT_SCHEMA). This ensures
@@ -4610,22 +4613,38 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, objec
 
         Args:
             content: Raw YAML blueprint content.
-            source_url: Target URL to enforce in the content.
+            source_url: Target URL to canonicalize and enforce in the content.
 
         Returns:
-            The YAML content with the target source_url guaranteed to be
+            The YAML content with the canonicalized source_url guaranteed to be
             present in the blueprint block, in canonical normalized YAML form.
 
         """
         if not isinstance(content, str):
             _LOGGER.debug("Non-string content passed to _ensure_source_url: %s", type(content))
             return ""
-        if not isinstance(source_url, str):
+        if not isinstance(source_url, str) or not source_url.strip():
             _LOGGER.debug(
-                "Non-string source_url passed to _ensure_source_url: %s", type(source_url)
+                "Non-string or empty source_url passed to _ensure_source_url: %s", type(source_url)
             )
             return BlueprintUpdateCoordinator._normalize_content(content)
-        return BlueprintUpdateCoordinator._ensure_source_url_cached(content, source_url)
+
+        canonical_source_url = BlueprintUpdateCoordinator._canonicalize_source_url(source_url)
+        return BlueprintUpdateCoordinator._ensure_source_url_cached(content, canonical_source_url)
+
+    @staticmethod
+    def _canonicalize_source_url(source_url: str) -> str:
+        """Canonicalize non-empty string source_url to a stable canonical form.
+
+        Handles malformed URLs gracefully by falling back to the stripped string representation.
+        """
+        clean_url = source_url.strip()
+        if not clean_url:
+            return ""
+        try:
+            return registry.canonicalize_url(registry.normalize_url(clean_url))
+        except (ValueError, TypeError):
+            return clean_url
 
     @staticmethod
     def _stabilize_yaml_structure(orig_data: object, normalized_data: object) -> object:
@@ -4781,6 +4800,29 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, objec
             )
             return None
 
+        clean_source_url = source_url.strip()
+        try:
+            parsed_url = urlparse(clean_source_url)
+            _ = parsed_url.port
+            hostname = parsed_url.hostname
+            scheme = parsed_url.scheme.lower()
+            if scheme not in ("http", "https") or not hostname:
+                _LOGGER.warning(
+                    "Skipping blueprint at %s: unsupported or invalid 'source_url' scheme or host "
+                    "in blueprint metadata: %s",
+                    path,
+                    redact_url(clean_source_url),
+                )
+                return None
+        except ValueError as err:
+            _LOGGER.warning(
+                "Skipping blueprint at %s: malformed 'source_url' in blueprint metadata: %s",
+                path,
+                err,
+            )
+            return None
+
+        canonical_source_url = BlueprintUpdateCoordinator._canonicalize_source_url(clean_source_url)
         raw_name = bp_info.get("name")
         name = (
             raw_name.strip()
@@ -4797,8 +4839,8 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, objec
         return {
             "name": name,
             "domain": domain,
-            "source_url": source_url.strip(),
-            "local_hash": BlueprintUpdateCoordinator._hash_content(content, source_url),
+            "source_url": canonical_source_url,
+            "local_hash": BlueprintUpdateCoordinator._hash_content(content, canonical_source_url),
             "local_file_hash": (
                 file_hash
                 if file_hash is not None
@@ -4876,6 +4918,9 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, objec
             }
         except UnicodeDecodeError as err:
             _LOGGER.warning("Skipping non-UTF-8 blueprint at %s: %s", full_path, err)
+            return None
+        except ValueError as err:
+            _LOGGER.warning("Skipping invalid blueprint at %s: %s", full_path, err)
             return None
         except OSError:
             _LOGGER.exception("Error reading blueprint at %s", full_path)

--- a/custom_components/blueprints_updater/providers.py
+++ b/custom_components/blueprints_updater/providers.py
@@ -7,7 +7,7 @@ import logging
 from abc import ABC, abstractmethod
 from collections.abc import Iterator, Mapping
 from pathlib import Path
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import ParseResult, urlparse, urlunparse
 
 import orjson
 from homeassistant.exceptions import HomeAssistantError
@@ -39,9 +39,69 @@ def _normalize_hostname(hostname: str | None) -> str:
     return hostname[4:] if hostname.startswith("www.") else hostname
 
 
+def _without_fragment(url: str) -> str:
+    """Return a URL without its client-side fragment."""
+    return urlunparse(urlparse(url)._replace(fragment=""))
+
+
+# Default ports that are implicit for a given scheme and must be omitted from
+# canonical URLs so that urls with and without the explicit port compare equal.
+_SCHEME_DEFAULT_PORTS: dict[str, int] = {"https": 443, "http": 80}
+
+
+def _build_netloc(hostname: str | None, port: int | None) -> str:
+    """Build a normalized netloc string with proper IPv6 bracket handling.
+
+    urlparse strips brackets from IPv6 literal addresses, so naive
+    reconstruction (f"{host}:{port}") produces invalid netloc strings such as
+    '::1:8080'.  This helper re-brackets IPv6 addresses (detected by the
+    presence of ':' in the normalized host) before appending the port.
+    Credentials (userinfo) are stripped during canonicalization to prevent
+    sensitive information from entering hashes or metadata.
+    """
+    host = _normalize_hostname(hostname)
+    bracketed = f"[{host}]" if ":" in host else host
+    return f"{bracketed}:{port}" if port is not None else bracketed
+
+
+def _normalize_netloc(parsed: ParseResult) -> str:
+    """Build a normalized netloc from parsed URL, omitting default scheme ports.
+
+    Strips credentials, preserves non-default ports (such as 8443 or 0), and
+    preserves IPv6 bracketed hosts. Omits default ports (443 for HTTPS, 80 for HTTP).
+    Preserves raw netloc without credentials if the port or hostname is malformed or out of range.
+    """
+    try:
+        port = parsed.port
+        hostname = parsed.hostname
+    except ValueError:
+        raw_netloc = parsed.netloc
+        if "@" in raw_netloc:
+            _, _, raw_netloc = raw_netloc.rpartition("@")
+        return raw_netloc
+
+    if port is not None and _SCHEME_DEFAULT_PORTS.get(parsed.scheme.lower()) == port:
+        port = None
+
+    return _build_netloc(hostname, port)
+
+
 def _replace_path_segment(url: str, raw_marker: str, from_seg: str, to_seg: str) -> str:
-    """Helper to replace a specific path segment for raw URL normalization."""
-    parsed = urlparse(url)
+    """Helper to replace a specific path segment for raw URL normalization.
+
+    Scans path segments from position 2 onward (after owner/repo). At each
+    position the raw_marker is checked first; a match means the path is already
+    normalized. Then from_seg is checked and replaced with to_seg when found.
+    The returned URL has a normalized netloc (with default ports omitted and
+    non-default ports preserved) and no fragment.
+    The input URL scheme is preserved.
+
+    Callers must ensure raw_marker and from_seg are structurally disjoint at
+    any given position, otherwise a raw_marker match may shadow an unprocessed
+    from_seg that happens to appear later in the path.
+    """
+    parsed = urlparse(_without_fragment(url))
+    netloc = _normalize_netloc(parsed)
     path_parts = parsed.path.strip("/").split("/")
     raw_parts = [p.lower() for p in raw_marker.strip("/").split("/")]
     from_parts = [p.lower() for p in from_seg.strip("/").split("/")]
@@ -50,22 +110,29 @@ def _replace_path_segment(url: str, raw_marker: str, from_seg: str, to_seg: str)
     raw_len = len(raw_parts)
     from_len = len(from_parts)
 
+    scheme = parsed.scheme.lower()
     if not path_parts or path_parts == [""]:
-        return url
+        return urlunparse(parsed._replace(scheme=scheme, netloc=netloc))
 
     if len(path_parts) < 3:
-        return url
+        return urlunparse(parsed._replace(scheme=scheme, netloc=netloc))
 
     path_parts_lower = [p.lower() for p in path_parts]
 
     for i in range(2, len(path_parts)):
         if i + raw_len <= len(path_parts) and path_parts_lower[i : i + raw_len] == raw_parts:
-            return url
+            return urlunparse(parsed._replace(scheme=scheme, netloc=netloc))
         if i + from_len <= len(path_parts) and path_parts_lower[i : i + from_len] == from_parts:
             new_parts = path_parts[:i] + to_parts + path_parts[i + from_len :]
-            return urlunparse(parsed._replace(path="/" + "/".join(new_parts)))
+            return urlunparse(
+                parsed._replace(
+                    scheme=scheme,
+                    netloc=netloc,
+                    path="/" + "/".join(new_parts),
+                )
+            )
 
-    return url
+    return urlunparse(parsed._replace(scheme=scheme, netloc=netloc))
 
 
 def _strip_yaml_extension(filename: str) -> str:
@@ -116,6 +183,32 @@ class SourceProvider(ABC):
         """Parse the response content to extract the blueprint YAML."""
         return response_text
 
+    def canonicalize_url(self, url: str) -> str:
+        """Return a stable canonical representation of the URL.
+
+        Normalizes scheme (lowercase), hostname (lowercase, strips leading 'www.'),
+        omits default ports for the scheme (443 for HTTPS, 80 for HTTP) while
+        preserving non-default ports (such as 8443 or 0), strips credentials, and
+        removes trailing slashes from the path so that is_same_source comparisons
+        are not confused by case, port, or www-prefix variants.
+        """
+        parsed = urlparse(url.strip())
+        netloc = _normalize_netloc(parsed)
+        return urlunparse(
+            parsed._replace(
+                scheme=parsed.scheme.lower(),
+                netloc=netloc,
+                path=parsed.path.rstrip("/"),
+                fragment="",
+            )
+        )
+
+    def is_same_source(self, url1: str, url2: str) -> bool:
+        """Check if two URLs represent the exact same source resource."""
+        return self.canonicalize_url(self.normalize_url(url1)) == self.canonicalize_url(
+            self.normalize_url(url2)
+        )
+
 
 class GitHubProvider(SourceProvider):
     """Provider for GitHub hosted blueprints."""
@@ -127,44 +220,45 @@ class GitHubProvider(SourceProvider):
 
     def can_handle(self, url: str) -> bool:
         """Check if URL is a GitHub URL."""
-        parsed = urlparse(url)
+        parsed = urlparse(_without_fragment(url))
         hostname = _normalize_hostname(parsed.hostname)
         return hostname in (DOMAIN_GITHUB, DOMAIN_GITHUB_RAW)
 
     def normalize_url(self, url: str) -> str:
         """Normalize GitHub URL to raw content endpoint."""
-        parsed = urlparse(url)
+        parsed = urlparse(_without_fragment(url))
         hostname = _normalize_hostname(parsed.hostname)
+        scheme = parsed.scheme.lower()
         if hostname != DOMAIN_GITHUB:
-            return url
+            return urlunparse(parsed._replace(scheme=scheme, netloc=_normalize_netloc(parsed)))
 
         path_parts = parsed.path.strip("/").split("/")
         if len(path_parts) < 5:
-            return url
+            return urlunparse(parsed._replace(scheme=scheme, netloc=_normalize_netloc(parsed)))
 
         route_segment = path_parts[2].lower()
         if route_segment not in ("blob", "raw"):
-            return url
+            return urlunparse(parsed._replace(scheme=scheme, netloc=_normalize_netloc(parsed)))
 
         new_parts = [*path_parts[:2], *path_parts[3:]]
 
         return urlunparse(
             (
-                parsed.scheme,
+                scheme,
                 DOMAIN_GITHUB_RAW,
                 "/" + "/".join(new_parts),
                 parsed.params,
                 parsed.query,
-                parsed.fragment,
+                "",
             )
         )
 
     def get_metadata(self, url: str, content: str | None = None) -> dict[str, str]:
         """Extract metadata from GitHub URL following HA Core parity (author/name)."""
         parsed = urlparse(url)
-        path_parts = parsed.path.strip("/").split("/")
-        author = path_parts[0] if len(path_parts) > 0 else "unknown"
-        filename = path_parts[-1] if len(path_parts) > 0 else "blueprint.yaml"
+        path_parts = [p for p in parsed.path.strip("/").split("/") if p]
+        author = path_parts[0] if path_parts else "unknown"
+        filename = path_parts[-1] if path_parts else "blueprint.yaml"
         name = _strip_yaml_extension(filename)
         return {"author": author, "name": name}
 
@@ -179,33 +273,34 @@ class GistProvider(SourceProvider):
 
     def can_handle(self, url: str) -> bool:
         """Check if URL is a Gist URL."""
-        parsed = urlparse(url)
+        parsed = urlparse(_without_fragment(url))
         hostname = _normalize_hostname(parsed.hostname)
         return hostname == DOMAIN_GIST
 
     def normalize_url(self, url: str) -> str:
         """Normalize Gist URL to raw endpoint."""
-        parsed = urlparse(url)
+        parsed = urlparse(_without_fragment(url))
+        netloc = _normalize_netloc(parsed)
+        scheme = parsed.scheme.lower()
         if RE_GIST_RAW.search(parsed.path):
-            return url
-
+            return urlunparse(parsed._replace(scheme=scheme, netloc=netloc))
         return urlunparse(
             (
-                parsed.scheme,
-                parsed.netloc,
+                scheme,
+                netloc,
                 f"{parsed.path.rstrip('/')}/raw",
                 parsed.params,
                 parsed.query,
-                parsed.fragment,
+                "",
             )
         )
 
     def get_metadata(self, url: str, content: str | None = None) -> dict[str, str]:
         """Extract metadata from Gist URL following HA Core parity (author/name)."""
         parsed = urlparse(url)
-        path_parts = parsed.path.strip("/").split("/")
-        author = path_parts[0] if len(path_parts) > 0 else "unknown"
-        filename = path_parts[-1] if len(path_parts) > 0 else "blueprint.yaml"
+        path_parts = [p for p in parsed.path.strip("/").split("/") if p]
+        author = path_parts[0] if path_parts else "unknown"
+        filename = path_parts[-1] if path_parts else "blueprint.yaml"
         if filename == "raw" and len(path_parts) > 1:
             filename = path_parts[-2]
         name = _strip_yaml_extension(filename)
@@ -245,29 +340,49 @@ class HAForumProvider(SourceProvider):
 
     def can_handle(self, url: str) -> bool:
         """Check if URL is an HA Forum URL."""
-        parsed = urlparse(url)
+        parsed = urlparse(_without_fragment(url))
         hostname = _normalize_hostname(parsed.hostname)
         return hostname == DOMAIN_HA_FORUM
 
     def normalize_url(self, url: str) -> str:
         """Normalize Forum URL to topic JSON endpoint."""
-        parsed = urlparse(url)
+        parsed = urlparse(_without_fragment(url))
+        scheme = parsed.scheme.lower() or "https"
+        netloc = _normalize_netloc(parsed) or DOMAIN_HA_FORUM
 
         match = RE_FORUM_TOPIC_ID.search(parsed.path)
         if not match:
-            return url
+            return urlunparse(parsed._replace(scheme=scheme, netloc=netloc))
 
         topic_id = match.group(1)
         return urlunparse(
             (
-                parsed.scheme,
-                parsed.netloc,
+                scheme,
+                netloc,
                 f"/t/{topic_id}.json",
                 parsed.params,
                 "",
-                parsed.fragment,
+                "",
             )
         )
+
+    def canonicalize_url(self, url: str) -> str:
+        """Canonicalize Forum URL to stable topic format without slugs."""
+        parsed = urlparse(url.strip())
+        if match := RE_FORUM_TOPIC_ID.search(parsed.path):
+            topic_id = match.group(1)
+            netloc = _normalize_netloc(parsed) or DOMAIN_HA_FORUM
+            return urlunparse(
+                (
+                    (parsed.scheme or "https").lower(),
+                    netloc,
+                    f"/t/{topic_id}",
+                    "",
+                    "",
+                    "",
+                )
+            )
+        return super().canonicalize_url(url)
 
     def get_metadata(self, url: str, content: str | None = None) -> dict[str, str]:
         """Extract metadata from Forum URL, prioritizing username/slug from topic JSON."""
@@ -340,7 +455,7 @@ class GitLabProvider(SourceProvider):
 
     def can_handle(self, url: str) -> bool:
         """Check if URL is a GitLab URL."""
-        parsed = urlparse(url)
+        parsed = urlparse(_without_fragment(url))
         hostname = _normalize_hostname(parsed.hostname)
         return hostname == DOMAIN_GITLAB
 
@@ -363,7 +478,7 @@ class CodebergProvider(SourceProvider):
 
     def can_handle(self, url: str) -> bool:
         """Check if URL is a Codeberg URL."""
-        parsed = urlparse(url)
+        parsed = urlparse(_without_fragment(url))
         hostname = _normalize_hostname(parsed.hostname)
         return hostname == DOMAIN_CODEBERG
 
@@ -386,7 +501,7 @@ class BitbucketProvider(SourceProvider):
 
     def can_handle(self, url: str) -> bool:
         """Check if URL is a Bitbucket URL."""
-        parsed = urlparse(url)
+        parsed = urlparse(_without_fragment(url))
         hostname = _normalize_hostname(parsed.hostname)
         return hostname == DOMAIN_BITBUCKET
 
@@ -413,14 +528,17 @@ class GenericProvider(SourceProvider):
         return bool(parsed.scheme and parsed.netloc)
 
     def normalize_url(self, url: str) -> str:
-        """No normalization for generic URLs."""
-        return url
+        """Return the generic URL without its client-side fragment."""
+        parsed = urlparse(_without_fragment(url))
+        return urlunparse(
+            parsed._replace(scheme=parsed.scheme.lower(), netloc=_normalize_netloc(parsed))
+        )
 
     def get_metadata(self, url: str, content: str | None = None) -> dict[str, str]:
         """Extract metadata from generic URL (HA Core Parity with Smart Fallback)."""
         parsed = urlparse(url)
         author = parsed.hostname.lower() if parsed.hostname else "imported"
-        path_parts = parsed.path.strip("/").split("/")
+        path_parts = [p for p in parsed.path.strip("/").split("/") if p]
         last_part = path_parts[-1] if path_parts else ""
 
         if last_part.lower().endswith((".yaml", ".yml")):
@@ -439,7 +557,8 @@ class GenericProvider(SourceProvider):
             name = ""
 
         if not name:
-            short_sha = hashlib.sha256(url.encode()).hexdigest()[:7]
+            canonical_url = self.canonicalize_url(url)
+            short_sha = hashlib.sha256(canonical_url.encode()).hexdigest()[:7]
             name = f"blueprint_{short_sha}"
 
         return {"author": author, "name": name}
@@ -489,22 +608,75 @@ class ProviderRegistry:
 
     def get_provider(self, url: str) -> SourceProvider | None:
         """Get the appropriate provider for the given URL."""
-        hostname = _normalize_hostname(urlparse(url).hostname)
+        try:
+            hostname = _normalize_hostname(urlparse(url).hostname)
+        except ValueError:
+            return None
         if hostname and (provider := self._host_to_provider.get(hostname)):
             return provider
 
         for provider in self._providers:
-            if not isinstance(provider, GenericProvider) and provider.can_handle(url):
-                return provider
+            try:
+                if not isinstance(provider, GenericProvider) and provider.can_handle(url):
+                    return provider
+            except ValueError:
+                continue
 
         generic = next((p for p in self._providers if isinstance(p, GenericProvider)), None)
-        return generic if generic and generic.can_handle(url) else None
+        try:
+            return generic if generic and generic.can_handle(url) else None
+        except ValueError:
+            return None
 
     def normalize_url(self, url: str) -> str:
         """Find appropriate provider and normalize URL."""
-        if provider := self.get_provider(url):
-            return provider.normalize_url(url)
+        with contextlib.suppress(ValueError):
+            if provider := self.get_provider(url):
+                return provider.normalize_url(url)
         return url
+
+    def canonicalize_url(self, url: str) -> str:
+        """Find appropriate provider and canonicalize URL."""
+        try:
+            if provider := self.get_provider(url):
+                return provider.canonicalize_url(url)
+            # Fallback for URLs without a matching provider (no valid scheme/netloc).
+            # Apply the same hostname and scheme normalization as SourceProvider.canonicalize_url
+            # so callers always get a consistently normalized result.
+            parsed = urlparse(url.strip())
+            netloc = _normalize_netloc(parsed)
+            return urlunparse(
+                parsed._replace(
+                    scheme=parsed.scheme.lower(),
+                    netloc=netloc,
+                    path=parsed.path.rstrip("/"),
+                    fragment="",
+                )
+            )
+        except ValueError:
+            return url.strip()
+
+    def are_same_source(self, url1: str | None, url2: str | None) -> bool:
+        """Check if two URLs represent the exact same source.
+
+        Returns False if either URL is so malformed that it cannot be parsed
+        (e.g. an unclosed IPv6 bracket such as 'https://[::1/path'), rather than
+        propagating the ValueError to the caller.  A URL that cannot be parsed
+        has no meaningful canonical identity and must not match any other URL.
+        Exact identical non-None strings match via the equality fast path.
+        """
+        if url1 is None or url2 is None:
+            return url1 == url2
+        if url1 == url2:
+            return True
+        try:
+            provider1 = self.get_provider(url1)
+            provider2 = self.get_provider(url2)
+            if provider1 is not None and provider1 == provider2:
+                return provider1.is_same_source(url1, url2)
+            return self.canonicalize_url(url1) == self.canonicalize_url(url2)
+        except ValueError:
+            return False
 
 
 registry = ProviderRegistry()

--- a/tests/coordinator/test_coordinator_url_handling.py
+++ b/tests/coordinator/test_coordinator_url_handling.py
@@ -1,0 +1,540 @@
+"""Tests for coordinator URL-change handling, startup merging, and 304 not-modified cases."""
+
+from collections.abc import Generator
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.blueprints_updater.const import FilterMode
+from custom_components.blueprints_updater.coordinator import (
+    BlueprintScanContext,
+    BlueprintUpdateCoordinator,
+)
+
+
+@pytest.fixture
+def mock_makedirs() -> Generator[MagicMock]:
+    """Mock os.makedirs to prevent creating actual directories on disk."""
+    with patch("os.makedirs") as mock:
+        yield mock
+
+
+def test_hash_content_stability_across_forum_slug_variations() -> None:
+    """Test that _hash_content produces deterministic hashes regardless of forum slug changes."""
+    content = """blueprint:
+  name: Test Blueprint
+  domain: automation
+  input: {}
+trigger:
+  - platform: state
+    entity_id: input_boolean.test
+action:
+  - service: light.toggle
+"""
+    url_slug_a = "https://community.home-assistant.io/t/initial-title-slug/787779"
+    url_slug_b = "https://community.home-assistant.io/t/updated-title-slug-v1-1/787779"
+    url_short = "https://community.home-assistant.io/t/787779"
+
+    hash_a = BlueprintUpdateCoordinator._hash_content(content, url_slug_a)
+    hash_b = BlueprintUpdateCoordinator._hash_content(content, url_slug_b)
+    hash_short = BlueprintUpdateCoordinator._hash_content(content, url_short)
+
+    assert hash_a == hash_b
+    assert hash_a == hash_short
+
+
+def test_hash_content_stability_across_github_blob_and_raw_urls() -> None:
+    """Test that _hash_content produces the same hash for GitHub blob and raw URL forms.
+
+    A blueprint stored via a github.com/blob/ URL and the equivalent
+    raw.githubusercontent.com URL represent the same resource; the content
+    hash must be identical for update-detection to work correctly.
+    """
+    content = """blueprint:
+  name: Test Blueprint
+  domain: automation
+  input: {}
+trigger:
+  - platform: state
+    entity_id: input_boolean.test
+action:
+  - service: light.toggle
+"""
+    blob_url = "https://github.com/owner/repo/blob/main/blueprints/test.yaml"
+    raw_url = "https://raw.githubusercontent.com/owner/repo/main/blueprints/test.yaml"
+
+    hash_blob = BlueprintUpdateCoordinator._hash_content(content, blob_url)
+    hash_raw = BlueprintUpdateCoordinator._hash_content(content, raw_url)
+
+    assert hash_blob == hash_raw
+
+
+def test_ensure_source_url_canonical_normalization() -> None:
+    """Test _ensure_source_url embeds the canonical URL into blueprint YAML."""
+    raw_content = """blueprint:
+  name: Forum Blueprint
+  domain: automation
+  source_url: https://community.home-assistant.io/t/old-slug/787779
+  input: {}
+"""
+    slug_url = "https://community.home-assistant.io/t/new-slug-v1-1/787779"
+    ensured = BlueprintUpdateCoordinator._ensure_source_url(raw_content, slug_url)
+
+    expected_canonical = "https://community.home-assistant.io/t/787779"
+    assert f"source_url: {expected_canonical}" in ensured
+
+
+@pytest.mark.asyncio
+async def test_handle_source_url_change_preserves_equivalent_forum_urls(
+    coordinator: BlueprintUpdateCoordinator, mock_makedirs: MagicMock
+) -> None:
+    """Test that _handle_source_url_change preserves all metadata on topic slug changes."""
+    path = "automation/smart_knob.yaml"
+    prev_url = "https://community.home-assistant.io/t/old-slug/787779"
+    curr_url = "https://community.home-assistant.io/t/new-slug-v1-1/787779"
+
+    coordinator._persisted_metadata = {
+        path: {
+            "etag": "etag_123",
+            "last_modified": "Mon, 01 Jan 2026 00:00:00 GMT",
+            "remote_hash": "hash_123",
+            "source_url": prev_url,
+        }
+    }
+    prev_info: dict[str, object] = {
+        "relative_path": path,
+        "source_url": prev_url,
+        "etag": "etag_123",
+        "last_modified": "Mon, 01 Jan 2026 00:00:00 GMT",
+        "remote_hash": "hash_123",
+    }
+    curr_info: dict[str, object] = {
+        "relative_path": path,
+        "source_url": curr_url,
+        "local_hash": "local_123",
+    }
+
+    result = coordinator._handle_source_url_change(path, curr_info, prev_info, prev_url=prev_url)
+
+    # Metadata should NOT be invalidated because topic IDs are identical
+    assert result.get("etag") == "etag_123"
+    assert result.get("last_modified") == "Mon, 01 Jan 2026 00:00:00 GMT"
+    assert result.get("remote_hash") == "hash_123"
+    assert path in coordinator._persisted_metadata
+
+
+@pytest.mark.asyncio
+async def test_handle_source_url_change_invalidates_on_different_source(
+    coordinator: BlueprintUpdateCoordinator, mock_makedirs: MagicMock
+) -> None:
+    """Test that _handle_source_url_change DOES invalidate metadata on genuine URL change."""
+    path = "automation/smart_knob.yaml"
+    prev_url = "https://community.home-assistant.io/t/topic-a/11111"
+    curr_url = "https://community.home-assistant.io/t/topic-b/22222"
+
+    coordinator._persisted_metadata = {
+        path: {
+            "etag": "etag_123",
+            "remote_hash": "hash_123",
+            "source_url": prev_url,
+        }
+    }
+    prev_info: dict[str, object] = {
+        "relative_path": path,
+        "source_url": prev_url,
+        "etag": "etag_123",
+        "remote_hash": "hash_123",
+    }
+    curr_info: dict[str, object] = {
+        "relative_path": path,
+        "source_url": curr_url,
+        "local_hash": "local_123",
+    }
+
+    result = coordinator._handle_source_url_change(path, curr_info, prev_info, prev_url=prev_url)
+
+    # Metadata SHOULD be cleared because topic IDs differ
+    assert result.get("etag") is None
+    assert result.get("remote_hash") is None
+    assert path not in coordinator._persisted_metadata
+
+
+def test_merge_previous_data_startup_matching_and_mismatching(
+    coordinator: BlueprintUpdateCoordinator,
+) -> None:
+    """Test that startup _merge_previous_data preserves ETags on match and flags on mismatch."""
+    coordinator.data = {}
+    coordinator._persisted_metadata = {
+        "automation/match.yaml": {
+            "etag": "saved_etag_111",
+            "last_modified": "Mon, 01 Jan 2026 00:00:00 GMT",
+            "remote_hash": "matching_hash_111",
+            "source_url": "https://example.com/match.yaml",
+        },
+        "automation/mismatch.yaml": {
+            "etag": "saved_etag_222",
+            "last_modified": "Mon, 01 Jan 2026 00:00:00 GMT",
+            "remote_hash": "stale_hash_222",
+            "source_url": "https://example.com/mismatch.yaml",
+        },
+    }
+
+    results: dict[str, dict[str, object]] = {
+        "automation/match.yaml": {
+            "name": "Match BP",
+            "relative_path": "automation/match.yaml",
+            "domain": "automation",
+            "source_url": "https://example.com/match.yaml",
+            "local_hash": "matching_hash_111",
+            "remote_hash": "matching_hash_111",
+            "etag": "saved_etag_111",
+            "last_modified": "Mon, 01 Jan 2026 00:00:00 GMT",
+            "persisted_source_url": "https://example.com/match.yaml",
+            "updatable": False,
+        },
+        "automation/mismatch.yaml": {
+            "name": "Mismatch BP",
+            "relative_path": "automation/mismatch.yaml",
+            "domain": "automation",
+            "source_url": "https://example.com/mismatch.yaml",
+            "local_hash": "new_local_hash_333",
+            "remote_hash": "stale_hash_222",
+            "etag": "saved_etag_222",
+            "last_modified": "Mon, 01 Jan 2026 00:00:00 GMT",
+            "persisted_source_url": "https://example.com/mismatch.yaml",
+            "updatable": False,
+        },
+    }
+
+    coordinator._merge_previous_data(results)
+
+    match_info = results["automation/match.yaml"]
+    assert match_info["updatable"] is False
+    assert match_info["etag"] == "saved_etag_111"
+    assert match_info["last_modified"] == "Mon, 01 Jan 2026 00:00:00 GMT"
+
+    mismatch_info = results["automation/mismatch.yaml"]
+    assert mismatch_info["updatable"] is True
+    assert mismatch_info["etag"] is None
+    assert mismatch_info["last_modified"] is None
+
+
+@pytest.mark.asyncio
+async def test_handle_not_modified_case_matching_hashes_marks_not_updatable(
+    coordinator: BlueprintUpdateCoordinator,
+) -> None:
+    """Test that 304 with matching hashes transitions updatable from True to False."""
+    path = "automation/bp.yaml"
+    coordinator.data = {
+        path: {
+            "name": "Test BP",
+            "relative_path": path,
+            "domain": "automation",
+            "source_url": "https://example.com/bp.yaml",
+            "local_hash": "same_hash_123",
+            "remote_hash": "same_hash_123",
+            "updatable": True,
+        }
+    }
+
+    info: dict[str, object] = {
+        "name": "Test BP",
+        "local_hash": "same_hash_123",
+    }
+
+    session = MagicMock()
+    await coordinator._handle_not_modified_case(
+        session=session,
+        path=path,
+        info=info,
+        normalized_url="https://example.com/bp.yaml",
+        new_etag="new_etag_789",
+    )
+
+    assert coordinator.data[path]["updatable"] is False
+    assert coordinator.data[path]["etag"] == "new_etag_789"
+
+
+@pytest.mark.asyncio
+async def test_handle_not_modified_case_mismatching_hashes_marks_updatable(
+    coordinator: BlueprintUpdateCoordinator,
+) -> None:
+    """Test that 304 with mismatching hashes transitions updatable to True."""
+    path = "automation/bp.yaml"
+    coordinator.data = {
+        path: {
+            "name": "Test BP",
+            "relative_path": path,
+            "domain": "automation",
+            "source_url": "https://example.com/bp.yaml",
+            "local_hash": "local_hash_123",
+            "remote_hash": "remote_hash_456",
+            "updatable": False,
+        }
+    }
+
+    info: dict[str, object] = {
+        "name": "Test BP",
+        "local_hash": "local_hash_123",
+    }
+
+    session = MagicMock()
+    await coordinator._handle_not_modified_case(
+        session=session,
+        path=path,
+        info=info,
+        normalized_url="https://example.com/bp.yaml",
+        new_etag="new_etag_789",
+    )
+
+    assert coordinator.data[path]["updatable"] is True
+    assert coordinator.data[path]["etag"] == "new_etag_789"
+
+
+@pytest.mark.asyncio
+async def test_handle_not_modified_case_missing_remote_hash(
+    coordinator: BlueprintUpdateCoordinator,
+) -> None:
+    """Test that 304 handles missing remote_hash safely."""
+    path = "automation/bp.yaml"
+    coordinator.data = {
+        path: {
+            "name": "Test BP",
+            "relative_path": path,
+            "domain": "automation",
+            "source_url": "https://example.com/bp.yaml",
+            "local_hash": "local_hash_123",
+            "remote_hash": None,
+            "updatable": False,
+        }
+    }
+
+    info: dict[str, object] = {
+        "name": "Test BP",
+        "local_hash": "local_hash_123",
+    }
+
+    session = MagicMock()
+    result = await coordinator._handle_not_modified_case(
+        session=session,
+        path=path,
+        info=info,
+        normalized_url="https://example.com/bp.yaml",
+        new_etag="new_etag_789",
+    )
+
+    assert result == (None, "new_etag_789", None)
+    assert coordinator.data[path]["updatable"] is False
+
+
+@pytest.mark.parametrize(
+    "malformed_source_url",
+    [
+        "https://example.com:invalid_port/bp.yaml",
+        "https://example.com:70000/bp.yaml",
+        "https://[::1/path",
+        "https://[2001:db8::1/path",
+        "https:///blueprint.yaml",
+        "https://:443/blueprint.yaml",
+        "//host/blueprint.yaml",
+        "blueprint.yaml",
+        "file:///etc/passwd",
+        "javascript:alert(1)",
+        "ftp://example.com/bp.yaml",
+        "gopher://example.com/test",
+    ],
+)
+def test_parse_blueprint_data_rejects_malformed_port(malformed_source_url: str) -> None:
+    """_parse_blueprint_data must reject blueprints with malformed or unusable source_url."""
+    content = f"""blueprint:
+  name: Malformed Port Blueprint
+  domain: automation
+  source_url: {malformed_source_url}
+  input: {{}}
+"""
+    result = BlueprintUpdateCoordinator._parse_blueprint_data("automation/test.yaml", content)
+    assert result is None
+
+
+def test_parse_blueprint_data_stores_canonical_source_url() -> None:
+    """_parse_blueprint_data must store the canonicalized source_url in blueprint metadata."""
+    content = """blueprint:
+  name: Forum Blueprint
+  domain: automation
+  source_url: HTTPS://community.home-assistant.io:443/t/some-slug/787779
+  input: {}
+"""
+    result = BlueprintUpdateCoordinator._parse_blueprint_data("automation/test.yaml", content)
+    assert result is not None
+    assert result["source_url"] == "https://community.home-assistant.io/t/787779"
+
+
+@pytest.mark.parametrize(
+    "malformed_source_url",
+    [
+        "https://example.com:invalid_port/bp.yaml",
+        "https://example.com:70000/bp.yaml",
+        "https://[::1/path",
+        "https://[2001:db8::1/path",
+    ],
+)
+def test_hash_content_handles_malformed_port_gracefully(malformed_source_url: str) -> None:
+    """_hash_content must handle malformed port in source_url safely without raising."""
+    content = """blueprint:
+  name: Test Blueprint
+  domain: automation
+  input: {}
+"""
+    result = BlueprintUpdateCoordinator._hash_content(content, malformed_source_url)
+    assert isinstance(result, str)
+    assert len(result) == 64
+
+
+@pytest.mark.parametrize(
+    "invalid_or_non_string_source_url",
+    [
+        None,
+        "",
+        "   ",
+        12345,
+        object(),
+        "https://example.com:invalid_port/bp.yaml",
+        "https://example.com:99999/bp.yaml",
+        "https://[::1/path",
+    ],
+)
+def test_hash_content_and_ensure_source_url_handle_source_url_variants(
+    invalid_or_non_string_source_url: object,
+) -> None:
+    """Test _hash_content and _ensure_source_url handle arbitrary source_url inputs."""
+    content = """blueprint:
+  name: Test Blueprint
+  domain: automation
+  input: {}
+"""
+    hash_result = BlueprintUpdateCoordinator._hash_content(
+        content,
+        invalid_or_non_string_source_url,
+    )
+    assert isinstance(hash_result, str)
+    assert len(hash_result) == 64
+
+    ensure_result = BlueprintUpdateCoordinator._ensure_source_url(
+        content, invalid_or_non_string_source_url
+    )
+    assert isinstance(ensure_result, str)
+
+
+@pytest.mark.parametrize(
+    "malformed_prev_url",
+    [
+        "https://example.com:invalid/bp.yaml",
+        "https://example.com:70000/bp.yaml",
+    ],
+)
+@pytest.mark.asyncio
+async def test_handle_source_url_change_malformed_persisted_url_does_not_raise(
+    coordinator: BlueprintUpdateCoordinator,
+    mock_makedirs: MagicMock,
+    malformed_prev_url: str,
+) -> None:
+    """Malformed port in persisted source_url must not abort _handle_source_url_change.
+
+    GenericProvider.canonicalize_url preserves the raw netloc when the port is
+    malformed, so the persisted URL remains distinct from the port-free curr_url.
+    are_same_source therefore returns False → _invalidate_blueprint_metadata clears
+    stale remote metadata without raising.
+    """
+    path = "automation/test_malformed.yaml"
+    # Use the host-only form of the URL as the new source — same host, no port.
+    curr_url = "https://example.com/bp.yaml"
+
+    coordinator._persisted_metadata = {
+        path: {
+            "etag": "etag_stale",
+            "remote_hash": "hash_stale",
+            "source_url": malformed_prev_url,
+        }
+    }
+    prev_info: dict[str, object] = {
+        "relative_path": path,
+        "source_url": malformed_prev_url,
+        "etag": "etag_stale",
+        "remote_hash": "hash_stale",
+    }
+    curr_info: dict[str, object] = {
+        "relative_path": path,
+        "source_url": curr_url,
+        "local_hash": "local_abc",
+    }
+
+    # Must not raise even though the persisted URL contains a malformed port.
+    result = coordinator._handle_source_url_change(
+        path, curr_info, prev_info, prev_url=malformed_prev_url
+    )
+
+    # The malformed port is preserved in canonical form → URLs are distinct sources.
+    # are_same_source returns False → stale remote metadata is cleared.
+    assert result.get("etag") is None
+    assert result.get("remote_hash") is None
+    assert path not in coordinator._persisted_metadata
+
+
+def test_scan_single_blueprint_file_skips_non_utf8_file(
+    coordinator: BlueprintUpdateCoordinator, tmp_path: Path
+) -> None:
+    """_scan_single_blueprint_file must skip non-UTF-8 blueprint files without raising."""
+    bp_file = tmp_path / "invalid_utf8.yaml"
+    bp_file.write_bytes(b"\xff\xfe\xfa\xfb")
+
+    context = BlueprintScanContext(
+        hass=coordinator.hass,
+        real_blueprint_path=str(tmp_path),
+        filter_mode=FilterMode.ALL,
+        selected_set=set(),
+        max_backups=3,
+    )
+    with patch(
+        "custom_components.blueprints_updater.coordinator.get_blueprint_relative_path",
+        return_value="automation/invalid_utf8.yaml",
+    ):
+        result = BlueprintUpdateCoordinator._scan_single_blueprint_file(str(bp_file), context)
+
+    assert result is None
+
+
+@pytest.mark.parametrize(
+    "malformed_url",
+    [
+        "https://[::1/invalid_ipv6.yaml",
+        "https://example.com:70000/invalid_port.yaml",
+    ],
+)
+def test_scan_single_blueprint_file_skips_malformed_url_value_error(
+    coordinator: BlueprintUpdateCoordinator, tmp_path: Path, malformed_url: str
+) -> None:
+    """_scan_single_blueprint_file must skip files with malformed source_url without raising."""
+    content = f"""blueprint:
+  name: Malformed URL Blueprint
+  domain: automation
+  source_url: {malformed_url}
+  input: {{}}
+"""
+    bp_file = tmp_path / "malformed_url.yaml"
+    bp_file.write_text(content, encoding="utf-8")
+
+    context = BlueprintScanContext(
+        hass=coordinator.hass,
+        real_blueprint_path=str(tmp_path),
+        filter_mode=FilterMode.ALL,
+        selected_set=set(),
+        max_backups=3,
+    )
+    with patch(
+        "custom_components.blueprints_updater.coordinator.get_blueprint_relative_path",
+        return_value="automation/malformed_url.yaml",
+    ):
+        result = BlueprintUpdateCoordinator._scan_single_blueprint_file(str(bp_file), context)
+
+    assert result is None

--- a/tests/coordinator/test_metadata.py
+++ b/tests/coordinator/test_metadata.py
@@ -51,88 +51,113 @@ def test_normalize_url():
 
 def test_ensure_source_url(coordinator):
     """Test ensuring source_url is present."""
+    # _ensure_source_url normalizes blob URLs to their raw.githubusercontent.com
+    # equivalent before canonicalizing, so the embedded source_url is always
+    # the canonical raw form regardless of what URL form is passed in.
     source_url = "https://github.com/user/repo/blob/main/test.yaml"
-
     new_content = coordinator._ensure_source_url(
         "blueprint:\n  name: Test\n  domain: automation", source_url
     )
-    assert f"source_url: {source_url}" in new_content
+    canonical_url = "https://raw.githubusercontent.com/user/repo/main/test.yaml"
+    assert f"source_url: {canonical_url}" in new_content
 
     parsed = yaml.safe_load(new_content)
-    assert parsed["blueprint"]["source_url"] == source_url
+    assert parsed["blueprint"]["source_url"] == canonical_url
     assert parsed["blueprint"]["name"] == "Test"
     assert parsed["blueprint"]["input"] == {}
 
     content_with_url = f"blueprint:\n  name: Test\n  domain: automation\n  source_url: {source_url}"
     result = coordinator._ensure_source_url(content_with_url, source_url)
-    assert f"source_url: {source_url}" in result
+    assert f"source_url: {canonical_url}" in result
 
     content_with_quotes = (
         f"blueprint:\n  name: Test\n  domain: automation\n  source_url: '{source_url}'"
     )
     result_quotes = coordinator._ensure_source_url(content_with_quotes, source_url)
-    assert source_url in result_quotes
+    assert canonical_url in result_quotes
 
     different_url = "https://github.com/user/new-repo/blob/main/test.yaml"
     content_different = (
         f"blueprint:\n  name: Test\n  domain: automation\n  source_url: {different_url}"
     )
     result = coordinator._ensure_source_url(content_different, source_url)
-    assert f"source_url: {source_url}" in result
+    assert f"source_url: {canonical_url}" in result
     assert different_url not in result
     assert result.count("source_url") == 1
 
-    content_outside = (
+    result_outside = _assert_embedded_canonical_source_url(
         "blueprint:\n  name: Test\n  domain: automation\n"
         "action:\n  - service: rest.post\n    data:\n"
-        "      source_url: https://api.example.com"
+        "      source_url: https://api.example.com",
+        coordinator,
+        source_url,
+        canonical_url,
     )
-    result_outside = coordinator._ensure_source_url(content_outside, source_url)
-    assert f"source_url: {source_url}" in result_outside
     parsed_outside = yaml.safe_load(result_outside)
-    assert parsed_outside["blueprint"]["source_url"] == source_url
+    assert parsed_outside["blueprint"]["source_url"] == canonical_url
     assert parsed_outside["actions"][0]["data"]["source_url"] == "https://api.example.com"
 
-    content_nested_input = (
+    result_nested = _assert_embedded_canonical_source_url(
         "blueprint:\n  name: Test\n  domain: automation\n"
         "  input:\n    source_url:\n      name: Enter URL\n"
-        "trigger:\n  - platform: webhook"
+        "trigger:\n  - platform: webhook",
+        coordinator,
+        source_url,
+        canonical_url,
     )
-    result_nested = coordinator._ensure_source_url(content_nested_input, source_url)
-    assert f"source_url: {source_url}" in result_nested
     assert result_nested.count("source_url") == 2
 
-    content_with_comment = "blueprint: # comment\n  name: Test\n  domain: automation"
-    result_comment = coordinator._ensure_source_url(content_with_comment, source_url)
-    assert f"source_url: {source_url}" in result_comment
-
-    content_flow = "blueprint: { name: Test, domain: automation }"
-    result_flow = coordinator._ensure_source_url(content_flow, source_url)
-    assert f"source_url: {source_url}" in result_flow
-
+    _assert_embedded_canonical_source_url(
+        "blueprint: # comment\n  name: Test\n  domain: automation",
+        coordinator,
+        source_url,
+        canonical_url,
+    )
+    _assert_embedded_canonical_source_url(
+        "blueprint: { name: Test, domain: automation }",
+        coordinator,
+        source_url,
+        canonical_url,
+    )
     content_invalid = "\ufeffblueprint: [unclosed\r\n"
     result_invalid = coordinator._ensure_source_url(content_invalid, source_url)
     assert "\ufeff" not in result_invalid
     assert "\r" not in result_invalid
 
-    content_multi = (
+    result_multi = _assert_embedded_canonical_source_url(
         "# Some info: blueprint:\n"
         "blueprint:\n"
         "  name: Test\n"
         "  domain: automation\n"
-        "description: 'This is another blueprint: key in string'"
+        "description: 'This is another blueprint: key in string'",
+        coordinator,
+        source_url,
+        canonical_url,
     )
-    result_multi = coordinator._ensure_source_url(content_multi, source_url)
-    assert f"source_url: {source_url}" in result_multi
     parsed_multi = yaml_util.parse_yaml(result_multi)
     assert isinstance(parsed_multi, dict)
     assert isinstance(parsed_multi["blueprint"], dict)
-    assert parsed_multi["blueprint"]["source_url"] == source_url
+    assert parsed_multi["blueprint"]["source_url"] == canonical_url
     assert parsed_multi["blueprint"]["input"] == {}
 
     content_none = "not_a_blueprint: true"
     expected_none = coordinator._normalize_content(content_none)
     assert coordinator._ensure_source_url(content_none, source_url) == expected_none
+
+
+def _assert_embedded_canonical_source_url(
+    content: str,
+    coordinator: BlueprintUpdateCoordinator,
+    source_url: str,
+    canonical_url: str,
+) -> str:
+    """Assert _ensure_source_url embeds the canonical URL for the given content."""
+    result = coordinator._ensure_source_url(content, source_url)
+    parsed = yaml_util.parse_yaml(result)
+    assert isinstance(parsed, dict)
+    assert isinstance(parsed.get("blueprint"), dict)
+    assert parsed["blueprint"].get("source_url") == canonical_url
+    return result
 
 
 @pytest.mark.parametrize(
@@ -789,14 +814,18 @@ def test_set_cached_git_diff(coordinator):
 
 def test_ensure_source_url_script(coordinator):
     """Test ensuring source_url for a script blueprint."""
+    # _ensure_source_url normalizes blob URLs to their raw.githubusercontent.com
+    # equivalent before canonicalizing, so the embedded source_url is the canonical
+    # raw form regardless of what URL form is passed in.
     source_url = "https://github.com/user/repo/blob/main/script.yaml"
+    canonical_url = "https://raw.githubusercontent.com/user/repo/main/script.yaml"
     content = "blueprint:\n  name: Test Script\n  domain: script"
 
     new_content = coordinator._ensure_source_url(content, source_url)
-    assert f"source_url: {source_url}" in new_content
+    assert f"source_url: {canonical_url}" in new_content
 
     parsed = yaml.safe_load(new_content)
-    assert parsed["blueprint"]["source_url"] == source_url
+    assert parsed["blueprint"]["source_url"] == canonical_url
     assert parsed["blueprint"]["name"] == "Test Script"
     assert parsed["blueprint"]["domain"] == FunctionalDomain.SCRIPT
 

--- a/tests/coordinator/test_update_cycle.py
+++ b/tests/coordinator/test_update_cycle.py
@@ -1356,11 +1356,16 @@ async def test_async_install_blueprint_state_sync_fix(coordinator, mock_makedirs
     ):
         await coordinator.async_install_blueprint(path, raw_remote)
 
+    # Both _hash_content and _ensure_source_url now normalize blob URLs to
+    # their raw.githubusercontent.com equivalent before canonicalizing, so the
+    # blob and raw URL forms produce the same hash.  The blob URL here is the
+    # value stored in coordinator.data["source_url"] and exercises that path.
     expected_hash = coordinator._hash_content(
         raw_remote, "https://github.com/user/repo/blob/main/test.yaml"
     )
     assert coordinator.data[path]["local_hash"] == expected_hash
     assert coordinator.data[path]["remote_hash"] == expected_hash
+    assert coordinator.data[path]["local_hash"] == coordinator.data[path]["remote_hash"]
     assert not coordinator.data[path]["updatable"]
     assert coordinator.data[path]["last_error"] is None
     assert coordinator.data[path]["invalid_remote_hash"] is None

--- a/tests/providers/test_providers_edge_cases.py
+++ b/tests/providers/test_providers_edge_cases.py
@@ -1,6 +1,9 @@
 """Tests for specialized blueprint provider behaviors and edge case URL formats."""
 
+from urllib.parse import urlparse
+
 import orjson
+import pytest
 
 from custom_components.blueprints_updater.const import SourceProviderType
 from custom_components.blueprints_updater.providers import (
@@ -12,6 +15,8 @@ from custom_components.blueprints_updater.providers import (
     GitLabProvider,
     HAForumProvider,
     ProviderRegistry,
+    SourceProvider,
+    registry,
 )
 
 
@@ -24,6 +29,107 @@ def test_provider_identity():
     assert CodebergProvider().provider_type == SourceProviderType.CODEBERG
     assert BitbucketProvider().provider_type == SourceProviderType.BITBUCKET
     assert GenericProvider().provider_type == SourceProviderType.GENERIC
+
+
+def test_forum_provider_canonicalize_url() -> None:
+    """Test HAForumProvider canonicalize_url removes slugs and normalizes topic URLs."""
+    provider = HAForumProvider()
+    url_full = "https://community.home-assistant.io/t/zigbee2mqtt-control-light-entity-including-press-turn-with-tuya-moes-smart-knob-ers-10tzbvk-aa/787779"
+    url_updated_slug = "https://community.home-assistant.io/t/zigbee2mqtt-control-light-entity-including-press-turn-with-tuya-moes-smart-knob-ers-10tzbvk-aa-v1-1/787779"
+    url_short = "https://community.home-assistant.io/t/787779"
+    url_trailing_slash = "https://community.home-assistant.io/t/787779/"
+    url_with_post = "https://community.home-assistant.io/t/slug/787779/1"
+    url_www = "https://www.community.home-assistant.io/t/slug/787779"
+    url_upper_scheme = "HTTPS://community.home-assistant.io/t/slug/787779"
+
+    expected = "https://community.home-assistant.io/t/787779"
+    assert provider.canonicalize_url(url_full) == expected
+    assert provider.canonicalize_url(url_updated_slug) == expected
+    assert provider.canonicalize_url(url_short) == expected
+    assert provider.canonicalize_url(url_trailing_slash) == expected
+    assert provider.canonicalize_url(url_with_post) == expected
+    assert provider.canonicalize_url(url_www) == expected
+    assert provider.canonicalize_url(url_upper_scheme) == expected
+
+
+def test_forum_provider_is_same_source() -> None:
+    """Test HAForumProvider is_same_source recognizes equivalent topic URLs."""
+    provider = HAForumProvider()
+    url1 = "https://community.home-assistant.io/t/old-slug/787779"
+    url2 = "https://community.home-assistant.io/t/new-slug-v1-1/787779"
+    url3 = "https://community.home-assistant.io/t/787779"
+    url_www = "https://www.community.home-assistant.io/t/787779"
+    url_different = "https://community.home-assistant.io/t/different-topic/12345"
+
+    assert provider.is_same_source(url1, url2) is True
+    assert provider.is_same_source(url1, url3) is True
+    assert provider.is_same_source(url2, url3) is True
+    assert provider.is_same_source(url1, url_www) is True
+    assert provider.is_same_source(url1, url_different) is False
+
+
+def test_github_provider_canonicalize_and_same_source() -> None:
+    """Test GitHubProvider canonicalization and source comparison with edge cases."""
+    provider = GitHubProvider()
+    blob_url = "https://github.com/user/repo/blob/main/blueprint.yaml"
+    raw_url = "https://raw.githubusercontent.com/user/repo/main/blueprint.yaml"
+    raw_web_url = "https://github.com/user/repo/raw/main/blueprint.yaml"
+    diff_file = "https://github.com/user/repo/blob/main/other.yaml"
+    diff_branch = "https://github.com/user/repo/blob/dev/blueprint.yaml"
+    diff_repo = "https://github.com/user/other-repo/blob/main/blueprint.yaml"
+
+    # Canonicalization trims whitespace and trailing slashes while preserving URL scheme
+    assert provider.canonicalize_url(blob_url) == blob_url
+    assert provider.canonicalize_url(raw_url) == raw_url
+    assert provider.canonicalize_url(raw_web_url) == raw_web_url
+    assert provider.canonicalize_url(f"  {blob_url}/  ") == blob_url
+
+    # Equivalence checks normalize endpoints to verify source identity
+    assert provider.is_same_source(blob_url, raw_url) is True
+    assert provider.is_same_source(blob_url, raw_web_url) is True
+    assert provider.is_same_source(blob_url, diff_file) is False
+    assert provider.is_same_source(blob_url, diff_branch) is False
+    assert provider.is_same_source(blob_url, diff_repo) is False
+
+
+@pytest.mark.parametrize(
+    ("url1", "url2", "expected"),
+    [
+        # HA Forum topic matching
+        (
+            "https://community.home-assistant.io/t/slug-a/99999",
+            "https://community.home-assistant.io/t/99999/",
+            True,
+        ),
+        (
+            "https://community.home-assistant.io/t/slug-a/99999",
+            "https://community.home-assistant.io/t/88888",
+            False,
+        ),
+        # GitHub matching
+        (
+            "https://github.com/org/repo/blob/master/automation.yaml",
+            "https://raw.githubusercontent.com/org/repo/master/automation.yaml",
+            True,
+        ),
+        # Generic matching & whitespace/slashes
+        ("https://example.com/bp.yaml", "https://example.com/bp.yaml", True),
+        ("  https://example.com/bp.yaml/  ", "https://example.com/bp.yaml", True),
+        ("https://example.com/a.yaml", "https://example.com/b.yaml", False),
+        # Provider boundary (e.g. cross-domain comparison)
+        (
+            "https://community.home-assistant.io/t/slug-a/99999",
+            "https://github.com/org/repo/blob/master/automation.yaml",
+            False,
+        ),
+        # None handling
+        (None, None, True),
+        ("https://example.com/bp.yaml", None, False),
+    ],
+)
+def test_registry_are_same_source(url1: str | None, url2: str | None, expected: bool) -> None:
+    """Test ProviderRegistry are_same_source across diverse providers and boundaries."""
+    assert registry.are_same_source(url1, url2) is expected
 
 
 def test_github_provider_complex_urls():
@@ -352,3 +458,823 @@ def test_ha_forum_skips_malformed_post_before_valid_blueprint():
         content=orjson.dumps(response_json).decode("utf-8"),
     )
     assert meta == {"author": "good_author", "name": "awesome-blueprint"}
+
+
+def test_is_same_source_hostname_case_gist() -> None:
+    """GistProvider.is_same_source must be insensitive to hostname case."""
+    provider = GistProvider()
+    lower = "https://gist.github.com/user/abc123"
+    upper = "https://GIST.GITHUB.COM/user/abc123"
+    mixed = "https://Gist.GitHub.Com/user/abc123"
+    assert provider.is_same_source(lower, upper) is True
+    assert provider.is_same_source(lower, mixed) is True
+
+
+def test_is_same_source_hostname_case_gitlab() -> None:
+    """GitLabProvider.is_same_source must be insensitive to hostname case."""
+    provider = GitLabProvider()
+    lower = "https://gitlab.com/user/repo/-/blob/main/bp.yaml"
+    upper = "https://GITLAB.COM/user/repo/-/blob/main/bp.yaml"
+    assert provider.is_same_source(lower, upper) is True
+
+
+def test_is_same_source_hostname_case_codeberg() -> None:
+    """CodebergProvider.is_same_source must be insensitive to hostname case."""
+    provider = CodebergProvider()
+    lower = "https://codeberg.org/user/repo/src/branch/main/bp.yaml"
+    upper = "https://CODEBERG.ORG/user/repo/src/branch/main/bp.yaml"
+    assert provider.is_same_source(lower, upper) is True
+
+
+def test_is_same_source_hostname_case_bitbucket() -> None:
+    """BitbucketProvider.is_same_source must be insensitive to hostname case."""
+    provider = BitbucketProvider()
+    lower = "https://bitbucket.org/user/repo/src/master/bp.yaml"
+    upper = "https://BITBUCKET.ORG/user/repo/src/master/bp.yaml"
+    assert provider.is_same_source(lower, upper) is True
+
+
+def test_is_same_source_www_alias_generic() -> None:
+    """GenericProvider.is_same_source treats www. as an alias for the bare host."""
+    provider = GenericProvider()
+    bare = "https://example.com/blueprint.yaml"
+    www = "https://www.example.com/blueprint.yaml"
+    assert provider.is_same_source(bare, www) is True
+
+
+def test_registry_are_same_source_hostname_case_variants() -> None:
+    """registry.are_same_source handles hostname-case and www. variants end-to-end."""
+    reg = ProviderRegistry()
+
+    # GitLab via registry
+    assert (
+        reg.are_same_source(
+            "https://gitlab.com/u/r/-/blob/main/bp.yaml",
+            "https://GITLAB.COM/u/r/-/blob/main/bp.yaml",
+        )
+        is True
+    )
+
+    # Codeberg via registry
+    assert (
+        reg.are_same_source(
+            "https://codeberg.org/u/r/src/branch/main/bp.yaml",
+            "https://CODEBERG.ORG/u/r/src/branch/main/bp.yaml",
+        )
+        is True
+    )
+
+    # Bitbucket via registry
+    assert (
+        reg.are_same_source(
+            "https://bitbucket.org/u/r/src/master/bp.yaml",
+            "https://BITBUCKET.ORG/u/r/src/master/bp.yaml",
+        )
+        is True
+    )
+
+    # Gist via registry (hostname-case)
+    assert (
+        reg.are_same_source(
+            "https://gist.github.com/user/abc123",
+            "https://GIST.GITHUB.COM/user/abc123",
+        )
+        is True
+    )
+
+    # Generic www. alias via registry
+    assert (
+        reg.are_same_source(
+            "https://example.com/bp.yaml",
+            "https://www.example.com/bp.yaml",
+        )
+        is True
+    )
+
+
+@pytest.mark.parametrize(
+    ("url", "expected_fragment"),
+    [
+        ("https://[::1]:8080/blueprint.yaml", "[::1]:8080"),
+        ("https://[::1]/blueprint.yaml", "[::1]"),
+    ],
+)
+def test_canonicalize_url_ipv6_idempotent(url: str, expected_fragment: str) -> None:
+    """canonicalize_url must bracket IPv6 literals and remain stable on repeated calls."""
+    provider = GenericProvider()
+    canonical = provider.canonicalize_url(url)
+    assert expected_fragment in canonical
+    assert provider.canonicalize_url(canonical) == canonical  # idempotent
+
+
+def test_gist_normalize_url_normalizes_hostname_on_already_raw_url() -> None:
+    """GistProvider.normalize_url must normalize hostname even when URL is already /raw."""
+    provider = GistProvider()
+    upper_raw = "https://GIST.GITHUB.COM/user/abc123/raw"
+    result = provider.normalize_url(upper_raw)
+    assert result == "https://gist.github.com/user/abc123/raw"
+    # Idempotent: normalizing an already-lowercase raw URL returns it unchanged.
+    lower_raw = "https://gist.github.com/user/abc123/raw"
+    assert provider.normalize_url(lower_raw) == lower_raw
+
+
+def test_ha_forum_canonicalize_url_non_topic_fallback_normalizes_hostname() -> None:
+    """HAForumProvider.canonicalize_url non-topic fallback must normalize hostname via super()."""
+    provider = HAForumProvider()
+    non_topic_upper = "https://WWW.COMMUNITY.HOME-ASSISTANT.IO/categories"
+    result = provider.canonicalize_url(non_topic_upper)
+    assert result == "https://community.home-assistant.io/categories"
+
+
+def test_github_get_metadata_empty_path_returns_fallback() -> None:
+    """GitHubProvider.get_metadata must return 'unknown' for empty path URLs."""
+    provider = GitHubProvider()
+    result = provider.get_metadata("https://github.com")
+    assert result["author"] == "unknown"
+    # 'blueprint.yaml' is the fallback filename; _strip_yaml_extension removes .yaml
+    assert result["name"] == "blueprint"
+
+
+def test_dedicated_providers_strip_explicit_ports() -> None:
+    """Dedicated HTTPS providers must remove explicit ports from normalized URLs."""
+    cases = (
+        (
+            GitHubProvider(),
+            "https://github.com:443/user/repo/blob/main/bp.yaml",
+            "https://raw.githubusercontent.com/user/repo/main/bp.yaml",
+        ),
+        (
+            GistProvider(),
+            "https://gist.github.com:443/user/abc123",
+            "https://gist.github.com/user/abc123/raw",
+        ),
+        (
+            HAForumProvider(),
+            "https://community.home-assistant.io:443/t/topic/123",
+            "https://community.home-assistant.io/t/123.json",
+        ),
+        (
+            GitLabProvider(),
+            "https://gitlab.com:443/user/repo/-/blob/main/bp.yaml",
+            "https://gitlab.com/user/repo/-/raw/main/bp.yaml",
+        ),
+        (
+            CodebergProvider(),
+            "https://codeberg.org:443/user/repo/src/branch/main/bp.yaml",
+            "https://codeberg.org/user/repo/raw/branch/main/bp.yaml",
+        ),
+        (
+            BitbucketProvider(),
+            "https://bitbucket.org:443/user/repo/src/master/bp.yaml",
+            "https://bitbucket.org/user/repo/raw/master/bp.yaml",
+        ),
+    )
+
+    for provider, source_url, expected_url in cases:
+        assert provider.normalize_url(source_url) == expected_url
+
+
+def test_normalize_url_removes_fragments() -> None:
+    """Normalized fetching URLs must not contain client-side fragments."""
+    cases = (
+        (
+            GenericProvider(),
+            "https://example.com/blueprint.yaml#section",
+            "https://example.com/blueprint.yaml",
+        ),
+        (
+            GitHubProvider(),
+            "https://github.com/user/repo/blob/main/blueprint.yaml#section",
+            "https://raw.githubusercontent.com/user/repo/main/blueprint.yaml",
+        ),
+        (
+            GistProvider(),
+            "https://gist.github.com/user/abc123#section",
+            "https://gist.github.com/user/abc123/raw",
+        ),
+        (
+            GitLabProvider(),
+            "https://gitlab.com/user/repo/-/blob/main/bp.yaml#section",
+            "https://gitlab.com/user/repo/-/raw/main/bp.yaml",
+        ),
+        (
+            CodebergProvider(),
+            "https://codeberg.org/user/repo/src/branch/main/bp.yaml#section",
+            "https://codeberg.org/user/repo/raw/branch/main/bp.yaml",
+        ),
+        (
+            BitbucketProvider(),
+            "https://bitbucket.org/user/repo/src/master/bp.yaml#section",
+            "https://bitbucket.org/user/repo/raw/master/bp.yaml",
+        ),
+        (
+            HAForumProvider(),
+            "https://community.home-assistant.io/t/topic/123#section",
+            "https://community.home-assistant.io/t/123.json",
+        ),
+    )
+
+    for provider, source_url, expected_url in cases:
+        assert provider.normalize_url(source_url) == expected_url
+
+
+def test_normalize_url_strips_credentials() -> None:
+    """Normalized fetching URLs must not contain user credentials."""
+    cases = (
+        (
+            GenericProvider(),
+            "https://user:pass@example.com/blueprint.yaml",
+            "https://example.com/blueprint.yaml",
+        ),
+        (
+            GitHubProvider(),
+            "https://user:pass@github.com/user/repo/blob/main/blueprint.yaml",
+            "https://raw.githubusercontent.com/user/repo/main/blueprint.yaml",
+        ),
+        (
+            GistProvider(),
+            "https://user:pass@gist.github.com/user/abc123",
+            "https://gist.github.com/user/abc123/raw",
+        ),
+        (
+            GitLabProvider(),
+            "https://user:pass@gitlab.com/user/repo/-/blob/main/bp.yaml",
+            "https://gitlab.com/user/repo/-/raw/main/bp.yaml",
+        ),
+        (
+            CodebergProvider(),
+            "https://user:pass@codeberg.org/user/repo/src/branch/main/bp.yaml",
+            "https://codeberg.org/user/repo/raw/branch/main/bp.yaml",
+        ),
+        (
+            BitbucketProvider(),
+            "https://user:pass@bitbucket.org/user/repo/src/master/bp.yaml",
+            "https://bitbucket.org/user/repo/raw/master/bp.yaml",
+        ),
+        (
+            HAForumProvider(),
+            "https://user:pass@community.home-assistant.io/t/topic/123",
+            "https://community.home-assistant.io/t/123.json",
+        ),
+    )
+
+    for provider, source_url, expected_url in cases:
+        assert provider.normalize_url(source_url) == expected_url
+
+
+def test_registry_normalize_url_removes_fragments() -> None:
+    """Registry normalization must remove fragments for every provider."""
+    reg = ProviderRegistry()
+    cases = (
+        (
+            "https://example.com/blueprint.yaml#section",
+            "https://example.com/blueprint.yaml",
+        ),
+        (
+            "https://github.com/user/repo/blob/main/blueprint.yaml#section",
+            "https://raw.githubusercontent.com/user/repo/main/blueprint.yaml",
+        ),
+        (
+            "https://community.home-assistant.io/t/topic/123#section",
+            "https://community.home-assistant.io/t/123.json",
+        ),
+    )
+
+    for source_url, expected_url in cases:
+        assert reg.normalize_url(source_url) == expected_url
+
+
+def test_canonicalization_ignores_generic_url_fragments() -> None:
+    """Generic URLs differing only by fragments must have the same identity."""
+    provider = GenericProvider()
+    base = "https://example.com/blueprint.yaml"
+
+    assert provider.canonicalize_url(base) == provider.canonicalize_url(f"{base}#section")
+    assert provider.is_same_source(base, f"{base}#section") is True
+
+
+def test_canonicalization_ignores_github_url_fragments() -> None:
+    """GitHub URLs differing only by fragments must have the same identity."""
+    provider = GitHubProvider()
+    base = "https://github.com/user/repo/blob/main/blueprint.yaml"
+
+    assert provider.canonicalize_url(base) == provider.canonicalize_url(f"{base}#section")
+    assert provider.is_same_source(base, f"{base}#section") is True
+
+
+def test_generic_metadata_fallback_ignores_url_fragment() -> None:
+    """Generic fallback names must ignore URL fragments."""
+    provider = GenericProvider()
+    base = "https://example.com/source"
+
+    assert provider.get_metadata(base) == provider.get_metadata(f"{base}#section")
+
+
+def test_generic_provider_preserves_explicit_port() -> None:
+    """Generic URL canonicalization must preserve an explicit source port."""
+    provider = GenericProvider()
+    url = "https://example.com:8443/blueprint.yaml"
+
+    assert provider.canonicalize_url(url) == url
+
+
+def test_dedicated_provider_strips_port_on_already_normalized_git_url() -> None:
+    """Dedicated Git providers must strip default ports even when no path rewrite is needed."""
+    cases = (
+        (
+            GitLabProvider(),
+            "https://gitlab.com:443/user/repo/-/raw/main/bp.yaml",
+        ),
+        (
+            CodebergProvider(),
+            "https://codeberg.org:443/user/repo/raw/branch/main/bp.yaml",
+        ),
+        (
+            BitbucketProvider(),
+            "https://bitbucket.org:443/user/repo/raw/master/bp.yaml",
+        ),
+    )
+
+    for provider, url in cases:
+        assert ":443" not in provider.normalize_url(url)
+
+
+def test_generic_provider_preserves_ipv6_port_zero() -> None:
+    """Generic canonicalization must preserve an explicit zero port."""
+    provider = GenericProvider()
+    url = "https://[::1]:0/blueprint.yaml"
+
+    assert provider.canonicalize_url(url) == url
+
+
+@pytest.mark.parametrize(
+    "malformed_url",
+    [
+        "https://example.com:invalid/blueprint.yaml",
+        "https://example.com:70000/blueprint.yaml",
+    ],
+)
+def test_generic_provider_handles_malformed_port_gracefully(malformed_url: str) -> None:
+    """Generic canonicalization must handle malformed or out-of-range ports safely.
+
+    Malformed ports are preserved verbatim so the URL retains a distinct canonical
+    identity — it must not be silently collapsed onto the port-free form of the same host.
+    """
+    provider = GenericProvider()
+    canonical = provider.canonicalize_url(malformed_url)
+    # The broken port is kept; the result is NOT the same as the port-free URL.
+    assert canonical != "https://example.com/blueprint.yaml"
+    assert urlparse(canonical).hostname == "example.com"
+    # are_same_source must treat the malformed-port URL as a distinct source.
+    reg = ProviderRegistry()
+    assert reg.are_same_source(malformed_url, "https://example.com/blueprint.yaml") is False
+
+
+@pytest.mark.parametrize(
+    ("url_with_port", "url_without_port", "scheme"),
+    [
+        (
+            "https://example.com:443/blueprint.yaml",
+            "https://example.com/blueprint.yaml",
+            "https",
+        ),
+        (
+            "http://example.com:80/blueprint.yaml",
+            "http://example.com/blueprint.yaml",
+            "http",
+        ),
+        (
+            "https://github.com:443/user/repo/blob/main/test.yaml",
+            "https://github.com/user/repo/blob/main/test.yaml",
+            "https",
+        ),
+        (
+            "https://raw.githubusercontent.com:443/user/repo/main/test.yaml",
+            "https://raw.githubusercontent.com/user/repo/main/test.yaml",
+            "https",
+        ),
+        (
+            "https://gist.github.com:443/user/gist123",
+            "https://gist.github.com/user/gist123",
+            "https",
+        ),
+        (
+            "https://community.home-assistant.io:443/t/slug/787779",
+            "https://community.home-assistant.io/t/slug/787779",
+            "https",
+        ),
+        (
+            "https://gitlab.com:443/user/repo/-/blob/main/bp.yaml",
+            "https://gitlab.com/user/repo/-/blob/main/bp.yaml",
+            "https",
+        ),
+        (
+            "https://codeberg.org:443/user/repo/src/branch/main/bp.yaml",
+            "https://codeberg.org/user/repo/src/branch/main/bp.yaml",
+            "https",
+        ),
+        (
+            "https://bitbucket.org:443/user/repo/src/master/bp.yaml",
+            "https://bitbucket.org/user/repo/src/master/bp.yaml",
+            "https",
+        ),
+    ],
+)
+def test_registry_are_same_source_treats_default_port_as_equivalent(
+    url_with_port: str, url_without_port: str, scheme: str
+) -> None:
+    """registry.are_same_source must treat explicit default ports as equivalent.
+
+    https://example.com:443/… and https://example.com/… are the same source;
+    http://example.com:80/… and http://example.com/… are likewise the same source.
+    """
+    reg = ProviderRegistry()
+    assert reg.are_same_source(url_with_port, url_without_port) is True
+    assert reg.are_same_source(url_without_port, url_with_port) is True
+    # The canonical form must not contain the default port.
+    assert f":{443 if scheme == 'https' else 80}" not in reg.canonicalize_url(url_with_port)
+
+
+def test_generic_provider_preserves_non_default_port_in_canonical_url() -> None:
+    """GenericProvider must preserve non-default ports such as 8443 in canonical form."""
+    provider = GenericProvider()
+    url = "https://example.com:8443/blueprint.yaml"
+
+    canonical = provider.canonicalize_url(url)
+    assert ":8443" in canonical
+    assert canonical == url
+
+
+@pytest.mark.parametrize(
+    ("provider", "url_with_default_port", "expected_canonical"),
+    [
+        (
+            GitHubProvider(),
+            "https://github.com:443/user/repo/blob/main/blueprint.yaml",
+            "https://github.com/user/repo/blob/main/blueprint.yaml",
+        ),
+        (
+            GitHubProvider(),
+            "https://raw.githubusercontent.com:443/user/repo/main/blueprint.yaml",
+            "https://raw.githubusercontent.com/user/repo/main/blueprint.yaml",
+        ),
+        (
+            GistProvider(),
+            "https://gist.github.com:443/user/gist_id",
+            "https://gist.github.com/user/gist_id",
+        ),
+        (
+            HAForumProvider(),
+            "https://community.home-assistant.io:443/t/title-slug/12345",
+            "https://community.home-assistant.io/t/12345",
+        ),
+        (
+            GitLabProvider(),
+            "https://gitlab.com:443/user/repo/-/blob/main/blueprint.yaml",
+            "https://gitlab.com/user/repo/-/blob/main/blueprint.yaml",
+        ),
+        (
+            CodebergProvider(),
+            "https://codeberg.org:443/user/repo/src/branch/main/blueprint.yaml",
+            "https://codeberg.org/user/repo/src/branch/main/blueprint.yaml",
+        ),
+        (
+            BitbucketProvider(),
+            "https://bitbucket.org:443/user/repo/src/master/blueprint.yaml",
+            "https://bitbucket.org/user/repo/src/master/blueprint.yaml",
+        ),
+        (
+            GenericProvider(),
+            "https://example.com:443/blueprint.yaml",
+            "https://example.com/blueprint.yaml",
+        ),
+        (
+            GenericProvider(),
+            "http://example.com:80/blueprint.yaml",
+            "http://example.com/blueprint.yaml",
+        ),
+        (
+            GenericProvider(),
+            "https://[::1]:443/blueprint.yaml",
+            "https://[::1]/blueprint.yaml",
+        ),
+    ],
+)
+def test_all_providers_omit_default_ports_in_canonicalize_url(
+    provider: SourceProvider, url_with_default_port: str, expected_canonical: str
+) -> None:
+    """All providers must omit default ports for the scheme in canonicalize_url."""
+    assert provider.canonicalize_url(url_with_default_port) == expected_canonical
+
+
+@pytest.mark.parametrize(
+    ("provider", "url_with_non_default_port", "expected_canonical"),
+    [
+        (
+            GitHubProvider(),
+            "https://github.com:8443/user/repo/blob/main/blueprint.yaml",
+            "https://github.com:8443/user/repo/blob/main/blueprint.yaml",
+        ),
+        (
+            GitHubProvider(),
+            "https://github.com:0/user/repo/blob/main/blueprint.yaml",
+            "https://github.com:0/user/repo/blob/main/blueprint.yaml",
+        ),
+        (
+            GistProvider(),
+            "https://gist.github.com:8443/user/gist_id",
+            "https://gist.github.com:8443/user/gist_id",
+        ),
+        (
+            GistProvider(),
+            "https://gist.github.com:0/user/gist_id",
+            "https://gist.github.com:0/user/gist_id",
+        ),
+        (
+            HAForumProvider(),
+            "https://community.home-assistant.io:8443/t/title-slug/12345",
+            "https://community.home-assistant.io:8443/t/12345",
+        ),
+        (
+            HAForumProvider(),
+            "https://community.home-assistant.io:0/t/title-slug/12345",
+            "https://community.home-assistant.io:0/t/12345",
+        ),
+        (
+            GitLabProvider(),
+            "https://gitlab.com:8443/user/repo/-/blob/main/blueprint.yaml",
+            "https://gitlab.com:8443/user/repo/-/blob/main/blueprint.yaml",
+        ),
+        (
+            CodebergProvider(),
+            "https://codeberg.org:8443/user/repo/src/branch/main/blueprint.yaml",
+            "https://codeberg.org:8443/user/repo/src/branch/main/blueprint.yaml",
+        ),
+        (
+            BitbucketProvider(),
+            "https://bitbucket.org:8443/user/repo/src/master/blueprint.yaml",
+            "https://bitbucket.org:8443/user/repo/src/master/blueprint.yaml",
+        ),
+        (
+            GenericProvider(),
+            "https://example.com:8443/blueprint.yaml",
+            "https://example.com:8443/blueprint.yaml",
+        ),
+        (
+            GenericProvider(),
+            "http://example.com:8080/blueprint.yaml",
+            "http://example.com:8080/blueprint.yaml",
+        ),
+        (
+            GenericProvider(),
+            "https://example.com:0/blueprint.yaml",
+            "https://example.com:0/blueprint.yaml",
+        ),
+        (
+            GenericProvider(),
+            "http://example.com:443/blueprint.yaml",
+            "http://example.com:443/blueprint.yaml",
+        ),
+        (
+            GenericProvider(),
+            "https://example.com:80/blueprint.yaml",
+            "https://example.com:80/blueprint.yaml",
+        ),
+        (
+            GenericProvider(),
+            "https://[::1]:0/blueprint.yaml",
+            "https://[::1]:0/blueprint.yaml",
+        ),
+        (
+            GenericProvider(),
+            "https://[::1]:8443/blueprint.yaml",
+            "https://[::1]:8443/blueprint.yaml",
+        ),
+    ],
+)
+def test_all_providers_preserve_non_default_ports_in_canonicalize_url(
+    provider: SourceProvider, url_with_non_default_port: str, expected_canonical: str
+) -> None:
+    """All providers must preserve non-default ports (including 8443 and 0) in canonicalize_url."""
+    assert provider.canonicalize_url(url_with_non_default_port) == expected_canonical
+
+
+@pytest.mark.parametrize(
+    ("provider", "url_with_port", "expected_normalized"),
+    [
+        (
+            GitHubProvider(),
+            "https://raw.githubusercontent.com:443/user/repo/main/blueprint.yaml",
+            "https://raw.githubusercontent.com/user/repo/main/blueprint.yaml",
+        ),
+        (
+            GitHubProvider(),
+            "https://raw.githubusercontent.com:8443/user/repo/main/blueprint.yaml",
+            "https://raw.githubusercontent.com:8443/user/repo/main/blueprint.yaml",
+        ),
+        (
+            GistProvider(),
+            "https://gist.github.com:443/user/gist_id",
+            "https://gist.github.com/user/gist_id/raw",
+        ),
+        (
+            GistProvider(),
+            "https://gist.github.com:8443/user/gist_id",
+            "https://gist.github.com:8443/user/gist_id/raw",
+        ),
+        (
+            HAForumProvider(),
+            "https://community.home-assistant.io:443/t/title-slug/12345",
+            "https://community.home-assistant.io/t/12345.json",
+        ),
+        (
+            HAForumProvider(),
+            "https://community.home-assistant.io:8443/t/title-slug/12345",
+            "https://community.home-assistant.io:8443/t/12345.json",
+        ),
+        (
+            GitLabProvider(),
+            "https://gitlab.com:443/user/repo/-/blob/main/blueprint.yaml",
+            "https://gitlab.com/user/repo/-/raw/main/blueprint.yaml",
+        ),
+        (
+            GitLabProvider(),
+            "https://gitlab.com:8443/user/repo/-/blob/main/blueprint.yaml",
+            "https://gitlab.com:8443/user/repo/-/raw/main/blueprint.yaml",
+        ),
+        (
+            CodebergProvider(),
+            "https://codeberg.org:443/user/repo/src/branch/main/blueprint.yaml",
+            "https://codeberg.org/user/repo/raw/branch/main/blueprint.yaml",
+        ),
+        (
+            CodebergProvider(),
+            "https://codeberg.org:8443/user/repo/src/branch/main/blueprint.yaml",
+            "https://codeberg.org:8443/user/repo/raw/branch/main/blueprint.yaml",
+        ),
+        (
+            BitbucketProvider(),
+            "https://bitbucket.org:443/user/repo/src/master/blueprint.yaml",
+            "https://bitbucket.org/user/repo/raw/master/blueprint.yaml",
+        ),
+        (
+            BitbucketProvider(),
+            "https://bitbucket.org:8443/user/repo/src/master/blueprint.yaml",
+            "https://bitbucket.org:8443/user/repo/raw/master/blueprint.yaml",
+        ),
+        (
+            GenericProvider(),
+            "https://example.com:443/blueprint.yaml#section",
+            "https://example.com/blueprint.yaml",
+        ),
+        (
+            GenericProvider(),
+            "https://example.com:8443/blueprint.yaml#section",
+            "https://example.com:8443/blueprint.yaml",
+        ),
+    ],
+)
+def test_all_providers_normalize_url_port_handling(
+    provider: SourceProvider, url_with_port: str, expected_normalized: str
+) -> None:
+    """All providers must omit default ports and preserve non-default ports in normalize_url."""
+    assert provider.normalize_url(url_with_port) == expected_normalized
+
+
+@pytest.mark.parametrize(
+    "malformed_ipv6_url",
+    [
+        "https://[::1/path",
+        "https://[2001:db8::1/path",
+    ],
+)
+def test_registry_are_same_source_malformed_ipv6_returns_false(
+    malformed_ipv6_url: str,
+) -> None:
+    """are_same_source must return False for unclosed-bracket IPv6 URLs without raising.
+
+    urlparse raises ValueError('Invalid IPv6 URL') for these inputs; the guard in
+    are_same_source catches it and returns False when comparing against other URLs.
+    Exact identical strings return True via the string-equality fast path.
+    """
+    reg = ProviderRegistry()
+    valid_url = "https://example.com/blueprint.yaml"
+    # Must not raise, must return False — a malformed URL has no shared identity.
+    assert reg.are_same_source(malformed_ipv6_url, valid_url) is False
+    assert reg.are_same_source(valid_url, malformed_ipv6_url) is False
+    # Two identically malformed URLs compare equal only via the fast string path.
+    assert reg.are_same_source(malformed_ipv6_url, malformed_ipv6_url) is True
+
+
+def test_registry_are_same_source_fragment_only_difference_is_equal() -> None:
+    """are_same_source must treat fragment-only differences as the same source.
+
+    URL fragments are client-side anchors and do not identify a distinct resource.
+    """
+    reg = ProviderRegistry()
+    base = "https://example.com/blueprint.yaml"
+    assert reg.are_same_source(base, f"{base}#section") is True
+    assert reg.are_same_source(f"{base}#section1", f"{base}#section2") is True
+    assert reg.are_same_source(f"{base}#section", base) is True
+
+
+def test_registry_are_same_source_distinct_query_params_are_not_equal() -> None:
+    """are_same_source must treat distinct query parameters as different sources.
+
+    Query strings identify distinct resources (e.g. ?file=1 and ?file=2 resolve
+    to different content), so they must not share an identity.
+    """
+    reg = ProviderRegistry()
+    base = "https://example.com/blueprint.yaml"
+    assert reg.are_same_source(f"{base}?file=1", f"{base}?file=2") is False
+    assert reg.are_same_source(f"{base}?v=1", base) is False
+
+
+def test_registry_are_same_source_preserves_query_parameters() -> None:
+    """are_same_source must preserve query parameters when comparing equivalent URLs."""
+    reg = ProviderRegistry()
+    base = "https://example.com/blueprint.yaml?file=1"
+    assert reg.are_same_source(base, f"{base}#section") is True
+    assert (
+        reg.are_same_source(
+            "https://example.com:443/blueprint.yaml?file=1",
+            "HTTPS://example.com/blueprint.yaml?file=1#section",
+        )
+        is True
+    )
+
+
+@pytest.mark.parametrize(
+    ("url_with_credentials", "expected_canonical"),
+    [
+        (
+            "https://user:pass@example.com/blueprint.yaml",
+            "https://example.com/blueprint.yaml",
+        ),
+        (
+            "https://user:pass@example.com:443/blueprint.yaml",
+            "https://example.com/blueprint.yaml",
+        ),
+        (
+            "https://user:pass@example.com:8443/blueprint.yaml",
+            "https://example.com:8443/blueprint.yaml",
+        ),
+        (
+            "https://user@example.com:443/blueprint.yaml",
+            "https://example.com/blueprint.yaml",
+        ),
+        (
+            "https://user:pass@[::1]:8443/blueprint.yaml",
+            "https://[::1]:8443/blueprint.yaml",
+        ),
+        (
+            "https://user:pass@[::1]:443/blueprint.yaml",
+            "https://[::1]/blueprint.yaml",
+        ),
+        (
+            "HTTPS://user:pass@github.com:443/owner/repo/blob/main/test.yaml",
+            "https://github.com/owner/repo/blob/main/test.yaml",
+        ),
+        (
+            "HTTP://EXAMPLE.COM:80/blueprint.yaml",
+            "http://example.com/blueprint.yaml",
+        ),
+    ],
+)
+def test_canonicalize_url_strips_credentials_and_lowercases_scheme(
+    url_with_credentials: str, expected_canonical: str
+) -> None:
+    """canonicalize_url must strip user credentials and lowercase scheme across URLs."""
+    provider = GenericProvider()
+    assert provider.canonicalize_url(url_with_credentials) == expected_canonical
+
+
+def test_registry_are_same_source_strips_credentials_and_omits_default_port() -> None:
+    """Test are_same_source treats URLs with credentials and default port as equivalent."""
+    reg = ProviderRegistry()
+    url1 = "https://user:pass@example.com:443/blueprint.yaml"
+    url2 = "HTTPS://other:pass@example.com/blueprint.yaml"
+    url3 = "https://example.com/blueprint.yaml"
+
+    assert reg.are_same_source(url1, url2) is True
+    assert reg.are_same_source(url1, url3) is True
+
+
+@pytest.mark.parametrize(
+    ("malformed_url", "expected_fallback"),
+    [
+        ("  https://[::1/path  ", "https://[::1/path"),
+        ("  https://[2001:db8::1/path  ", "https://[2001:db8::1/path"),
+        (
+            "  https://example.com:invalid_port/bp.yaml  ",
+            "https://example.com:invalid_port/bp.yaml",
+        ),
+        ("  https://example.com:99999/bp.yaml  ", "https://example.com:99999/bp.yaml"),
+    ],
+)
+def test_registry_canonicalize_url_malformed_url_fallback(
+    malformed_url: str, expected_fallback: str
+) -> None:
+    """Test ProviderRegistry.canonicalize_url fallback for malformed inputs."""
+    reg = ProviderRegistry()
+    assert reg.canonicalize_url(malformed_url) == expected_fallback

--- a/uv.lock
+++ b/uv.lock
@@ -531,30 +531,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.43.82"
+version = "1.43.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3f/b1/5d8bc6b7335d86f15d43a34a4bbbeced202aef2b4e942c67a5846120c1ff/boto3-1.43.82.tar.gz", hash = "sha256:bc5a7824568c117110bac8fe7ccfac63f0a946f253953d42e73a8c1fb65162e0", size = 112671, upload-time = "2026-08-27T20:08:42.01Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/30/96cf7d324e75cd2c349e2911ae2334d987fb8525d551495a2ef6758c26f3/boto3-1.43.83.tar.gz", hash = "sha256:6413d6e99f716af5d333a732db140e4b3359cac005a1271b11777b6d9ca82194", size = 112686, upload-time = "2026-08-28T19:35:52.273Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/d7/743fafc6d544b3552517d45958b093ec70b934b513d95b238abe935e54a3/boto3-1.43.82-py3-none-any.whl", hash = "sha256:65319e8bba6e30f74a6e2727a5688725222da2ab71c6069bc484ce5bfd101c73", size = 140026, upload-time = "2026-08-27T20:08:40.323Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/4b/843f30dc77324778efa90c4169d503963668760b8d8abdf26a61bd090141/boto3-1.43.83-py3-none-any.whl", hash = "sha256:73a3564f737d4516625964eee709a498fa98ccee6aca929febad2b0b5fbeae1e", size = 140025, upload-time = "2026-08-28T19:35:49.228Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.43.82"
+version = "1.43.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/96/54e8d9a09689bf870bc723bf95ee8f5a4bba3b9c203baaaca3fb557d4924/botocore-1.43.82.tar.gz", hash = "sha256:347573c0bab52e29c923e28128764fcc50f469ed98dc5460220026cd3672ac0c", size = 16007302, upload-time = "2026-08-27T20:08:36.615Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/6f/cf16418004c832e6eb9abc6905fa323a3bf96a76ca7f2e97858801a4103e/botocore-1.43.83.tar.gz", hash = "sha256:d9389b3b74400c34219965a2fb858c1d48744718865ee0496fd03bd5b21b943f", size = 16010078, upload-time = "2026-08-28T19:35:46.211Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/70/78cd83cf91d954846fe034edac415a700fd919782a003f1c71b779d06cfd/botocore-1.43.82-py3-none-any.whl", hash = "sha256:97b3e89061decc91e7745d726dae595cbe2053894611c49ea91d6fdcb2ecc36b", size = 15699695, upload-time = "2026-08-27T20:08:34.01Z" },
+    { url = "https://files.pythonhosted.org/packages/98/50/332d6713fa09b05ff0882f5d194569fa70d1c8735aca9829b1286fef32ba/botocore-1.43.83-py3-none-any.whl", hash = "sha256:bf75a6cf587c22d968e43e79fe122c39f82deafbe9c3422bc5d3e80b6210fc98", size = 15704489, upload-time = "2026-08-28T19:35:40.603Z" },
 ]
 
 [[package]]
@@ -1030,23 +1030,23 @@ wheels = [
 
 [[package]]
 name = "grpcio"
-version = "1.83.0"
+version = "1.83.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/98/304898ac4e04e2d5e4e4c2eadc178b1f2a16d5f4bc2f91306c87d64680b9/grpcio-1.83.0.tar.gz", hash = "sha256:7674587248fbbb2ac6e4eecf83a8a0f3d91a928f941de571acfd3a2f007fbc24", size = 13428824, upload-time = "2026-07-23T15:20:37.759Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/b1/46539f5050d7c316a13396d185451f95084a74ddc68b12d818595bef0377/grpcio-1.83.1.tar.gz", hash = "sha256:9cee6fcbf2eb57c4b49451787bfa87be8efc1ca02a0b327dd4b54d44502e362b", size = 13445033, upload-time = "2026-08-28T07:09:11.464Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/60/f2cca8147ea213d3e43ae9158d03ad04e020fdf32ff027253e1fe93f921d/grpcio-1.83.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3f351629f6ae16ecc0ec3553e586a6763ffd9f6114044286d0cbec3e09241bfa", size = 6305607, upload-time = "2026-07-23T15:20:15.353Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/ab/d3874931d123a95e83a3ebf8aa04537988fb62425cedb8bf3cefc5ad41b2/grpcio-1.83.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d05ff664100d429335b93c91b8b34ddf9e94a112205e7fa06dede309e44a4e4c", size = 12166617, upload-time = "2026-07-23T15:20:17.435Z" },
-    { url = "https://files.pythonhosted.org/packages/92/ff/6f18f9426b69306f4e00a9add3b0ee2748da8aad53836ef80cab0d62d04f/grpcio-1.83.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7936f2a56cf04f6514705c0fedf400971de01b6aa1719327e4718f410a765e2b", size = 6880213, upload-time = "2026-07-23T15:20:19.98Z" },
-    { url = "https://files.pythonhosted.org/packages/70/21/706d1147c6b93b98f179240c13991fbcc56880eba0c868abb1ad40d8a0a6/grpcio-1.83.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b0a0be840e51b6b7ee9df9269770faf77bdf4b771053c257c21d12bad607714c", size = 7618335, upload-time = "2026-07-23T15:20:22.161Z" },
-    { url = "https://files.pythonhosted.org/packages/74/04/1a8443c889115ec9e213a213e86bc93a71ee9088027e5befa09aaa0edd9d/grpcio-1.83.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:009667eaf3dcd5224c713589cdc98e7ca4ed0ff0b61132c6b276e930eb83a2df", size = 7043416, upload-time = "2026-07-23T15:20:24.209Z" },
-    { url = "https://files.pythonhosted.org/packages/86/c6/94e0fee5b12bc1da1370185b680988db6f739d19b42d9959db01a7ea50bf/grpcio-1.83.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bb669918fd88936b15599caff4160a77ab74bdeb25f2231f6e45b61282d6107b", size = 7583253, upload-time = "2026-07-23T15:20:26.313Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/97/de1ccb671fb85575bc5192faedf9ecdbdf5b390d2e6584dcf552bcbd370e/grpcio-1.83.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:c19b454d3d3f28db81f2c7c4dbaee96e7f6fd149721733ffe79d6bc530f17404", size = 8605102, upload-time = "2026-07-23T15:20:28.437Z" },
-    { url = "https://files.pythonhosted.org/packages/17/0f/0e0ec749a7034ffcbaa050e39779872950ead90c22e7e0116be3f28b2b46/grpcio-1.83.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:61007cd08640abc5c54547ee32505474c482cd733a53cb87551ea81faa6350af", size = 7979826, upload-time = "2026-07-23T15:20:31.182Z" },
-    { url = "https://files.pythonhosted.org/packages/83/fa/c3fda157287f64bc65acee6c5aa90c41acf9e0d3a8e69a265eecff6d00a1/grpcio-1.83.0-cp314-cp314-win32.whl", hash = "sha256:32e11c37f5285b0c6fa3042c05fe06903696689749833fc64e67dec71b9bbe33", size = 4471765, upload-time = "2026-07-23T15:20:33.195Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/00/b1b26431c9d54eee11724fd6e5585473a2ed47fbc1fb95e5204906a642ce/grpcio-1.83.0-cp314-cp314-win_amd64.whl", hash = "sha256:2bb48cb5e6dd005ca12b89ce4b6ac0b48ff3112c747542ee7986ef611a8ca6d9", size = 5298932, upload-time = "2026-07-23T15:20:35.48Z" },
+    { url = "https://files.pythonhosted.org/packages/42/9c/484d981d8b90c4e6abf3030bd2ed747e84d1eb192b3ec9cbb41e0b73e4bf/grpcio-1.83.1-cp314-cp314-linux_armv7l.whl", hash = "sha256:8b3c87ca908296bf125f841d3e1a2225a2b39aaa8ed7a57e7ccde465ee519bab", size = 6306089, upload-time = "2026-08-28T07:08:48.379Z" },
+    { url = "https://files.pythonhosted.org/packages/84/01/0afec1c92e4f292f74a44ecf75eabbf40903125b8c4df103c9868d6338da/grpcio-1.83.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:c0f3f20c90e72a171917ae65706500b096a1c3eb5f162c3ce702a2e25635f132", size = 12170381, upload-time = "2026-08-28T07:08:50.653Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/5a/e9a2383804433a0a61d6d93777ad321c7f36ac1cfdaa4c6d1a7c9ac846b7/grpcio-1.83.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:81bbf35a46bf8cad2dfbb2eccc19c711befb58b288acb534bbcd0d74283202a6", size = 6883286, upload-time = "2026-08-28T07:08:53.654Z" },
+    { url = "https://files.pythonhosted.org/packages/63/e7/f8ca8f76994e14c70b9a0052e82f10de497a23db450c36379c9716ebfc4d/grpcio-1.83.1-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:215cec07d11176507387bda4bf2751816e880f9bff8dc1ca524bfbb8ed8f2fad", size = 7624293, upload-time = "2026-08-28T07:08:55.709Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/7a/4b672814b0cd0fe63bdd735379d88b165759f3144ab023ad8ec5fc4d53ac/grpcio-1.83.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:abce7d43ec29cd39230fa8339de1a07643b55adc412a454850fbd875349950ff", size = 7044346, upload-time = "2026-08-28T07:08:57.802Z" },
+    { url = "https://files.pythonhosted.org/packages/50/b8/d89fe60e4239ad51be333dd9cc703741d449a35064e51f8a0b5bfa755432/grpcio-1.83.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e256f95a40e3b0183a98556fb7164d24b97eeb353123ccabfcba94712b35ee2a", size = 7584187, upload-time = "2026-08-28T07:08:59.867Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b2/b290d7402633d9166e4dd47e6f5f74a24ce10a8340b84455896ebc349f85/grpcio-1.83.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:2110059146fb0ea216e1ffddb29377b5cc2fd412a5b0a92e102616bd5edf18c2", size = 8608730, upload-time = "2026-08-28T07:09:02.592Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/44/fa89e44d1b5cf5b9fa71b2fd7abf506f182fd43917231a92fbf1ea326b02/grpcio-1.83.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:20d944d967843f8183f9f23d5916388362e5f8eeeae855bbe4354d906dc9f31b", size = 7983283, upload-time = "2026-08-28T07:09:05.087Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/b8/9db73ed1f35ffa76124ac574bf296d06a359798dfd6b50d382f2b8a060a1/grpcio-1.83.1-cp314-cp314-win32.whl", hash = "sha256:623c87c6d4a1cb30d82c4e896f95477050f2e01b4a1f8cf91ff2b1abdf89c457", size = 4474327, upload-time = "2026-08-28T07:09:07.179Z" },
+    { url = "https://files.pythonhosted.org/packages/65/22/fc9a622d885a7a37ff972a12faaef443d74e47407181da70d0ab62ab41f0/grpcio-1.83.1-cp314-cp314-win_amd64.whl", hash = "sha256:47e6934ad38779271e2e7cc5f78a63a407cf3d98114c65c1fdbcd3f5a716f29b", size = 5302032, upload-time = "2026-08-28T07:09:09.285Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Close #183

## Summary by Sourcery

Standardize blueprint source URL identity and hashing to avoid false update flags for unchanged content.

Bug Fixes:
- Prevent unchanged blueprints from being marked for update when equivalent source URLs differ only by provider-specific formatting, such as forum slugs, hostname aliases, fragments, or URL casing.
- Ensure 304 responses and startup metadata merging derive update status consistently from matching local and remote hashes.

Enhancements:
- Introduce provider-aware URL canonicalization and source identity comparison across supported and generic providers.
- Normalize blueprint source URLs before embedding them in content hashes and metadata.
- Harden URL normalization for fragments, ports, trailing slashes, IPv6 hosts, and provider metadata fallbacks.

Tests:
- Add comprehensive coordinator and provider coverage for canonical URL handling, source equivalence, hash stability, metadata preservation, and update-state transitions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source URL matching across providers, including hostname case, `www.` aliases, ports, fragments, credentials, and IPv6 addresses.
  * Canonicalized GitHub blob and raw URLs for consistent source identification and blueprint metadata.
  * Improved forum topic URL consistency when slugs change or schemes are omitted.
  * Improved metadata handling and update behavior for changed or missing content hashes.
  * Invalid, unsupported, or malformed source URLs are now handled safely during blueprint scanning.

* **Tests**
  * Added comprehensive coverage for URL normalization, source equivalence, metadata, and update scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->