### PR TITLE
Improve Compatibility Guard by adding proactive blueprint schema validation tests

### DIFF
--- a/custom_components/blueprints_updater/coordinator.py
+++ b/custom_components/blueprints_updater/coordinator.py
@@ -1704,6 +1704,54 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, objec
         return keys
 
     @staticmethod
+    def _extract_inputs_with_default(input_dict: object) -> set[str]:
+        """Recursively extract defined input keys that specify a default value.
+
+        Args:
+            input_dict: Parsed input mapping from blueprint metadata.
+
+        Returns:
+            A set of input key names that define a default value.
+
+        """
+        keys: set[str] = set()
+        if not isinstance(input_dict, Mapping):
+            return keys
+
+        for k, v in input_dict.items():
+            if isinstance(v, Mapping):
+                if "input" in v and isinstance(v["input"], Mapping):
+                    keys.update(BlueprintUpdateCoordinator._extract_inputs_with_default(v["input"]))
+                elif "default" in v and isinstance(k, str):
+                    keys.add(k)
+        return keys
+
+    @staticmethod
+    def _extract_mandatory_inputs(input_dict: object) -> set[str]:
+        """Recursively extract defined input keys that do not define a default value.
+
+        Args:
+            input_dict: Parsed input mapping from blueprint metadata.
+
+        Returns:
+            A set of mandatory input key names.
+
+        """
+        keys: set[str] = set()
+        if not isinstance(input_dict, Mapping):
+            return keys
+
+        for k, v in input_dict.items():
+            if isinstance(v, Mapping):
+                if "input" in v and isinstance(v["input"], Mapping):
+                    keys.update(BlueprintUpdateCoordinator._extract_mandatory_inputs(v["input"]))
+                elif "default" not in v and isinstance(k, str):
+                    keys.add(k)
+            elif isinstance(k, str):
+                keys.add(k)
+        return keys
+
+    @staticmethod
     def _extract_used_inputs(obj: object) -> list[str]:
         """Recursively find all !input references in the parsed structure.
 
@@ -3384,15 +3432,24 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, objec
         blueprint_content: str,
         configs: dict[str, dict[str, object]],
     ) -> list[StructuredRisk]:
-        """Validate all consumers of a blueprint against specific content.
+        """Validate blueprint consumers, default fallbacks, and proactive baseline candidates.
 
-        This uses Home Assistant's native input substitution and domain
-        validators without publishing candidate content to the shared hub.
+        This uses Home Assistant's native input substitution and domain validators
+        without publishing candidate content to the shared hub.
+
+        In addition to validating existing consumer configurations, this method evaluates:
+        - Proactive default-fallback simulation: For existing consumers that explicitly
+          configure inputs with blueprint defaults, omitting those inputs is simulated to
+          ensure that default fallback values pass domain schema validation.
+        - Proactive baseline candidate simulation: When no consumers exist and the
+          blueprint defines no mandatory inputs, a baseline candidate with empty inputs is
+          validated against Home Assistant Core if the blueprint provides a self-contained
+          executable structure.
 
         Args:
             relative_path: Relative path of the blueprint.
             blueprint_content: Raw YAML content for validation.
-            configs: Current configurations of all affected entities.
+            configs: Current configurations of all affected entities, or empty if none exist.
 
         Returns:
             A list of compatibility risks or system errors if validation fails.
@@ -3423,7 +3480,7 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, objec
                         },
                     }
                 ]
-            domain = parts[0]
+            domain = normalize_domain(parts[0])
             schema = BlueprintUpdateCoordinator._get_blueprint_schema(domain)
 
             blueprint_obj = Blueprint(
@@ -3446,34 +3503,20 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, objec
                 }
             ]
 
+        blueprint_meta = blueprint_dict.get("blueprint")
+        input_meta = blueprint_meta.get("input") if isinstance(blueprint_meta, Mapping) else None
+        optional_keys = BlueprintUpdateCoordinator._extract_inputs_with_default(input_meta)
+        mandatory_keys = BlueprintUpdateCoordinator._extract_mandatory_inputs(input_meta)
+
         async with self._blueprint_validate_lock:
             for entity_id, config in configs.items():
                 try:
                     blueprint_inputs = BlueprintInputs(blueprint_obj, config)
                     blueprint_inputs.validate()
                     substituted_config = blueprint_inputs.async_substitute()
-                    if domain == FunctionalDomain.AUTOMATION:
-                        await async_validate_automation_config(
-                            self.hass,
-                            config_key=entity_id,
-                            config=substituted_config,
-                        )
-                    elif domain == FunctionalDomain.TEMPLATE:
-                        await async_validate_template_config(
-                            self.hass,
-                            config=substituted_config,
-                        )
-                    else:
-                        object_id = (
-                            entity_id.split(".", 1)[1]
-                            if entity_id.startswith("script.") and "." in entity_id
-                            else entity_id
-                        )
-                        await async_validate_script_config(
-                            self.hass,
-                            object_id=object_id,
-                            config=substituted_config,
-                        )
+                    await self._async_validate_substituted_domain_config(
+                        domain, entity_id, substituted_config
+                    )
                 except (HomeAssistantError, vol.Invalid) as err:
                     risks.append(
                         {
@@ -3484,8 +3527,135 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, objec
                             },
                         }
                     )
+                    continue
+
+                # Proactive default-fallback simulation: if the consumer explicitly configured
+                # inputs that have defaults in the blueprint, verify that omitting them still passes
+                # native HA Core domain schema validation.
+                use_bp = config.get("use_blueprint") if isinstance(config, Mapping) else None
+                if isinstance(use_bp, Mapping):
+                    configured_inputs = use_bp.get("input")
+                    if isinstance(configured_inputs, Mapping) and any(
+                        k in optional_keys for k in configured_inputs
+                    ):
+                        fallback_inputs = {
+                            k: v for k, v in configured_inputs.items() if k not in optional_keys
+                        }
+                        fallback_config = {
+                            **config,
+                            "use_blueprint": {
+                                **use_bp,
+                                "input": fallback_inputs,
+                            },
+                        }
+                        try:
+                            fallback_bp_inputs = BlueprintInputs(blueprint_obj, fallback_config)
+                            fallback_bp_inputs.validate()
+                            substituted_fallback = fallback_bp_inputs.async_substitute()
+                            await self._async_validate_substituted_domain_config(
+                                domain, entity_id, substituted_fallback
+                            )
+                        except (HomeAssistantError, vol.Invalid) as err:
+                            risks.append(
+                                {
+                                    "type": BlueprintRiskType.COMPATIBILITY,
+                                    "args": {
+                                        "entity": entity_id,
+                                        "error": sanitize_error_detail(str(err)),
+                                    },
+                                }
+                            )
+
+            # Proactive baseline candidate simulation: when no consumers exist,
+            # if the blueprint defines no mandatory inputs and provides self-contained
+            # executable structure, validate the baseline with empty inputs against HA Core.
+            if not configs and not mandatory_keys:
+                has_executable_structure = (
+                    (
+                        domain == FunctionalDomain.AUTOMATION
+                        and (
+                            ("trigger" in blueprint_dict or "triggers" in blueprint_dict)
+                            and (
+                                "action" in blueprint_dict
+                                or "actions" in blueprint_dict
+                                or "sequence" in blueprint_dict
+                            )
+                        )
+                    )
+                    or (domain == FunctionalDomain.SCRIPT and "sequence" in blueprint_dict)
+                    or (
+                        domain == FunctionalDomain.TEMPLATE
+                        and any(
+                            k in blueprint_dict for k in ("sensor", "binary_sensor", "template")
+                        )
+                    )
+                )
+                if has_executable_structure:
+                    baseline_config: dict[str, object] = {
+                        "use_blueprint": {
+                            "path": relative_path,
+                            "input": {},
+                        }
+                    }
+                    try:
+                        baseline_inputs = BlueprintInputs(blueprint_obj, baseline_config)
+                        baseline_inputs.validate()
+                        substituted_baseline = baseline_inputs.async_substitute()
+                        await self._async_validate_substituted_domain_config(
+                            domain, relative_path, substituted_baseline
+                        )
+                    except (HomeAssistantError, vol.Invalid) as err:
+                        risks.append(
+                            {
+                                "type": BlueprintRiskType.COMPATIBILITY,
+                                "args": {
+                                    "entity": relative_path,
+                                    "error": sanitize_error_detail(str(err)),
+                                },
+                            }
+                        )
 
         return risks
+
+    async def _async_validate_substituted_domain_config(
+        self,
+        domain: FunctionalDomain,
+        config_key: str,
+        substituted_config: dict[str, object],
+    ) -> None:
+        """Validate a fully substituted blueprint config against Home Assistant Core domain schemas.
+
+        Args:
+            domain: Functional domain (automation, script, template).
+            config_key: Entity ID or path label for error reporting.
+            substituted_config: Config dictionary after input substitution.
+
+        Raises:
+            HomeAssistantError: If configuration fails domain validation.
+            vol.Invalid: If configuration fails schema validation.
+
+        """
+        if domain == FunctionalDomain.AUTOMATION:
+            await async_validate_automation_config(
+                self.hass,
+                config_key=config_key,
+                config=substituted_config,
+            )
+        elif domain == FunctionalDomain.TEMPLATE:
+            await async_validate_template_config(
+                self.hass,
+                config=substituted_config,
+            )
+        elif domain == FunctionalDomain.SCRIPT:
+            if config_key.startswith("script."):
+                object_id = config_key.split(".", 1)[1]
+            else:
+                object_id = slugify(f"{domain}_{config_key}")
+            await async_validate_script_config(
+                self.hass,
+                object_id=object_id,
+                config=substituted_config,
+            )
 
     async def async_summarize_risks(self, risks: Iterable[Mapping[str, object]]) -> str:
         """Create a localized newline-separated string of risks.
@@ -4305,10 +4475,15 @@ class BlueprintUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, objec
         relative_path_obj = info.get("relative_path")
         relative_path = relative_path_obj if isinstance(relative_path_obj, str) else None
         in_use_entities = self._get_entities_using_blueprint(relative_path) if relative_path else []
+        has_compatibility_risk = any(
+            risk.get("type") == BlueprintRiskType.COMPATIBILITY for risk in risks
+        )
         guard_failed = in_use_entities is None or any(
             risk.get("type") == BlueprintRiskType.SYSTEM_ERROR for risk in risks
         )
-        is_breaking = bool(risks) and (guard_failed or bool(in_use_entities))
+        is_breaking = bool(risks) and (
+            guard_failed or bool(in_use_entities) or has_compatibility_risk
+        )
 
         if is_breaking:
             await self._async_handle_auto_update_blocked(

--- a/tests/coordinator/test_compatibility_guard.py
+++ b/tests/coordinator/test_compatibility_guard.py
@@ -234,3 +234,46 @@ async def test_auto_update_guard_blocks_on_usage_lookup_failure(
     assert coordinator.data[blueprint_path]["update_blocking_reason"] == (
         BlueprintBlockingReason.SYSTEM_ERROR
     )
+
+
+@pytest.mark.asyncio
+async def test_auto_update_guard_blocks_when_compatibility_risk_present_even_without_consumers(
+    coordinator: BlueprintUpdateCoordinator,
+):
+    """Auto-update is blocked when compatibility risk is present.
+
+    Applies even if no entities currently use the blueprint.
+    """
+    blueprint_path = "automation/test_compat_no_consumers.yaml"
+    _prepare_blueprint_entry(coordinator, blueprint_path)
+
+    with (
+        patch.object(coordinator, "_get_entities_using_blueprint", return_value=[]),
+        patch.object(coordinator, "_async_send_auto_update_notification", return_value=None),
+        patch.object(coordinator, "async_translate", side_effect=lambda key, **kwargs: key),
+    ):
+        risks: list[StructuredRisk] = [
+            {
+                "type": BlueprintRiskType.COMPATIBILITY,
+                "args": {
+                    "entity": blueprint_path,
+                    "error": "Entity ID  is an invalid entity ID",
+                },
+            }
+        ]
+
+        result = await coordinator._handle_auto_update_step(
+            blueprint_path,
+            coordinator.data[blueprint_path],
+            "blueprint: name: New",
+            risks,
+            [],
+            set(),
+            remote_hash="new_hash",
+            new_etag="new_etag",
+        )
+
+    assert result is True
+    entry = coordinator.data[blueprint_path]
+    assert entry["updatable"] is True
+    assert entry["update_blocking_reason"] == BlueprintBlockingReason.BREAKING_CHANGE

--- a/tests/integration/test_compatibility.py
+++ b/tests/integration/test_compatibility.py
@@ -324,3 +324,262 @@ async def test_unmocked_template_blueprint_consumer_validation(
     )
 
     assert risks == []
+
+
+@pytest.mark.asyncio
+async def test_proactive_default_fallback_simulation_catches_unsafe_empty_default(
+    hass: HomeAssistant,
+) -> None:
+    """Active consumer with valid input fails when default fallback violates HA schema."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={},
+        options={"update_interval": 24},
+        entry_id="test_compat_fallback_val",
+    )
+    entry.add_to_hass(hass)
+    coordinator = BlueprintUpdateCoordinator(hass, entry, timedelta(hours=24))
+
+    unsafe_blueprint = (
+        "blueprint:\n"
+        "  name: Unsafe Action Target Blueprint\n"
+        "  domain: automation\n"
+        "  input:\n"
+        "    trigger_bool:\n"
+        "      name: Trigger Boolean\n"
+        "      selector:\n"
+        "        entity:\n"
+        "          domain: input_boolean\n"
+        "    optional_helper:\n"
+        "      name: Optional Helper\n"
+        "      default: ''\n"
+        "      selector:\n"
+        "        entity:\n"
+        "          domain: input_boolean\n"
+        "trigger:\n"
+        "  - platform: state\n"
+        "    entity_id: !input trigger_bool\n"
+        "action:\n"
+        "  - service: input_boolean.turn_on\n"
+        "    target:\n"
+        "      entity_id: !input optional_helper\n"
+    )
+
+    # Consumer explicitly supplied optional_helper, so direct evaluation succeeds
+    consumer_config: dict[str, object] = {
+        "use_blueprint": {
+            "path": "automation/unsafe_bp.yaml",
+            "input": {
+                "trigger_bool": "input_boolean.trigger",
+                "optional_helper": "input_boolean.target",
+            },
+        }
+    }
+
+    risks = await coordinator._async_validate_blueprint_consumers(
+        relative_path="automation/unsafe_bp.yaml",
+        blueprint_content=unsafe_blueprint,
+        configs={"automation.test_instance": consumer_config},
+    )
+
+    # Default-fallback simulation catches that omitting optional_helper fails schema
+    assert len(risks) == 1
+    assert risks[0]["type"] == BlueprintRiskType.COMPATIBILITY
+    assert risks[0]["args"]["entity"] == "automation.test_instance"
+
+
+@pytest.mark.asyncio
+async def test_proactive_baseline_simulation_zero_consumers_catches_unsafe_empty_default(
+    hass: HomeAssistant,
+) -> None:
+    """Zero-consumer blueprint with unsafe default input fails proactive baseline simulation."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={},
+        options={"update_interval": 24},
+        entry_id="test_compat_zero_consumers",
+    )
+    entry.add_to_hass(hass)
+    coordinator = BlueprintUpdateCoordinator(hass, entry, timedelta(hours=24))
+
+    unsafe_blueprint = (
+        "blueprint:\n"
+        "  name: Unsafe Zero Consumer Blueprint\n"
+        "  domain: automation\n"
+        "  input:\n"
+        "    optional_helper:\n"
+        "      name: Optional Helper\n"
+        "      default: ''\n"
+        "      selector:\n"
+        "        entity:\n"
+        "          domain: input_boolean\n"
+        "trigger:\n"
+        "  - platform: homeassistant\n"
+        "    event: start\n"
+        "action:\n"
+        "  - service: input_boolean.turn_on\n"
+        "    target:\n"
+        "      entity_id: !input optional_helper\n"
+    )
+
+    risks = await coordinator._async_validate_blueprint_consumers(
+        relative_path="automation/unsafe_zero.yaml",
+        blueprint_content=unsafe_blueprint,
+        configs={},
+    )
+
+    assert len(risks) == 1
+    assert risks[0]["type"] == BlueprintRiskType.COMPATIBILITY
+    assert risks[0]["args"]["entity"] == "automation/unsafe_zero.yaml"
+
+
+@pytest.mark.asyncio
+async def test_proactive_simulation_allows_standard_target_selector_default_dict(
+    hass: HomeAssistant,
+) -> None:
+    """Standard target selector with default: {} is valid in Home Assistant Core."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={},
+        options={"update_interval": 24},
+        entry_id="test_compat_target_dict",
+    )
+    entry.add_to_hass(hass)
+    coordinator = BlueprintUpdateCoordinator(hass, entry, timedelta(hours=24))
+
+    valid_blueprint = (
+        "blueprint:\n"
+        "  name: Valid Target Dict Blueprint\n"
+        "  domain: automation\n"
+        "  input:\n"
+        "    target_dev:\n"
+        "      name: Target Device\n"
+        "      default: {}\n"
+        "      selector:\n"
+        "        target:\n"
+        "trigger:\n"
+        "  - platform: homeassistant\n"
+        "    event: start\n"
+        "action:\n"
+        "  - service: homeassistant.turn_on\n"
+        "    target: !input target_dev\n"
+    )
+
+    risks = await coordinator._async_validate_blueprint_consumers(
+        relative_path="automation/valid_target.yaml",
+        blueprint_content=valid_blueprint,
+        configs={},
+    )
+
+    assert risks == []
+
+
+@pytest.mark.asyncio
+async def test_proactive_baseline_simulation_zero_consumers_valid_script(
+    hass: HomeAssistant,
+) -> None:
+    """Zero-consumer script blueprint validates successfully in proactive baseline simulation."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={},
+        options={"update_interval": 24},
+        entry_id="test_compat_zero_script",
+    )
+    entry.add_to_hass(hass)
+    coordinator = BlueprintUpdateCoordinator(hass, entry, timedelta(hours=24))
+
+    valid_script_bp = (
+        "blueprint:\n"
+        "  name: Valid Zero Consumer Script Blueprint\n"
+        "  domain: script\n"
+        "  input:\n"
+        "    delay_seconds:\n"
+        "      name: Delay\n"
+        "      default: 5\n"
+        "      selector:\n"
+        "        number:\n"
+        "          min: 1\n"
+        "          max: 60\n"
+        "sequence:\n"
+        "  - delay:\n"
+        "      seconds: !input delay_seconds\n"
+    )
+
+    risks = await coordinator._async_validate_blueprint_consumers(
+        relative_path="script/valid_zero_script.yaml",
+        blueprint_content=valid_script_bp,
+        configs={},
+    )
+
+    assert risks == []
+
+
+@pytest.mark.asyncio
+async def test_proactive_baseline_simulation_zero_consumers_catches_invalid_script(
+    hass: HomeAssistant,
+) -> None:
+    """Zero-consumer script blueprint with invalid action fails baseline simulation."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={},
+        options={"update_interval": 24},
+        entry_id="test_compat_zero_script_invalid",
+    )
+    entry.add_to_hass(hass)
+    coordinator = BlueprintUpdateCoordinator(hass, entry, timedelta(hours=24))
+
+    invalid_script_bp = (
+        "blueprint:\n"
+        "  name: Invalid Zero Consumer Script\n"
+        "  domain: script\n"
+        "sequence:\n"
+        "  - service: ''\n"
+    )
+
+    risks = await coordinator._async_validate_blueprint_consumers(
+        relative_path="script/invalid_zero.yaml",
+        blueprint_content=invalid_script_bp,
+        configs={},
+    )
+
+    assert len(risks) == 1
+    assert risks[0]["type"] == BlueprintRiskType.COMPATIBILITY
+    assert risks[0]["args"]["entity"] == "script/invalid_zero.yaml"
+
+
+@pytest.mark.asyncio
+async def test_proactive_baseline_simulation_zero_consumers_valid_template(
+    hass: HomeAssistant,
+) -> None:
+    """Zero-consumer template blueprint validates successfully in proactive baseline simulation."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={},
+        options={"update_interval": 24},
+        entry_id="test_compat_zero_template",
+    )
+    entry.add_to_hass(hass)
+    coordinator = BlueprintUpdateCoordinator(hass, entry, timedelta(hours=24))
+
+    valid_template_bp = (
+        "blueprint:\n"
+        "  name: Valid Zero Consumer Template\n"
+        "  domain: template\n"
+        "  input:\n"
+        "    sensor_name:\n"
+        "      name: Sensor Name\n"
+        "      default: My Template Sensor\n"
+        "      selector:\n"
+        "        text:\n"
+        "sensor:\n"
+        "  - name: !input sensor_name\n"
+        '    state: "OK"\n'
+    )
+
+    risks = await coordinator._async_validate_blueprint_consumers(
+        relative_path="template/valid_zero.yaml",
+        blueprint_content=valid_template_bp,
+        configs={},
+    )
+
+    assert risks == []

--- a/uv.lock
+++ b/uv.lock
@@ -232,14 +232,15 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.14.2"
+version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.15'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/9a/c15a60547004a3f3cea20296c934f827ddd7bdba225a2e7e9fcb5ec48c80/anyio-4.15.0.tar.gz", hash = "sha256:b5c620ed540725e2579c31b17bb995b3bf02c9281c9cace04c7d186380bab85e", size = 276504, upload-time = "2026-09-02T21:46:36.957Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a6/2b21ce5ebe4d8938a247c9b0dbb7271566ae559b01795c83ea4bb2660ed7/anyio-4.15.0-py3-none-any.whl", hash = "sha256:7ecd9937369ffce8bba0b5ccb9b3a9507b101b0ed50256aecfbab27e6c2acb99", size = 131908, upload-time = "2026-09-02T21:46:35.485Z" },
 ]
 
 [[package]]
@@ -551,30 +552,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.43.86"
+version = "1.43.88"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f1/a0/b8693637bee21e266a52f3e1b8bb9fe4897934aa62c55cc132f8721c1b8f/boto3-1.43.86.tar.gz", hash = "sha256:aca7b5d7f31a90ad37bec773552ec9bfb57e0029c9aa0f0f4d51d5bf9607b1c4", size = 112685, upload-time = "2026-09-01T19:24:02.867Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/a4/d7b6ca0c2c21722c12b6ecc942ff3e2304c40f00724182500236616c4236/boto3-1.43.88.tar.gz", hash = "sha256:b3d03fba8ace049de27e3a6ed69b25a55d752f49d563394985e805ed5f0a0a74", size = 112730, upload-time = "2026-09-03T19:24:05.814Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/dd/f4874f7bab882a778178b03965b1474c63f2e8bd2eea5dd714f06b0e8713/boto3-1.43.86-py3-none-any.whl", hash = "sha256:94543a5ce482df8bb6a0bf8a944bf5ccf6625889b1df0d7886dfc3311ebd4169", size = 140026, upload-time = "2026-09-01T19:24:00.638Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/04/b024d6c8ba2ae18ebaf6597981069a6f51d97ab64d769d466936f1454954/boto3-1.43.88-py3-none-any.whl", hash = "sha256:62efee681fefc9b14244d66ab66ead11dd4a32fec0a54ac9f23106003ef210ca", size = 140024, upload-time = "2026-09-03T19:24:04.27Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.43.86"
+version = "1.43.88"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/58/77/0ed1c398b7d3aa5d02c1b15df32a049e07961339fe41640af1440079c2f7/botocore-1.43.86.tar.gz", hash = "sha256:0e943c77ab6a54aaaf4d57e6026ede5c3dca341af71ce91f71849a6eae9d5dbf", size = 16059433, upload-time = "2026-09-01T19:23:57.72Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/16/8944ffdbd6df92c463b77e933bae41a46fb1ec903c48a286e855761ce115/botocore-1.43.88.tar.gz", hash = "sha256:3c8a6e2292f05c590c5d5299934dd23c81d19a2b6dd70b9eb724f79bd432d04f", size = 16072325, upload-time = "2026-09-03T19:24:01.045Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/59/eb95d57ea576feaf1693f5e914f9f27ff9961429cf9ecbc85cef610a6d84/botocore-1.43.86-py3-none-any.whl", hash = "sha256:4efc7fbd6e7616edbd55623bb585a044906149b9a5d3d8558420506526e5a5ac", size = 15751556, upload-time = "2026-09-01T19:23:54.013Z" },
+    { url = "https://files.pythonhosted.org/packages/72/b0/2981d533ebf7f93a3fa8493fb243e11225f31ad5ae36f3259fe7215d9141/botocore-1.43.88-py3-none-any.whl", hash = "sha256:1b59b6d74fb77b0c3934014b6693d56da4a9a172edb9454f9a5f711b4b3f7353", size = 15765383, upload-time = "2026-09-03T19:23:57.936Z" },
 ]
 
 [[package]]
@@ -1200,7 +1201,7 @@ wheels = [
 
 [[package]]
 name = "homeassistant"
-version = "2026.9.0b4"
+version = "2026.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiodns" },
@@ -1252,9 +1253,9 @@ dependencies = [
     { name = "yarl" },
     { name = "zeroconf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d2/db/630cfdc8ae56e9428964178b0b90d21c039ba7cfdb950d44e4fb772fa8f8/homeassistant-2026.9.0b4.tar.gz", hash = "sha256:451b0eab119f9f1a1dbdb470c28272efeca0fe68fbe831b434583aabf884249d", size = 37462346, upload-time = "2026-08-29T21:06:45.378Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/ed/c6d0a0419265e3736b9696eb11a450b63b4ed5e01f1b6055ba67a6072094/homeassistant-2026.9.0.tar.gz", hash = "sha256:ac140c0d702b703ecb1e6c2a2cc7ab84ab070e8f74f75ec9db67fbdb9d87b6c2", size = 37518277, upload-time = "2026-09-02T16:23:23.606Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/b2/8db3cb900f29d9ae732fcc56975c1f4b684d03b31052f803d8428fb50060/homeassistant-2026.9.0b4-py3-none-any.whl", hash = "sha256:ec0139cf4bac9a7944b0c623692e7a7366a50b55eb284c4effb768e8115c0303", size = 61055093, upload-time = "2026-08-29T21:06:39.422Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/62/50227df31ac0de669e118cdfe23e2a2d6207d39cce92ad044154547d74de/homeassistant-2026.9.0-py3-none-any.whl", hash = "sha256:072764fd37d2c01fc8b3c87865327be2f79497232d4f8783efab5ea82281cf3e", size = 61125351, upload-time = "2026-09-02T16:23:17.583Z" },
 ]
 
 [[package]]
@@ -1701,18 +1702,18 @@ wheels = [
 
 [[package]]
 name = "prek"
-version = "0.5.1"
+version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/99/5e/76262cecced2c8d8d20474f8fc7cf4b7059d01a0b1ae2ffb9e375815c5a4/prek-0.5.1.tar.gz", hash = "sha256:581af5dc6462cfc60b58cadcf8e6bf5b9819d75493074f435dfa14d660a33218", size = 549170, upload-time = "2026-09-01T04:19:59.228Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/05/4402641f168dd862d27592cbd4c5fb171d119c15611e5dbef3df857e8932/prek-0.5.2.tar.gz", hash = "sha256:a90ea4eeba35c6081bad29775f6a49fcc33fb80372424fce64c7a9c5774e8204", size = 549442, upload-time = "2026-09-02T17:49:27.241Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/13/ab44b9a4aba8b8f1f4204bc754648cb89959ae4b0a81114c850ed8888bb6/prek-0.5.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:821fe17617fe0b26385ce6ce324a4201810ff50349b8bb75176da72f0b858cc6", size = 5981894, upload-time = "2026-09-01T04:19:46.92Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/b4/3b2f9bc42bdbf17b182508a32f1f382d84502b7be1091b4c8ef21d043124/prek-0.5.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:afa9f5567c559e3045688bace59fa6c8336a6950f0bba063b57e57c476fb63d1", size = 5526575, upload-time = "2026-09-01T04:19:48.695Z" },
-    { url = "https://files.pythonhosted.org/packages/df/26/a9e43ddc34fa3fe3199c7d5fc09d4d77045ac330d504c62a8b87983f0ebf/prek-0.5.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:25d2c63fadcc0b2eae434cea4ddc4164792add0abfb20e1bf6bbefd33610f2a9", size = 5824937, upload-time = "2026-09-01T04:19:50.184Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/e6/c67e1d0661a97aa88ce8a3dca4b67ca5d26a1dc759c9df37430cb8f4aea9/prek-0.5.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:231cc325d31e9d92db51da08b4d9a2e061f084d459307b5920ccea95e86b5c9f", size = 6202110, upload-time = "2026-09-01T04:19:51.747Z" },
-    { url = "https://files.pythonhosted.org/packages/55/1c/8d46f27b6be800ecda86f15b3d476d80f290d6d4a39a6cf992b170148ce6/prek-0.5.1-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:39d92d26a1d210d3fad63e316d9379ad4fbedb4545af42c82cb73ebc20ffc64d", size = 5829515, upload-time = "2026-09-01T04:19:53.473Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/de/0d5c1c20e26bfc866885aed4ca68222c1fb8d7ddd8639a789ba0be8ba57e/prek-0.5.1-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:c6481f5effbb1a83a578bf769a527e1192d0faf4f2e481733917e1fff2007253", size = 6317963, upload-time = "2026-09-01T04:19:55.051Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/21/56b31d445ac84607919679841b47288d42687925cdf9a31207db277d753d/prek-0.5.1-py3-none-win_amd64.whl", hash = "sha256:74609c3cd3f1c14d35d081905f58b266133b9532df53a75648a280e6a80febb3", size = 5726528, upload-time = "2026-09-01T04:19:56.482Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/95/ada15ee42ef72b7d422ae3e3fbc4753d4bc6634ba23de1b7cec84b407df7/prek-0.5.1-py3-none-win_arm64.whl", hash = "sha256:f408364fc7f10996f396a14542d8a3e35494a4fde2b1cb873d996715d1876322", size = 5490020, upload-time = "2026-09-01T04:19:57.841Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/25/cf9c6064fea82ba6f4801dc3be650cc86eae3d9951e2a6fb28b21cbfa156/prek-0.5.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:40d488a48de3f47f48bd4911ee5dec25e615f992b4cde821e9b50d40c615b39e", size = 5982622, upload-time = "2026-09-02T17:49:10.111Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/d9/9772fd4d4023c34780d957f407d9437e2a16d6bef77e3da9fa4374cd75bb/prek-0.5.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:0eb3b812fc13bc5c05cfc1a8b469f9665a02f845753c3759ad7aca50af707afb", size = 5525662, upload-time = "2026-09-02T17:49:12.336Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/19/be25a56ab243f2e5c9333c38bad33bddffec92ea8a25e34248eba6e00ac8/prek-0.5.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:c0219d1e694a962e3b3ae98f42f53065d2e2856719caee88578d24b35ea74cad", size = 5826109, upload-time = "2026-09-02T17:49:13.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/bd/a4a5a3022915b8e1768df9b2d8744f3e7c4b3bb7cdbe697612cc96054169/prek-0.5.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0e22f11c1fb5df89acf5cbde78f6139edf2c30a205bea5a5d4a094366dcdbda", size = 6201473, upload-time = "2026-09-02T17:49:16.156Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/fb/2e5f8adbee718f15333a113872104c4b3d25ecce423dd7117cfcd28a25fe/prek-0.5.2-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:1d52de8428d5eef7c8c0fd64efd7d31210d13924fd36a02975d462675715aeb7", size = 5829166, upload-time = "2026-09-02T17:49:17.997Z" },
+    { url = "https://files.pythonhosted.org/packages/44/71/c798d54741cc8f345b211e453dda9599546fb213c3593eb711cb6c710bbf/prek-0.5.2-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:86aebcd8ab831036fc3ac9b15275412403e21041da031e6c9f1547888843e5c6", size = 6318980, upload-time = "2026-09-02T17:49:21.145Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/f8/4aefbf76dae091078655fbaf065c34fa900d43b39c2b88e80cbaa71b5efb/prek-0.5.2-py3-none-win_amd64.whl", hash = "sha256:b6c0e4f272f9410f8218d1db0cc7ea10cd8f62db19f820b9ace9f6c2b33bd8dd", size = 5727075, upload-time = "2026-09-02T17:49:23.656Z" },
+    { url = "https://files.pythonhosted.org/packages/df/7c/409ced8866197da50e9bcb2c9bf101e3e9a35b98a851c0ccd2a44509eaa5/prek-0.5.2-py3-none-win_arm64.whl", hash = "sha256:0ebea4ef39f6446f6c414a5a506cde8942b17b5899f74cf90e352628085d4005", size = 5489643, upload-time = "2026-09-02T17:49:25.778Z" },
 ]
 
 [[package]]
@@ -2181,7 +2182,7 @@ wheels = [
 
 [[package]]
 name = "pytest-homeassistant-custom-component"
-version = "0.13.361"
+version = "0.13.363"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohasupervisor" },
@@ -2214,9 +2215,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "unidiff" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/68/ac/a0ed18f286c792deacf8e04fcec87920adb15f82b6e21fcd161dcf91775d/pytest_homeassistant_custom_component-0.13.361.tar.gz", hash = "sha256:2d4bb18690b70ca65659a514fb020f181523b9da0e1862f30a6c62df0d993c5d", size = 78539, upload-time = "2026-08-30T10:15:02.193Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/98/e60618f170a96650e1c6bcb78a2525b356f0067c2434972110b29bcf985e/pytest_homeassistant_custom_component-0.13.363.tar.gz", hash = "sha256:e14868eab5258b341493460317f7473ac4cb20d847e24cf3e78b8c4b7a5614fd", size = 78536, upload-time = "2026-09-03T09:21:58.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/37/dd/7623a1d041114df068ac217129a41dd8a2d50273edfd3f19abb0abdca17b/pytest_homeassistant_custom_component-0.13.361-py3-none-any.whl", hash = "sha256:fe83f2b396ddeecd4529c587d6ad5de54389a5ae2196189154f51735a232b5e3", size = 84458, upload-time = "2026-08-30T10:15:00.361Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/1f/4a8d7796d3d9cd6a81ae2c155f8358f70800115e3695e1f85f2b441b933b/pytest_homeassistant_custom_component-0.13.363-py3-none-any.whl", hash = "sha256:5437a1371bb1643973f4e0ebe8aa573b45fc589ec402a82f744d9bd9fb47e88f", size = 84452, upload-time = "2026-09-03T09:21:57.081Z" },
 ]
 
 [[package]]
@@ -2452,27 +2453,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.16.5"
+version = "0.16.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/85/c8e12473c93018f92d19dd988a294202e1c27426c47ec4de53ffb847b8d8/ruff-0.16.5.tar.gz", hash = "sha256:1b88500f9ffbcab3dedb0082c9f9492e91ec3d618aac1236a3e0189938f7040b", size = 4912003, upload-time = "2026-08-27T16:34:18.258Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/7c/6adb35d70e7c027e308274557901c7e00fb3407750faf3620c184ae058cb/ruff-0.16.6.tar.gz", hash = "sha256:dcf8a73d2ff77e99dde91244b4da16feba7f14e6beeb4015dee7c5a909e99050", size = 4921251, upload-time = "2026-09-03T16:57:29.037Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/b6/77c90a970fe2dae17a723acbd011043ea97c98d7deacccefdc4ba74ec512/ruff-0.16.5-py3-none-linux_armv6l.whl", hash = "sha256:12e5f673e774c35fbb62f288809c7653b73445f8ecec6b6063fd6ea3521aa14b", size = 10011941, upload-time = "2026-08-27T16:33:41.287Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/46/6cf67cf6411885a1d6f7f6d801682f155536a85176d10b605e2ceffed8bd/ruff-0.16.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:eda58a5802de40e7ed5b32b64e0b32539338cc6fcd2c78f61e3ad6a0d79f51c3", size = 10204049, upload-time = "2026-08-27T16:33:44.056Z" },
-    { url = "https://files.pythonhosted.org/packages/46/fd/c8720ca7a090abf0c2fef4abe8a5ef6e5127ed15196d8886ff75a2b370e2/ruff-0.16.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5ae9a7b9a8875131f40f8fe967cc86abf899779efd663cb7ce3d572d01da7eb", size = 9809037, upload-time = "2026-08-27T16:33:46.257Z" },
-    { url = "https://files.pythonhosted.org/packages/43/45/a684caacdedaca180f52bacccc40bf0789d2c5a7c75f25324853e9eaedb5/ruff-0.16.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b719b0a1f4d59710d283ab2965f621684a108a9e41da622e3b23f0326cd0025", size = 9964129, upload-time = "2026-08-27T16:33:48.352Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/f2/5d2bcdaca6b5b93d1b4dfc166cd2aebf7680143a1b38a28759df13a94d31/ruff-0.16.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2298f2780ed1be0c5cb1361e32ab7b1467f3cce7dabe101d2210a314f2fe42e9", size = 9821518, upload-time = "2026-08-27T16:33:50.57Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/ff/011cce29accf9257d5974145b733fc653a37985ed6825413a3987cefbfe0/ruff-0.16.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:258f29035a2dd021e7861e631b227a5b3f14e50c1184c9a6a122c5f4576154d7", size = 10534835, upload-time = "2026-08-27T16:33:52.522Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/5a/f0cf109bada9bba0e96c90c21c9f9251803f57225c32d293327a03c710d6/ruff-0.16.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b9a4f0432966834019c74d1b7e5c51224305d7713f3d7faf3e7451f1a3be3cde", size = 11252550, upload-time = "2026-08-27T16:33:54.521Z" },
-    { url = "https://files.pythonhosted.org/packages/63/4d/1d481aaea2046c6a7ed7c291f9004c669cce3c087b6b376ed5b08271e3fe/ruff-0.16.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b5eb3a8c3d0ade9cea42b591fd530368e8798380e30e0a308b85a5cf718f09ea", size = 10777949, upload-time = "2026-08-27T16:33:56.88Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/34/ee245ca55f64443233034b3d02b03236b19242004281247c079390b7facd/ruff-0.16.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef0f69e191a13a3c9816f63163c88790cb12cd157bbbb384e9c44745702ab105", size = 10311656, upload-time = "2026-08-27T16:33:59.12Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/4d/c33a333e341c0a2b96c715b52d89a606f5a34cd4ac493cd9b8d0187186b8/ruff-0.16.5-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:0eeab41fbea2c42f98dfb9822cdccda9d24ba38d49f6dc945b5c236d48f0ef29", size = 10532125, upload-time = "2026-08-27T16:34:01.166Z" },
-    { url = "https://files.pythonhosted.org/packages/30/e1/a64cef78b40192497bb98a27a8aa8f2c98ee9ee15bc97f7712d94ef32937/ruff-0.16.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f0768e9df4300713fff30733c87575f68b6f1d8de41184e505b7fdd9c0c95eaf", size = 10097648, upload-time = "2026-08-27T16:34:03.16Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/4e/4cdc9ed3c3e109d2f71e62572a37457298d7bc7501ec3138babb7ed32bbd/ruff-0.16.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:95cc70cdc7aa80c338de356279d2adbeb2de0f520b9ecd8aba75b94e95e02f91", size = 9829344, upload-time = "2026-08-27T16:34:05.134Z" },
-    { url = "https://files.pythonhosted.org/packages/39/4a/31ed35ce31729955fc583ee0d176d6e784c1290cb0b0a75cb2134c1ab72a/ruff-0.16.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d185c8398ded1bfd91c0c2cb258346307571eccc473a8490af8c3977399c384a", size = 10277117, upload-time = "2026-08-27T16:34:07.425Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/a0/60356d86687b4b666d593df213f4dc3041750d024cb7bf2cfa81cfd65c2e/ruff-0.16.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:fb8e3a3c4c6a784150a7ced53b015f4b253fc2bf97a610886419ead64b4756ef", size = 10711653, upload-time = "2026-08-27T16:34:09.712Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/20/656d67f5b25ca9bda4e02b1de25867b2954e1d19e03648060f167ad0f4cc/ruff-0.16.5-py3-none-win32.whl", hash = "sha256:288b0a5f080492fe5635db849f9e2e84aa3cce7b7f0e955997d416c507c76a26", size = 10034250, upload-time = "2026-08-27T16:34:11.8Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/42/ee8e68a207b9127fcde6c3d7e197def432f346cb1af159e1fa14ca0d1cdc/ruff-0.16.5-py3-none-win_amd64.whl", hash = "sha256:ddc6385fb2137f616357ca03d6c74f4be987f80fed4008566b754f6032b8546f", size = 10516714, upload-time = "2026-08-27T16:34:13.963Z" },
-    { url = "https://files.pythonhosted.org/packages/73/e3/7df5a396e445b9ba49ce9a9437439a4d80042c61c0ade199abf8d16de1ac/ruff-0.16.5-py3-none-win_arm64.whl", hash = "sha256:a64abe90968719b851bb7cedffaa8753fbdbdadab483089682db623f3edc587e", size = 10391564, upload-time = "2026-08-27T16:34:16.064Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/9cc1b79639e284ec103f43c88c644db4eb58cbd0ea1ca11f1193435369ac/ruff-0.16.6-py3-none-linux_armv6l.whl", hash = "sha256:61c368c26bf8e973e5ab14a2772de587bc068ea3f9a277f673380749b4898fb8", size = 10015638, upload-time = "2026-09-03T16:56:40.986Z" },
+    { url = "https://files.pythonhosted.org/packages/71/11/627d342ef727ea7794edf74fe23d60a074b02c3acc2e9436684e782286ca/ruff-0.16.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ecf4f068e2e123e43a26e9db4e19524cc56563912404e83bbfca375757e45a32", size = 10220762, upload-time = "2026-09-03T16:56:44.681Z" },
+    { url = "https://files.pythonhosted.org/packages/43/d9/b75668ce41e4c8d073d18d6d08672ba6906ce45d5c06ea4fdb2e84ce3853/ruff-0.16.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:99b62ea33baf130f50368798d841f0d95527b6d817bf31817b65dd058f1d314c", size = 9835082, upload-time = "2026-09-03T16:56:47.142Z" },
+    { url = "https://files.pythonhosted.org/packages/99/97/123ab10b05cde889c107c20f5a9774955104b5552796a2a8584b089ae8eb/ruff-0.16.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7fbf89013f2bb3f6835a6038ff658dc8a1b38c98dc8e724b964168ad4e881876", size = 9949304, upload-time = "2026-09-03T16:56:49.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/58/a4a2c59dd2e5b85929c912d9cac3056eb9ee8c7e75e9b9fe3e109174966b/ruff-0.16.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56a67065e22efa6bc4d498299d3bb06c0c90aace8fac2068b5a12f9dc4d8d51d", size = 9840612, upload-time = "2026-09-03T16:56:52.368Z" },
+    { url = "https://files.pythonhosted.org/packages/61/6a/ff8c8626a786c4f49d48ced4a752dadbca65f5263005f9c2416578194694/ruff-0.16.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e25cc89174874b176a157e4428d66761c2c0c006654419bf384f967f361ff1b1", size = 10543465, upload-time = "2026-09-03T16:56:55.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/bb/c47535923365f337b82e28192e4e9eef2176511007cfd99a62fc22df5dad/ruff-0.16.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0700580ed5303723cb3c11c2f1d2a8913ce77b7ea86646dddb887f5417a9ba70", size = 11267576, upload-time = "2026-09-03T16:56:57.791Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/50/e5119a5212b5cd63b51e1f4b25e7bd636a6668fc069a3160b108ad7e3c16/ruff-0.16.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:15f1d0b6e165a6e56567befb6629f8209271311d990bae0f37e6d065035ef5f3", size = 10781993, upload-time = "2026-09-03T16:57:00.666Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/98/083d8b4ef3c51a0d19db84367791cbe9f44e4b53343d19dfa83556e1cd9a/ruff-0.16.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d72c591a96986ee4268860e2b7235082129ca5e4cb9cbba653a4b57c11893757", size = 10317748, upload-time = "2026-09-03T16:57:03.428Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/29/68f7ff2c5ad95f19f00627ac2de95644e25fe47371ea60b2db1fd952315e/ruff-0.16.6-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:65a006baa18f33324325814c864daef03541d51564b98c517610ea756ab7003e", size = 10540096, upload-time = "2026-09-03T16:57:06.182Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f9/79a8f6de85968641d68a7863aeec577551924ef066a990a48ff93167beab/ruff-0.16.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:cd02a7bf1a21a8735228a3e8c95a9dc5cf86bd2a52194f4aaae2a5755b4de0f4", size = 10100494, upload-time = "2026-09-03T16:57:09.194Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/e8/b81a22d9b90c00b892ccf2fa2ac36fa95de4c13ab85aea3e73795cfe4651/ruff-0.16.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:31b36f1e5ad85e0737f09d2be4e512e2e283583c14015da3b9dc07359ac0fc88", size = 9843663, upload-time = "2026-09-03T16:57:12.168Z" },
+    { url = "https://files.pythonhosted.org/packages/39/aa/54f516ec5e5a11c4afdceb1c454ebb054ffb96e4f4a1705580b4346abd35/ruff-0.16.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:61029b4ab4aa723fd3064fab96b1d814492596bf0c792679fffcbde1e1679953", size = 10282461, upload-time = "2026-09-03T16:57:15.077Z" },
+    { url = "https://files.pythonhosted.org/packages/52/0b/38d0aa8aa32372b96dc44f97b22e576c4147808271aab7b2cb1e353d4445/ruff-0.16.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9ac8998457832c2061709d900856b7ad271dace0cb41f346588d540162bfa718", size = 10728808, upload-time = "2026-09-03T16:57:17.797Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e5/9e274e24eeb027640ffc7442f21239f16d17f47acec15ae34f32e03a5c79/ruff-0.16.6-py3-none-win32.whl", hash = "sha256:0b87d9d16fcb63e8018423ca1d50b7260f15cb2da33e30db4baad4183a948c25", size = 10049212, upload-time = "2026-09-03T16:57:20.55Z" },
+    { url = "https://files.pythonhosted.org/packages/22/31/72472449414223ed1a2da236b992adbb1a2ae59e34794574810f60ce068e/ruff-0.16.6-py3-none-win_amd64.whl", hash = "sha256:10d21c51c3495d8eaea7b703a16592117ea6eb1d649e36335aa965ff1173eb39", size = 10556402, upload-time = "2026-09-03T16:57:23.501Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/07/d781f8f8e1ac24bef9f3269cf62ffb1407ca24c3a8f12e5e22874f90528c/ruff-0.16.6-py3-none-win_arm64.whl", hash = "sha256:7a976c79b958f94e50a022a19f0f8c87387448020935ec14fc74331bd0a7f2c5", size = 10412850, upload-time = "2026-09-03T16:57:26.416Z" },
 ]
 
 [[package]]
@@ -2639,27 +2640,27 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.77"
+version = "0.0.78"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bb/ef/a2024d1d33d5ba8436677a6fd734f87a137150aba99906fc009f7c5de956/ty-0.0.77.tar.gz", hash = "sha256:8898f3097610f4a772ead6bfad7b204c7d76e8eb3a010c7285b9186278e0fb82", size = 7005734, upload-time = "2026-09-01T00:26:26.901Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/c7/2ba0861384c5b5097ac354383abb98188112cb330208c21d5197e98a29e5/ty-0.0.78.tar.gz", hash = "sha256:770b45854f85fa11595208f08c0f28df80943164d10a2832d86be6ac29f135b2", size = 7050609, upload-time = "2026-09-02T22:41:33.92Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/03/930f7454a6d797abc09aebbf537017825ebb08d9f8c2e2d905e74341dbb1/ty-0.0.77-py3-none-linux_armv6l.whl", hash = "sha256:ea76012f1ed387b6fc6500894fb8a7654b724c38713e263a23f12756f00e2469", size = 13241626, upload-time = "2026-09-01T00:25:51.02Z" },
-    { url = "https://files.pythonhosted.org/packages/65/41/7e064045775718673851f6c0e1cfde70d6e380b0db9d91d4484a362f2d67/ty-0.0.77-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:237a58c389e01d65c4693e0394feb0f0adea3fba0345c3b932d209084372f3d3", size = 12830037, upload-time = "2026-09-01T00:25:53.172Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/64/66f0b0dc89bd239922bdf12fa3e6d066aa7a425e8b70414368c4eb44a6e6/ty-0.0.77-py3-none-macosx_11_0_arm64.whl", hash = "sha256:bbb8ae7a753b9a6af25725c314d0eca967e5fde5eebb7a35b04b0d763dfb9d7c", size = 12612071, upload-time = "2026-09-01T00:25:55.116Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/5c/bef8b1f471931a9395792be023613b6cee0ef1449815bf97b18be07f883c/ty-0.0.77-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:603620c063b718ddbe302f83fb0d7c01a13f1941c3b9763512a89c9bbfabba96", size = 12641403, upload-time = "2026-09-01T00:25:57.305Z" },
-    { url = "https://files.pythonhosted.org/packages/43/66/e4d32a0145162f79bc3dd6fca4770f88966c3b5206121ffeecd5f7b05e8b/ty-0.0.77-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03f128cb8b204e22a18f4b01ef0194aa445f4edb080cb7d77621cb2ab353885c", size = 13013526, upload-time = "2026-09-01T00:25:59.278Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/be/33493ee43d4db7d402ceaee55c5d6c22e2b1105f10b1ac5928c220f79650/ty-0.0.77-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:97d1600ef69fc8e3b2310de1915cd34ba3b712fdc730cb02b713520956baec0a", size = 13828076, upload-time = "2026-09-01T00:26:01.343Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/d5/b6335fdc8c09aaaaf6541322076c5a7205fa16c29dbeddc1f24dd89b3894/ty-0.0.77-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dced0924a83b6d945fd48a29aa85e131fb98dc574f4c9a0e7c43d03eff373402", size = 14247770, upload-time = "2026-09-01T00:26:03.388Z" },
-    { url = "https://files.pythonhosted.org/packages/11/64/bbe96c1da26585919ac10f33df1d337d9b498013fc60c5178e76955c2a53/ty-0.0.77-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b14b002233a954115a04932b3a93d75a387569848276cf7bb0b5dc6b040001c4", size = 13926528, upload-time = "2026-09-01T00:26:05.587Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/e2/cdc94e9a1b69e9b7dd0ec3ad3ca75741245b8b5b2e3ffe9b365ca31d8052/ty-0.0.77-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:581adf1ae1e48e00e89ec162913d559ddf75a7805646a13ffd68943c1b5e8daa", size = 13290834, upload-time = "2026-09-01T00:26:07.912Z" },
-    { url = "https://files.pythonhosted.org/packages/92/8c/4929dd8e924ddbd6284dcb3cfbda488bd6cb091e5384f8b7fb5dd3de9122/ty-0.0.77-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9bda523b40e06c643feb6d5d5bcbacc56a2bd9eed3d7cae1119452502bcd69b0", size = 13829048, upload-time = "2026-09-01T00:26:10.093Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/f4/441a74ddc5e2db2690264c1ee0e478d46b8e42bd529472fdb1656b63bff2/ty-0.0.77-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4b8b04d8c3af8148e963e950094bd53c8cc4d3a11f5f8764ff8d39627bd6e64a", size = 12803755, upload-time = "2026-09-01T00:26:12.055Z" },
-    { url = "https://files.pythonhosted.org/packages/85/39/875bb7092ee1edb090b62eca74b7311f6416dc3aa7da442b4a1f95408251/ty-0.0.77-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:33a9ff9be488edf4d6fac46c456198cc848d9641f418f1a83aa123825e93c6ec", size = 13028244, upload-time = "2026-09-01T00:26:14.212Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/76/4b0a48f118dca6a32e1609f2d0bea2c3f7be9051af645fe5044ca35cbbb4/ty-0.0.77-py3-none-musllinux_1_2_i686.whl", hash = "sha256:61ad5467206e5ea6531c8aebebf1276c6150989a94a1d5974a84d9e0eeed5c38", size = 13321068, upload-time = "2026-09-01T00:26:16.418Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/46/cd21bc6441df4b221d9e131551bab2a5f9c0b724e60e1c960622ee175128/ty-0.0.77-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1293b94f26d1f330424e3b97c20b434f7e2ac1938287b8588466c75ece6c0b10", size = 13609112, upload-time = "2026-09-01T00:26:18.424Z" },
-    { url = "https://files.pythonhosted.org/packages/21/7b/0da4537a7eca4eb3ca72a2cb4539cfbb6fb3138d1dc4ae7a66299b941fb3/ty-0.0.77-py3-none-win32.whl", hash = "sha256:cb71152bdf56860375c790682cc3efc120aaf8e36f1cd6367773312905e82b50", size = 12573821, upload-time = "2026-09-01T00:26:20.404Z" },
-    { url = "https://files.pythonhosted.org/packages/96/91/aec75b11bfaa5a358f5a505afa6307fc4bee1c5f4c6444e18fa82c25f3be/ty-0.0.77-py3-none-win_amd64.whl", hash = "sha256:86f01d4af8b006c9442a2de0ab949cc24462f8f9431bebc0b73f6166fbbca19f", size = 13154851, upload-time = "2026-09-01T00:26:22.389Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/e5/77772f95ff81bf7c817595cd08b52d007acab90dac0f2339faa486e6a525/ty-0.0.77-py3-none-win_arm64.whl", hash = "sha256:942a3bb2a4786c80bd8ef4503e5024046617cdfcc550b56c1acc4817ce7ac144", size = 12992392, upload-time = "2026-09-01T00:26:24.44Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/ed/f34cfc06a9ba72979df219e48dae1a0b6a6c74a340763ccd30a547edf913/ty-0.0.78-py3-none-linux_armv6l.whl", hash = "sha256:122700b98f9d45785c1ce91a9418154562e7f64f4bf34679f6f7b38c5b97453f", size = 13304624, upload-time = "2026-09-02T22:40:56.649Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/28/5576e2a08b57676d9b2a736d528f077a6c6e32c3d1de2d75dbbe28346966/ty-0.0.78-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:cbe7e3709ccf29ef3d9f58f5914cc30ec36fb647008a5a4ff8483abe401bfe8d", size = 12928383, upload-time = "2026-09-02T22:40:59.162Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/027d49c3da5235e634da3d3fc52c4874ec89f50830388c9c259f8fb71e0e/ty-0.0.78-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c3528897b3ab9d3589561bc2b5e61a4d5d686de527a4400bb09a439b922a6c70", size = 12730058, upload-time = "2026-09-02T22:41:01.235Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/bc/6bf8ffefd8063730a70ae889cf85def72bc155fd1453135ebf8a09c2f1c2/ty-0.0.78-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8bfba4c44a06484093f527b8ef43a317abcf91395b49396170266629eedf74aa", size = 12813321, upload-time = "2026-09-02T22:41:03.251Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/c0/b3cdf26f82108908d92fdb7ddb741019c446ceb666cf204d4dbf611bde33/ty-0.0.78-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f903c06fdee17baf8373173039ab28f1bce28e66b1c734929a5f50b37eb54d9", size = 13072219, upload-time = "2026-09-02T22:41:05.225Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/36/16bfb0abdd178dae11dbc4b57b9a86c2b62642a18c1103fd2c2930aa5879/ty-0.0.78-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dd83e5fe3f07291d1bd4e591f8d2607c204f3eab53bcb1b8060c40e876e1aa61", size = 13903958, upload-time = "2026-09-02T22:41:07.333Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/0c/74d3b1f0344b13156c719dd68a7edf7e48c2051718c9f326ba3cbf45ea53/ty-0.0.78-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:325285377319cf7168a2b8b771ae5027f411530e3c7eab1faf4583cdd72fd7c9", size = 14355581, upload-time = "2026-09-02T22:41:09.56Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/d7/7ca0359e1e61b15b8b02328c8d120db3c507876b9b7c6bd9f26935353e0e/ty-0.0.78-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:54b7846a404da6492697b524a769755ee9bee157d67674063ecd9c5f69dc52ff", size = 14044749, upload-time = "2026-09-02T22:41:11.678Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/6a/731f16ff42c5fc96e742c2f4e0a6915356bae114ae02ae4af6f33502175f/ty-0.0.78-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:169d3b9d134c0b48fe1af8a844142d374655552054a9d6c15a4b6e51bb0382ea", size = 13391647, upload-time = "2026-09-02T22:41:13.928Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/af/250cc29daf310e837188509ea4d78460c495d8a74c4fb84b4152d9ef2d4f/ty-0.0.78-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:6108cb3b2d28dac5981d4e25008a0a5547d8c877a67f6da9e8c38e7e946be44f", size = 13945020, upload-time = "2026-09-02T22:41:15.968Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/f9/96aab1dee4535e66554e8dc7657c69f6c61c181d8e70b9c3527908e93ef4/ty-0.0.78-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:589ad03608d9d2975ef4b23c41c4f847e325bcc7686f51d4c66066b8dbc18a2a", size = 12851149, upload-time = "2026-09-02T22:41:18.06Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b0/53d8fe9a847534ef5fe2165c7d5292cb853b29dfd7011cbfb1cdb90a8012/ty-0.0.78-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b3fa0786edc1af06030f872d83499c0cea7c261dbbb651e0aee8306bf2c8a869", size = 13091464, upload-time = "2026-09-02T22:41:20.227Z" },
+    { url = "https://files.pythonhosted.org/packages/21/65/94a4e5a02de559f6c6c0ee7a14b88660b4eee058ec6fec5c0ff6ecfbf5cc/ty-0.0.78-py3-none-musllinux_1_2_i686.whl", hash = "sha256:92c5639befc577578c8abd4e5a7fccf98d828db98b09e8d4dd81605dc0e54aef", size = 13389389, upload-time = "2026-09-02T22:41:22.27Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b6/d0c7fe6be64ca5a15100c4b1f0e39c19660d53bc544f609fa117b346e661/ty-0.0.78-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:0dce70bc51652b2775debd1d1e422fb0179f5207c73deb4d5d0aca37e5f61695", size = 13691928, upload-time = "2026-09-02T22:41:24.292Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/5d/36081205611ba3fa802efc4ad63e4b1e949bda2f7bb37b34ac9bb6c00db0/ty-0.0.78-py3-none-win32.whl", hash = "sha256:1c80976ca9185d7a9d1baab1fb57240331b8dac58d3b11e46200284086a6de8d", size = 12647346, upload-time = "2026-09-02T22:41:26.699Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/89/b925fe1ea1bc56fc7f11d2496e29072fdd2ceb7b389884fc7b2d07cf0c41/ty-0.0.78-py3-none-win_amd64.whl", hash = "sha256:32e82b704471eab34f67b51c151660ca8a00815977b28278905d76fba54f7415", size = 13241810, upload-time = "2026-09-02T22:41:28.857Z" },
+    { url = "https://files.pythonhosted.org/packages/91/f1/090ef7b52355bcedfbfbff6ce70fa81ba5bd5f6ed3f8d99ae05e6f2fe75b/ty-0.0.78-py3-none-win_arm64.whl", hash = "sha256:3a14d641a3c04fa9a80f2a46be1531d915f60d4fb79d4b894627bbe46bb35d64", size = 13077433, upload-time = "2026-09-02T22:41:31.525Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary by Sourcery

Strengthen blueprint compatibility protection by validating default and baseline configurations proactively and treating any resulting compatibility risk as update-blocking.

New Features:
- Add proactive validation for blueprint default fallbacks and baseline configurations without existing consumers.

Bug Fixes:
- Block automatic updates when compatibility risks are detected even if no entities currently use the blueprint.

Enhancements:
- Consolidate substituted automation, script, and template validation through a shared domain validation path.
- Recognize optional and mandatory blueprint inputs when determining which proactive validation scenarios to run.
- Normalize blueprint domains before selecting their Home Assistant schemas.

Tests:
- Add integration coverage for valid and invalid default fallbacks and zero-consumer automation, script, and template blueprints.
- Add compatibility-guard coverage ensuring compatibility risks block updates without consumers.

Chores:
- Update the lockfile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Blueprint updates now distinguish required and optional inputs more reliably.
  - Consumer configurations are checked against fallback scenarios to catch invalid defaults before updates proceed.
  - Empty-input blueprints receive baseline validation when applicable.
  - Auto-updates are blocked when compatibility risks could cause breaking changes.

- **Tests**
  - Added coverage for compatibility-risk safeguards.
  - Added integration coverage for invalid defaults, zero-consumer blueprints, and valid empty-dictionary defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->