### PR TITLE
Preserve original blueprint URLs and stabilize semantic hashing

### DIFF
--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -1819,7 +1819,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, objec
         await self.async_install_blueprint(
             full_path,
             content,
-            source_url=canonical_url,
+            source_url=url.strip(),
             etag=response.headers.get("ETag"),
             last_modified=response.headers.get("Last-Modified"),
             file_precondition=file_precondition,
@@ -2036,7 +2036,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, objec
             if final_source_url
             else self._normalize_content(remote_content)
         )
-        expected_hash = self._hash_content(content, already_normalized=True)
+        expected_hash = self._hash_content(content, final_source_url)
         if remote_hash is not None and remote_hash != expected_hash:
             raise HomeAssistantError("Remote hash does not match validated install content")
 
@@ -2130,15 +2130,20 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, objec
             if last_modified is not None
             else (current.get("last_modified") if current else None)
         )
+        semantic_hash = (
+            BlueprintUpdateCoordinator._hash_content(prepared.content, prepared.source_url)
+            if prepared.source_url
+            else file_result.content_hash
+        )
         return {
             "name": prepared.name,
             "domain": prepared.functional_domain,
             "source_url": prepared.source_url,
             "relative_path": prepared.relative_path,
             "updatable": False,
-            "local_hash": file_result.content_hash,
+            "local_hash": semantic_hash,
             "local_file_hash": file_result.content_hash,
-            "remote_hash": file_result.content_hash,
+            "remote_hash": semantic_hash,
             "last_error": None,
             "auto_update_last_error": None,
             "remote_content": None,
@@ -2207,7 +2212,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, objec
             relative_path=prepared.relative_path,
             source_url=prepared.source_url,
             previous_hash=previous_hash,
-            new_hash=file_result.content_hash,
+            new_hash=str(metadata["local_hash"]),
             is_auto_update=is_auto_update,
             had_breaking_risks=had_breaking_risks,
         )
@@ -4596,14 +4601,10 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, objec
 
     @staticmethod
     def _ensure_source_url(content: object, source_url: object) -> str:
-        """Ensure the target canonical source_url is present in the blueprint metadata.
+        """Ensure the target source_url is present in the blueprint metadata.
 
         Always uses structured YAML parsing to guarantee data integrity and
         consistency with Home Assistant's core blueprint handling.
-
-        Note: This method canonicalizes the source_url and overwrites any
-        existing `source_url` in the blueprint metadata to ensure the
-        integration tracks the authoritative canonical source.
 
         It also applies semantic normalization using Home Assistant's official
         schemas (AUTOMATION_BLUEPRINT_SCHEMA or BLUEPRINT_SCHEMA). This ensures
@@ -4613,10 +4614,10 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, objec
 
         Args:
             content: Raw YAML blueprint content.
-            source_url: Target URL to canonicalize and enforce in the content.
+            source_url: Target URL to enforce in the content.
 
         Returns:
-            The YAML content with the canonicalized source_url guaranteed to be
+            The YAML content with the source_url guaranteed to be
             present in the blueprint block, in canonical normalized YAML form.
 
         """
@@ -4629,8 +4630,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, objec
             )
             return BlueprintUpdateCoordinator._normalize_content(content)
 
-        canonical_source_url = BlueprintUpdateCoordinator._canonicalize_source_url(source_url)
-        return BlueprintUpdateCoordinator._ensure_source_url_cached(content, canonical_source_url)
+        return BlueprintUpdateCoordinator._ensure_source_url_cached(content, source_url.strip())
 
     @staticmethod
     def _canonicalize_source_url(source_url: str) -> str:
@@ -4647,23 +4647,47 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, objec
             return clean_url
 
     @staticmethod
-    def _stabilize_yaml_structure(orig_data: object, normalized_data: object) -> object:
+    def _stabilize_yaml_structure(
+        orig_data: object,
+        normalized_data: object,
+        in_selector: bool = False,
+    ) -> object:
         """Recursively update normalized structures using original key ordering.
 
         Preserves existing dict/list identities when possible.
+        For selector configuration mappings, keys are deterministically sorted
+        so that option ordering or schema default additions do not trigger ghost diffs.
         """
         if isinstance(orig_data, dict) and isinstance(normalized_data, dict):
             orig_dict: dict[object, object] = dict(orig_data.items())
             norm_dict: dict[object, object] = dict(normalized_data.items())
+
+            if in_selector:
+                sorted_keys = sorted(norm_dict.keys(), key=str)
+                return {
+                    k: BlueprintUpdateCoordinator._stabilize_yaml_structure(
+                        orig_dict.get(k),
+                        norm_dict[k],
+                        in_selector=True,
+                    )
+                    for k in sorted_keys
+                }
+
             res: dict[object, object] = {
-                k: BlueprintUpdateCoordinator._stabilize_yaml_structure(orig_val, norm_dict[k])
+                k: BlueprintUpdateCoordinator._stabilize_yaml_structure(
+                    orig_val,
+                    norm_dict[k],
+                    in_selector=(k == "selector"),
+                )
                 for k, orig_val in orig_dict.items()
                 if k in norm_dict
             }
             new_keys = sorted([k for k in norm_dict if k not in res], key=str)
             for key in new_keys:
                 res[key] = BlueprintUpdateCoordinator._stabilize_yaml_structure(
-                    norm_dict[key], norm_dict[key]
+                    norm_dict[key],
+                    norm_dict[key],
+                    in_selector=(key == "selector"),
                 )
             return res
 
@@ -4674,7 +4698,11 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, objec
             for i, item in enumerate(normalized_data):
                 orig_item = orig_list[i] if i < len(orig_list) else None
                 res_list.append(
-                    BlueprintUpdateCoordinator._stabilize_yaml_structure(orig_item, item)
+                    BlueprintUpdateCoordinator._stabilize_yaml_structure(
+                        orig_item,
+                        item,
+                        in_selector=in_selector,
+                    )
                 )
             return res_list
 
@@ -4822,7 +4850,6 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, objec
             )
             return None
 
-        canonical_source_url = BlueprintUpdateCoordinator._canonicalize_source_url(clean_source_url)
         raw_name = bp_info.get("name")
         name = (
             raw_name.strip()
@@ -4839,8 +4866,8 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, objec
         return {
             "name": name,
             "domain": domain,
-            "source_url": canonical_source_url,
-            "local_hash": BlueprintUpdateCoordinator._hash_content(content, canonical_source_url),
+            "source_url": clean_source_url,
+            "local_hash": BlueprintUpdateCoordinator._hash_content(content, clean_source_url),
             "local_file_hash": (
                 file_hash
                 if file_hash is not None

--- a/custom_components/blueprints_updater/repairs.py
+++ b/custom_components/blueprints_updater/repairs.py
@@ -147,14 +147,14 @@ class WithdrawnBlueprintRepairFlow(RepairsFlow):
                 try:
                     (
                         content,
-                        canonical_url,
+                        _fetch_url,
                         _author,
                         _name,
                         _resp,
                     ) = await self.coordinator.async_fetch_import_data(new_url)
                     self._pending_url = new_url
                     self._pending_content = content
-                    self._pending_canonical_url = canonical_url
+                    self._pending_canonical_url = new_url
 
                     self._pending_precondition = await self.hass.async_add_executor_job(
                         BlueprintFileStore.capture_precondition,
@@ -167,7 +167,7 @@ class WithdrawnBlueprintRepairFlow(RepairsFlow):
                             BlueprintUpdateCoordinator._read_and_diff,
                             self.path,
                             content,
-                            canonical_url,
+                            new_url,
                         )
                     except (OSError, ValueError) as err:
                         _LOGGER.warning(
@@ -180,7 +180,7 @@ class WithdrawnBlueprintRepairFlow(RepairsFlow):
                     local_hash = self.coordinator.data.get(self.path, {}).get("local_hash")
                     self._is_semantic_sync = (
                         self.coordinator._is_semantically_equal(
-                            content, str(local_hash or ""), canonical_url
+                            content, str(local_hash or ""), new_url
                         )
                         if local_hash
                         else False

--- a/tests/coordinator/test_coordinator_url_handling.py
+++ b/tests/coordinator/test_coordinator_url_handling.py
@@ -71,7 +71,10 @@ action:
 
 
 def test_ensure_source_url_canonical_normalization() -> None:
-    """Test _ensure_source_url embeds the canonical URL into blueprint YAML."""
+    """Test _ensure_source_url embeds the original URL into blueprint YAML.
+
+    Hashing remains canonical and identity-aware.
+    """
     raw_content = """blueprint:
   name: Forum Blueprint
   domain: automation
@@ -81,8 +84,12 @@ def test_ensure_source_url_canonical_normalization() -> None:
     slug_url = "https://community.home-assistant.io/t/new-slug-v1-1/787779"
     ensured = BlueprintUpdateCoordinator._ensure_source_url(raw_content, slug_url)
 
-    expected_canonical = "https://community.home-assistant.io/t/787779"
-    assert f"source_url: {expected_canonical}" in ensured
+    assert f"source_url: {slug_url}" in ensured
+    hash_old = BlueprintUpdateCoordinator._hash_content(
+        raw_content, "https://community.home-assistant.io/t/old-slug/787779"
+    )
+    hash_new = BlueprintUpdateCoordinator._hash_content(raw_content, slug_url)
+    assert hash_old == hash_new
 
 
 @pytest.mark.asyncio
@@ -357,8 +364,8 @@ def test_parse_blueprint_data_rejects_malformed_port(malformed_source_url: str) 
     assert result is None
 
 
-def test_parse_blueprint_data_stores_canonical_source_url() -> None:
-    """_parse_blueprint_data must store the canonicalized source_url in blueprint metadata."""
+def test_parse_blueprint_data_stores_original_source_url() -> None:
+    """_parse_blueprint_data must store the clean original source_url in blueprint metadata."""
     content = """blueprint:
   name: Forum Blueprint
   domain: automation
@@ -367,7 +374,7 @@ def test_parse_blueprint_data_stores_canonical_source_url() -> None:
 """
     result = BlueprintUpdateCoordinator._parse_blueprint_data("automation/test.yaml", content)
     assert result is not None
-    assert result["source_url"] == "https://community.home-assistant.io/t/787779"
+    assert result["source_url"] == "HTTPS://community.home-assistant.io:443/t/some-slug/787779"
 
 
 @pytest.mark.parametrize(

--- a/tests/coordinator/test_metadata.py
+++ b/tests/coordinator/test_metadata.py
@@ -51,80 +51,72 @@ def test_normalize_url():
 
 def test_ensure_source_url(coordinator):
     """Test ensuring source_url is present."""
-    # _ensure_source_url normalizes blob URLs to their raw.githubusercontent.com
-    # equivalent before canonicalizing, so the embedded source_url is always
-    # the canonical raw form regardless of what URL form is passed in.
     source_url = "https://github.com/user/repo/blob/main/test.yaml"
     new_content = coordinator._ensure_source_url(
         "blueprint:\n  name: Test\n  domain: automation", source_url
     )
-    canonical_url = "https://raw.githubusercontent.com/user/repo/main/test.yaml"
-    assert f"source_url: {canonical_url}" in new_content
+    assert f"source_url: {source_url}" in new_content
 
     parsed = yaml.safe_load(new_content)
-    assert parsed["blueprint"]["source_url"] == canonical_url
+    assert parsed["blueprint"]["source_url"] == source_url
     assert parsed["blueprint"]["name"] == "Test"
     assert parsed["blueprint"]["input"] == {}
 
     content_with_url = f"blueprint:\n  name: Test\n  domain: automation\n  source_url: {source_url}"
     result = coordinator._ensure_source_url(content_with_url, source_url)
-    assert f"source_url: {canonical_url}" in result
+    assert f"source_url: {source_url}" in result
 
     content_with_quotes = (
         f"blueprint:\n  name: Test\n  domain: automation\n  source_url: '{source_url}'"
     )
     result_quotes = coordinator._ensure_source_url(content_with_quotes, source_url)
-    assert canonical_url in result_quotes
+    assert source_url in result_quotes
 
     different_url = "https://github.com/user/new-repo/blob/main/test.yaml"
     content_different = (
         f"blueprint:\n  name: Test\n  domain: automation\n  source_url: {different_url}"
     )
     result = coordinator._ensure_source_url(content_different, source_url)
-    assert f"source_url: {canonical_url}" in result
+    assert f"source_url: {source_url}" in result
     assert different_url not in result
     assert result.count("source_url") == 1
 
-    result_outside = _assert_embedded_canonical_source_url(
+    result_outside = _assert_embedded_source_url(
         "blueprint:\n  name: Test\n  domain: automation\n"
         "action:\n  - service: rest.post\n    data:\n"
         "      source_url: https://api.example.com",
         coordinator,
         source_url,
-        canonical_url,
     )
     parsed_outside = yaml.safe_load(result_outside)
-    assert parsed_outside["blueprint"]["source_url"] == canonical_url
+    assert parsed_outside["blueprint"]["source_url"] == source_url
     assert parsed_outside["actions"][0]["data"]["source_url"] == "https://api.example.com"
 
-    result_nested = _assert_embedded_canonical_source_url(
+    result_nested = _assert_embedded_source_url(
         "blueprint:\n  name: Test\n  domain: automation\n"
         "  input:\n    source_url:\n      name: Enter URL\n"
         "trigger:\n  - platform: webhook",
         coordinator,
         source_url,
-        canonical_url,
     )
     assert result_nested.count("source_url") == 2
 
-    _assert_embedded_canonical_source_url(
+    _assert_embedded_source_url(
         "blueprint: # comment\n  name: Test\n  domain: automation",
         coordinator,
         source_url,
-        canonical_url,
     )
-    _assert_embedded_canonical_source_url(
+    _assert_embedded_source_url(
         "blueprint: { name: Test, domain: automation }",
         coordinator,
         source_url,
-        canonical_url,
     )
     content_invalid = "\ufeffblueprint: [unclosed\r\n"
     result_invalid = coordinator._ensure_source_url(content_invalid, source_url)
     assert "\ufeff" not in result_invalid
     assert "\r" not in result_invalid
 
-    result_multi = _assert_embedded_canonical_source_url(
+    result_multi = _assert_embedded_source_url(
         "# Some info: blueprint:\n"
         "blueprint:\n"
         "  name: Test\n"
@@ -132,12 +124,11 @@ def test_ensure_source_url(coordinator):
         "description: 'This is another blueprint: key in string'",
         coordinator,
         source_url,
-        canonical_url,
     )
     parsed_multi = yaml_util.parse_yaml(result_multi)
     assert isinstance(parsed_multi, dict)
     assert isinstance(parsed_multi["blueprint"], dict)
-    assert parsed_multi["blueprint"]["source_url"] == canonical_url
+    assert parsed_multi["blueprint"]["source_url"] == source_url
     assert parsed_multi["blueprint"]["input"] == {}
 
     content_none = "not_a_blueprint: true"
@@ -145,18 +136,17 @@ def test_ensure_source_url(coordinator):
     assert coordinator._ensure_source_url(content_none, source_url) == expected_none
 
 
-def _assert_embedded_canonical_source_url(
+def _assert_embedded_source_url(
     content: str,
     coordinator: BlueprintUpdateCoordinator,
     source_url: str,
-    canonical_url: str,
 ) -> str:
-    """Assert _ensure_source_url embeds the canonical URL for the given content."""
+    """Assert _ensure_source_url embeds the source URL for the given content."""
     result = coordinator._ensure_source_url(content, source_url)
     parsed = yaml_util.parse_yaml(result)
     assert isinstance(parsed, dict)
     assert isinstance(parsed.get("blueprint"), dict)
-    assert parsed["blueprint"].get("source_url") == canonical_url
+    assert parsed["blueprint"].get("source_url") == source_url
     return result
 
 
@@ -814,18 +804,14 @@ def test_set_cached_git_diff(coordinator):
 
 def test_ensure_source_url_script(coordinator):
     """Test ensuring source_url for a script blueprint."""
-    # _ensure_source_url normalizes blob URLs to their raw.githubusercontent.com
-    # equivalent before canonicalizing, so the embedded source_url is the canonical
-    # raw form regardless of what URL form is passed in.
     source_url = "https://github.com/user/repo/blob/main/script.yaml"
-    canonical_url = "https://raw.githubusercontent.com/user/repo/main/script.yaml"
     content = "blueprint:\n  name: Test Script\n  domain: script"
 
     new_content = coordinator._ensure_source_url(content, source_url)
-    assert f"source_url: {canonical_url}" in new_content
+    assert f"source_url: {source_url}" in new_content
 
     parsed = yaml.safe_load(new_content)
-    assert parsed["blueprint"]["source_url"] == canonical_url
+    assert parsed["blueprint"]["source_url"] == source_url
     assert parsed["blueprint"]["name"] == "Test Script"
     assert parsed["blueprint"]["domain"] == FunctionalDomain.SCRIPT
 
@@ -833,8 +819,8 @@ def test_ensure_source_url_script(coordinator):
 def test_deterministic_yaml_hashing(coordinator):
     """Test that YAML hashing is deterministic between Local and Remote versions.
 
-    Verify that a Local version (with injected defaults) and a Remote version
-    (without them) result in the same hash after semantic normalization.
+    Verify that a Local version (with injected defaults or reordered options)
+    and a Remote version result in the same hash after semantic normalization.
     """
     source_url = "https://github.com/user/test"
     content_v1 = (
@@ -846,14 +832,22 @@ def test_deterministic_yaml_hashing(coordinator):
         "blueprint:\n  name: T\n  domain: automation\n  input:\n    t:\n"
         "      name: T\n      selector:\n        text: {}"
     )
+    content_v3 = (
+        "blueprint:\n  name: T\n  domain: automation\n  input:\n    t:\n"
+        "      name: T\n      selector:\n        text:\n"
+        "          multiple: false\n          multiline: false"
+    )
 
     hash1 = coordinator._hash_content(content_v1, source_url)
     hash2 = coordinator._hash_content(content_v2, source_url)
+    hash3 = coordinator._hash_content(content_v3, source_url)
 
-    assert hash1 == hash2
+    assert hash1 == hash2 == hash3
 
-    norm = coordinator._ensure_source_url(content_v2, source_url)
-    assert "multiline: false\n          multiple: false" in norm
+    norm1 = coordinator._ensure_source_url(content_v1, source_url)
+    norm2 = coordinator._ensure_source_url(content_v2, source_url)
+    norm3 = coordinator._ensure_source_url(content_v3, source_url)
+    assert norm1 == norm2 == norm3
 
 
 def test_yaml_order_preservation(coordinator):

--- a/tests/entities/test_update_entity.py
+++ b/tests/entities/test_update_entity.py
@@ -1030,3 +1030,36 @@ def test_relative_path_none_normalization():
         "test_entry", str(rel_val) if rel_val is not None else ""
     )
     assert known_id == expected_unique_id
+
+
+@pytest.mark.asyncio
+async def test_release_notes_displays_original_source_url(coordinator):
+    """Test that release notes and update notification display original source_url.
+
+    Ensure normalize_url is not displayed to the user.
+    """
+    github_url = "https://github.com/user/repo/blob/main/blueprints/motion_light.yaml"
+    coordinator.data["/config/blueprints/automation/motion.yaml"] = {
+        "name": "Motion Light",
+        "domain": FunctionalDomain.AUTOMATION,
+        "relative_path": "automation/motion.yaml",
+        "source_url": github_url,
+        "local_hash": "local123",
+        "remote_hash": "remote123",
+        "updatable": True,
+    }
+
+    entity = BlueprintUpdateEntity(
+        coordinator,
+        "/config/blueprints/automation/motion.yaml",
+        coordinator.data["/config/blueprints/automation/motion.yaml"],
+    )
+    entity.hass = coordinator.hass
+    entity.entity_id = "update.motion_light"
+    with patch.object(entity, "async_write_ha_state"):
+        await entity._async_localize_strings()
+
+    assert entity.release_url == github_url
+    notes = await entity.async_release_notes()
+    assert f"Update available from {github_url}" in (notes or "")
+    assert "raw.githubusercontent.com" not in (notes or "")

--- a/tests/integration/test_import_service.py
+++ b/tests/integration/test_import_service.py
@@ -137,7 +137,7 @@ async def test_import_blueprint_success_github(hass, setup_integration, respx_mo
     _assert_imported_blueprint(
         hass,
         "automation/user/test.yaml",
-        raw_url,
+        url,
         '"abc"',
     )
 

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -287,12 +287,13 @@ async def test_change_url_clean_success(mock_repair_flow, hass):
             content,
             reload_services=False,
             backup=True,
-            source_url=canonical_url,
+            source_url="https://valid.url/test.yaml",
             file_precondition=mock_repair_flow._pending_precondition,
         )
         mock_delete.assert_called_once_with(hass, DOMAIN, "withdrawn_blueprint_12345")
         assert (
-            mock_repair_flow.coordinator.data[mock_repair_flow.path]["source_url"] == canonical_url
+            mock_repair_flow.coordinator.data[mock_repair_flow.path]["source_url"]
+            == "https://valid.url/test.yaml"
         )
 
 
@@ -334,7 +335,7 @@ async def test_change_url_with_risks_and_confirm(mock_repair_flow, hass):
             content,
             reload_services=False,
             backup=True,
-            source_url=canonical_url,
+            source_url="https://valid.url/test.yaml",
             file_precondition=mock_repair_flow._pending_precondition,
         )
         mock_delete.assert_called_once_with(hass, DOMAIN, "withdrawn_blueprint_12345")
@@ -1072,7 +1073,9 @@ async def test_change_url_with_git_diff_preview(mock_repair_flow):
 
         assert result.get("type") == data_entry_flow.FlowResultType.FORM
         assert result.get("step_id") == "confirm_risks"
-        mock_diff.assert_called_once_with(mock_repair_flow.path, content, canonical_url)
+        mock_diff.assert_called_once_with(
+            mock_repair_flow.path, content, "https://valid.url/test.yaml"
+        )
         assert mock_repair_flow._pending_diff == diff_content
 
         placeholders = result.get("description_placeholders", {})

--- a/tests/ui/test_ghost_update.py
+++ b/tests/ui/test_ghost_update.py
@@ -101,3 +101,49 @@ blueprint:
     parsed = cast(dict[str, Any], yaml_util.parse_yaml(normalized))
     assert parsed["blueprint"]["source_url"] == source_url
     assert parsed["blueprint"]["domain"] == 123
+
+
+@pytest.mark.asyncio
+async def test_selector_option_order_invariance(hass: HomeAssistant) -> None:
+    """Test that selector options in different orders do not trigger ghost updates."""
+    local_yaml = """
+blueprint:
+  name: Smart Knob
+  domain: automation
+  input:
+    device:
+      name: Smart Knob Device
+      description: The smart knob device.
+      selector:
+        text:
+          multiple: false
+          multiline: false
+    light_entity:
+      name: Light Entity
+      description: The light to be controlled.
+"""
+    remote_yaml = """
+blueprint:
+  name: Smart Knob
+  domain: automation
+  input:
+    device:
+      name: Smart Knob Device
+      description: The smart knob device.
+      selector:
+        text:
+          multiline: false
+          multiple: false
+    light_entity:
+      name: Light Entity
+      description: The light to be controlled.
+"""
+    source_url = "https://github.com/user/repo/blob/main/smart_knob.yaml"
+
+    hash_local = BlueprintUpdateCoordinator._hash_content(local_yaml, source_url)
+    hash_remote = BlueprintUpdateCoordinator._hash_content(remote_yaml, source_url)
+    assert hash_local == hash_remote
+
+    norm_local = BlueprintUpdateCoordinator._ensure_source_url(local_yaml, source_url)
+    norm_remote = BlueprintUpdateCoordinator._ensure_source_url(remote_yaml, source_url)
+    assert norm_local == norm_remote


### PR DESCRIPTION
## Summary by Sourcery

Preserve original blueprint URLs while stabilizing semantic comparison and update detection across equivalent YAML representations.

Bug Fixes:
- Preserve the original user-provided blueprint URL in metadata, imports, URL changes, and update notifications instead of replacing it with a canonicalized URL.
- Prevent false blueprint updates by making semantic hashing invariant to selector option ordering and schema-added defaults.

Enhancements:
- Separate semantic content hashes from raw file hashes so blueprint change detection remains stable while retaining file-level integrity information.

Tests:
- Update URL-handling, metadata, repair-flow, import, notification, and ghost-update tests to cover original URL preservation and deterministic semantic hashing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Blueprint metadata and release links now preserve the URL entered by the user.
  * URL-based imports, updates, previews, and repairs consistently use the original source URL.
  * Equivalent selector configurations now produce consistent ordering, normalized YAML, and content hashes.
  * Source URL formatting changes no longer alter blueprint identity or semantic content hashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->